### PR TITLE
fix: #21 フッターを二層構造にしてsafe area余白を解消

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -318,6 +318,7 @@
 }
 
 /* Footer */
+/* 外層: 背景を画面最下端まで塗る。高さ = ボタン領域 + safe-area-inset-bottom */
 .app-footer {
   position: fixed;
   bottom: 0;
@@ -330,11 +331,7 @@
   -webkit-backdrop-filter: blur(16px);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
   height: calc(var(--footer-peek-height) + env(safe-area-inset-bottom));
-  padding-bottom: env(safe-area-inset-bottom);
   overflow: hidden;
   z-index: 20;
   transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1);
@@ -342,6 +339,20 @@
 
 .app.scrolled .app-footer {
   height: calc(var(--footer-open-height) + env(safe-area-inset-bottom));
+}
+
+/* 内層: ボタンの配置領域。safe-area分を除いたコンテンツ高さのみ */
+.app-footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  height: var(--footer-peek-height);
+  overflow: hidden;
+  transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.app.scrolled .app-footer-inner {
+  height: var(--footer-open-height);
 }
 
 .footer-btn {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -539,24 +539,26 @@ export default function App() {
       )}
 
       <footer className="app-footer">
-        <button className="footer-btn" onClick={() => setModal({ type: 'stats' })}>
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="18" y1="20" x2="18" y2="10" /><line x1="12" y1="20" x2="12" y2="4" /><line x1="6" y1="20" x2="6" y2="14" />
-          </svg>
-          <span>統計</span>
-        </button>
-        <button className="footer-btn" onClick={() => setModal({ type: 'help' })}>
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="10" /><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" /><line x1="12" y1="17" x2="12.01" y2="17" />
-          </svg>
-          <span>ヘルプ</span>
-        </button>
-        <button className="footer-btn" onClick={() => setModal({ type: 'settings' })}>
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-          </svg>
-          <span>設定</span>
-        </button>
+        <div className="app-footer-inner">
+          <button className="footer-btn" onClick={() => setModal({ type: 'stats' })}>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="20" x2="18" y2="10" /><line x1="12" y1="20" x2="12" y2="4" /><line x1="6" y1="20" x2="6" y2="14" />
+            </svg>
+            <span>統計</span>
+          </button>
+          <button className="footer-btn" onClick={() => setModal({ type: 'help' })}>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" /><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" /><line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+            <span>ヘルプ</span>
+          </button>
+          <button className="footer-btn" onClick={() => setModal({ type: 'settings' })}>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+            <span>設定</span>
+          </button>
+        </div>
       </footer>
     </div>
   )


### PR DESCRIPTION
## 概要
- app-footer（外層）がbottom: 0からheight = コンテンツ + env(safe-area-inset-bottom)で画面最下端まで背景を塗る
- app-footer-inner（内層）でボタンをコンテンツ高さのみの領域に配置し、safe-areaに侵食されない
- padding-bottomによるhackを廃止し責務を明確に分離

## Closes
Closes #21