### PR TITLE
fix: safe area余白・Service Worker更新対応 (#2 #3)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6,11 +6,11 @@
   background: var(--color-primary);
   color: rgba(255, 255, 255, 0.9);
   height: 0;
-  padding-top: env(safe-area-inset-top);
 }
 
 .pull-indicator.refreshing {
   height: calc(44px + env(safe-area-inset-top));
+  padding-top: env(safe-area-inset-top);
   opacity: 1;
   transition: height 0.2s ease, opacity 0.2s ease;
 }
@@ -177,14 +177,14 @@
 .app-main {
   flex: 1;
   padding: 16px 16px;
-  padding-bottom: max(16px, env(safe-area-inset-bottom));
+  padding-bottom: calc(var(--footer-peek-height) + max(16px, env(safe-area-inset-bottom)));
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
 .app.scrolled .app-main {
-  padding-bottom: calc(var(--footer-open-height) + 16px);
+  padding-bottom: calc(var(--footer-open-height) + env(safe-area-inset-bottom) + 16px);
 }
 
 /* Section */
@@ -320,7 +320,7 @@
 /* Footer */
 .app-footer {
   position: fixed;
-  bottom: calc(-1 * env(safe-area-inset-bottom));
+  bottom: 0;
   left: 0;
   right: 0;
   margin: 0 auto;
@@ -337,13 +337,11 @@
   padding-bottom: env(safe-area-inset-bottom);
   overflow: hidden;
   z-index: 20;
-  transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1),
-              padding-bottom 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .app.scrolled .app-footer {
   height: calc(var(--footer-open-height) + env(safe-area-inset-bottom));
-  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .footer-btn {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -246,15 +246,30 @@ export default function App() {
     }
   }, [])
 
-  const handleTouchEnd = useCallback(() => {
+  const handleTouchEnd = useCallback(async () => {
     gestureStartY.current = null
     if (pullY >= PULL_THRESHOLD) {
       setRefreshing(true)
       setPullY(0)
+
+      let swUpdated = false
+      if ('serviceWorker' in navigator) {
+        try {
+          const reg = await navigator.serviceWorker.getRegistration()
+          if (reg) {
+            await reg.update()
+            swUpdated = !!(reg.installing || reg.waiting)
+          }
+        } catch {}
+      }
+
       const fresh = loadData()
       setHabits(fresh.habits)
       setRecords(fresh.records)
-      setTimeout(() => setRefreshing(false), 700)
+      setTimeout(() => {
+        setRefreshing(false)
+        if (swUpdated) window.location.reload()
+      }, 700)
     } else {
       setPullY(0)
     }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,7 +5,7 @@ import App from './App.jsx'
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js')
+    navigator.serviceWorker.register(import.meta.env.BASE_URL + 'sw.js')
   })
 }
 


### PR DESCRIPTION
## 概要

GitHub Issueで報告された2件のバグを修正します。

## 変更内容

### fix: #3 ヘッダー上余白・フッター下余白のsafe area修正

**原因**
- `.pull-indicator` のデフォルト状態に `padding-top: env(safe-area-inset-top)` が指定されており、`height: 0` でも CSSの仕様上 padding 分（約44px）が描画されてヘッダー上に余白が生じていた
- `.app-footer` が `bottom: calc(-1 * env(safe-area-inset-bottom))` という負値で位置調整していたが、PWA/iOS Safari実機で不安定だった

**対応**
- `.pull-indicator` のデフォルト状態から `padding-top` を削除し、`.refreshing` 状態にのみ移動
- `.app-footer` を `bottom: 0` に変更し、`height` に safe area 分を含めるシンプルな実装に統一
- `.app-main` の `padding-bottom` をフッター高さ + safe area を正しく考慮した値に更新

### fix: #2 Service Worker登録パスとpull-to-refresh更新対応

**原因**
- SW登録パスが `/sw.js`（ルート絶対パス）になっており、GitHub Pages の `/habit-tracker/` スコープと不一致
- pull-to-refresh が localStorage の再読込のみで、アプリ本体（CSS/JS/SW）の更新確認をしていなかった

**対応**
- `main.jsx`: SW登録パスを `import.meta.env.BASE_URL + 'sw.js'` に変更（`/habit-tracker/sw.js` になり正しいスコープで動作）
- `App.jsx`: pull-to-refresh 時に `reg.update()` を呼び出し、新バージョンのSWが見つかった場合はスピナー後に `window.location.reload()` で自動反映

## レビューポイント

- iOS Safari / PWA での safe area 動作が前提。デスクトップでは safe area 値が 0 になるため影響なし
- pull-to-refresh のデータ更新（localStorage）とアプリ更新（SW）の責務を分離した状態を維持
- `npm run build` 成功確認済み

## 関連Issue

- Closes #3
- Closes #2
- Closes #1（#3 対応で実質的に解消）