### PR TITLE
fix/feat: #8 #15 #16 #19 #20 #21 各種バグ修正・機能改善

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,12 @@
+/* 通常フローから外してヘッダーを押し下げないようにする */
 .pull-indicator {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  max-width: 480px;
+  margin: 0 auto;
+  z-index: 30;
   overflow: hidden;
   display: flex;
   align-items: center;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import ConfirmModal from './components/ConfirmModal'
 import StatsModal from './components/StatsModal'
 import SettingsModal, { THEMES, applyTheme } from './components/SettingsModal'
 import { getToday, getYesterday } from './utils/date'
+import { calcCurrentStreak } from './utils/stats'
 import { validateImportData } from './utils/validation'
 import './App.css'
 
@@ -418,6 +419,7 @@ export default function App() {
                   key={habit.id}
                   habit={habit}
                   completed={todayRecords.includes(habit.id)}
+                  streak={calcCurrentStreak(habit.id, records)}
                   onPress={(h) => toggleHabit(h.id, today)}
                   onLongPress={(h) => setModal({ type: 'longPress', habit: h })}
                 />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -178,6 +178,12 @@ export default function App() {
   const handleFileChange = useCallback((e) => {
     const file = e.target.files?.[0]
     if (!file) return
+    const MAX_FILE_SIZE = 2 * 1024 * 1024
+    if (file.size > MAX_FILE_SIZE) {
+      setModal({ type: 'importError', message: 'ファイルサイズが大きすぎます（上限 2MB）。\nバックアップファイルを確認してください。' })
+      e.target.value = ''
+      return
+    }
     const reader = new FileReader()
     reader.onload = (ev) => {
       try {
@@ -488,15 +494,21 @@ export default function App() {
         />
       )}
 
-      {modal?.type === 'importFile' && (
-        <ConfirmModal
-          message={`「${modal.filename}」をインポートします。\n現在のデータはすべて上書きされます。よろしいですか？`}
-          confirmLabel="インポート"
-          danger={false}
-          onConfirm={handleImportConfirm}
-          onClose={closeModal}
-        />
-      )}
+      {modal?.type === 'importFile' && (() => {
+        const recordDates = Object.keys(modal.data.records).sort()
+        const rangeText = recordDates.length > 0
+          ? `${recordDates[0]} 〜 ${recordDates[recordDates.length - 1]}`
+          : 'なし'
+        return (
+          <ConfirmModal
+            message={`「${modal.filename}」をインポートします。\n\n習慣: ${modal.data.habits.length}件\n記録日数: ${recordDates.length}日\n期間: ${rangeText}\n\n現在のデータはすべて上書きされます。`}
+            confirmLabel="インポート"
+            danger={false}
+            onConfirm={handleImportConfirm}
+            onClose={closeModal}
+          />
+        )
+      })()}
 
       {modal?.type === 'importError' && (
         <ConfirmModal

--- a/src/components/HabitButton.css
+++ b/src/components/HabitButton.css
@@ -74,3 +74,13 @@
   font-weight: 700;
   opacity: 0.9;
 }
+
+.habit-streak {
+  position: absolute;
+  bottom: 5px;
+  right: 7px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  opacity: 0.7;
+  line-height: 1;
+}

--- a/src/components/HabitButton.jsx
+++ b/src/components/HabitButton.jsx
@@ -3,7 +3,7 @@ import './HabitButton.css'
 
 const LONG_PRESS_DELAY = 500
 
-export default function HabitButton({ habit, completed, onPress, onLongPress }) {
+export default function HabitButton({ habit, completed, streak, onPress, onLongPress }) {
   const timerRef = useRef(null)
   const isLongPressRef = useRef(false)
   const startPosRef = useRef(null)
@@ -69,6 +69,7 @@ export default function HabitButton({ habit, completed, onPress, onLongPress }) 
         style={{ backgroundColor: completed ? '#fff' : habit.color }}
       />
       <span className="habit-name">{habit.name}</span>
+      {streak > 1 && <span className="habit-streak">{streak}日</span>}
       {completed && <span className="habit-check">✓</span>}
     </button>
   )

--- a/src/components/HelpModal.jsx
+++ b/src/components/HelpModal.jsx
@@ -26,8 +26,8 @@ export default function HelpModal({ onClose }) {
         <section className="help-section">
           <h3 className="help-heading">統計を見る</h3>
           <ul className="help-list">
-            <li>右上の棒グラフアイコンから統計を確認できます。</li>
-            <li>習慣ごとに「現在の連続日数」「最長連続日数」「累計達成回数」が表示されます。</li>
+            <li>統計アイコンから習慣ごとの記録を確認できます。</li>
+            <li>「現在の連続日数」「最長連続日数」「累計達成回数」が表示されます。</li>
           </ul>
         </section>
 

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -32,6 +32,8 @@
 
 .theme-swatch.selected {
   border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary);
+  background: var(--color-primary-light);
 }
 
 .swatch-circle {
@@ -45,6 +47,23 @@
   font-size: 0.78rem;
   color: var(--color-text-secondary);
   font-weight: 500;
+  transition: color 0.15s, font-weight 0.15s;
+}
+
+.theme-swatch.selected .swatch-label {
+  color: var(--color-primary);
+  font-weight: 700;
+}
+
+.swatch-chips {
+  display: flex;
+  gap: 4px;
+}
+
+.swatch-chip {
+  width: 14px;
+  height: 7px;
+  border-radius: 3px;
 }
 
 .swatch-check {

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -28,12 +28,16 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
             key={theme.id}
             className={`theme-swatch${currentThemeId === theme.id ? ' selected' : ''}`}
             onClick={() => onSelectTheme(theme)}
-            aria-label={theme.label}
+            aria-label={`${theme.label}${currentThemeId === theme.id ? '（選択中）' : ''}`}
           >
             <span className="swatch-circle" style={{ background: theme.primary }} />
             <span className="swatch-label">{theme.label}</span>
+            <div className="swatch-chips">
+              <span className="swatch-chip" style={{ background: theme.primary }} />
+              <span className="swatch-chip" style={{ background: theme.today }} />
+            </div>
             {currentThemeId === theme.id && (
-              <span className="swatch-check">
+              <span className="swatch-check" style={{ background: theme.primary }}>
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
                   <polyline points="20 6 9 17 4 12" />
                 </svg>

--- a/src/components/StatsModal.jsx
+++ b/src/components/StatsModal.jsx
@@ -1,45 +1,6 @@
 import Modal from './Modal'
-import { formatDate, parseLocalDate } from '../utils/date'
+import { calcStats } from '../utils/stats'
 import './StatsModal.css'
-
-const MS_PER_DAY = 86400000
-
-function calcStats(habitId, records) {
-  const completedDates = Object.keys(records)
-    .filter(date => (records[date] || []).includes(habitId))
-    .sort()
-
-  const total = completedDates.length
-  if (total === 0) return { current: 0, longest: 0, total: 0 }
-
-  let longest = 1, run = 1
-  for (let i = 1; i < completedDates.length; i++) {
-    const prev = parseLocalDate(completedDates[i - 1])
-    const curr = parseLocalDate(completedDates[i])
-    const diff = (curr - prev) / MS_PER_DAY
-    if (diff === 1) {
-      run++
-      if (run > longest) longest = run
-    } else {
-      run = 1
-    }
-  }
-
-  let current = 0
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  while (true) {
-    const dateStr = formatDate(d)
-    if ((records[dateStr] || []).includes(habitId)) {
-      current++
-      d.setDate(d.getDate() - 1)
-    } else {
-      break
-    }
-  }
-
-  return { current, longest, total }
-}
 
 export default function StatsModal({ habits, records, onClose }) {
   return (

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -1,0 +1,44 @@
+import { formatDate, parseLocalDate } from './date'
+
+const MS_PER_DAY = 86400000
+
+export function calcCurrentStreak(habitId, records) {
+  let count = 0
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  while (true) {
+    const dateStr = formatDate(d)
+    if ((records[dateStr] || []).includes(habitId)) {
+      count++
+      d.setDate(d.getDate() - 1)
+    } else {
+      break
+    }
+  }
+  return count
+}
+
+export function calcStats(habitId, records) {
+  const completedDates = Object.keys(records)
+    .filter(date => (records[date] || []).includes(habitId))
+    .sort()
+
+  const total = completedDates.length
+  if (total === 0) return { current: 0, longest: 0, total: 0 }
+
+  let longest = 1, run = 1
+  for (let i = 1; i < completedDates.length; i++) {
+    const prev = parseLocalDate(completedDates[i - 1])
+    const curr = parseLocalDate(completedDates[i])
+    const diff = (curr - prev) / MS_PER_DAY
+    if (diff === 1) {
+      run++
+      if (run > longest) longest = run
+    } else {
+      run = 1
+    }
+  }
+
+  const current = calcCurrentStreak(habitId, records)
+  return { current, longest, total }
+}


### PR DESCRIPTION
## 対応Issue

- fix: #21 フッター二層構造化（safe area余白解消）
- fix: #19 pull-indicatorをposition:fixedに変更（ヘッダー押し下げ解消）
- docs: #16 ヘルプの統計アイコン説明を更新
- feat: #20 インポートに2MBサイズ制限と復元前プレビューを追加
- feat: #8 習慣カードに連続日数バッジを表示（utils/stats.js共通化）
- feat: #15 テーマスウォッチの選択状態と配色プレビューを改善

## スキップ
- #7 文字化け: コード確認済み、全ファイル正常な日本語のためスキップ