### PR TITLE
fix: #21 pull-indicator配置修正とフッターsafe-area余白の根本解消

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,12 +1,5 @@
-/* 通常フローから外してヘッダーを押し下げないようにする */
+/* ヘッダー直下に配置し、通常フローで展開する */
 .pull-indicator {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  max-width: 480px;
-  margin: 0 auto;
-  z-index: 30;
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -17,8 +10,7 @@
 }
 
 .pull-indicator.refreshing {
-  height: calc(44px + env(safe-area-inset-top));
-  padding-top: env(safe-area-inset-top);
+  height: 44px;
   opacity: 1;
   transition: height 0.2s ease, opacity 0.2s ease;
 }
@@ -326,7 +318,7 @@
 }
 
 /* Footer */
-/* 外層: 背景を画面最下端まで塗る。高さ = ボタン領域 + safe-area-inset-bottom */
+/* 外層: padding-bottomでsafe-area分を確保し背景を画面最下端まで塗る */
 .app-footer {
   position: fixed;
   bottom: 0;
@@ -339,17 +331,11 @@
   -webkit-backdrop-filter: blur(16px);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-  height: calc(var(--footer-peek-height) + env(safe-area-inset-bottom));
-  overflow: hidden;
+  padding-bottom: env(safe-area-inset-bottom);
   z-index: 20;
-  transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.app.scrolled .app-footer {
-  height: calc(var(--footer-open-height) + env(safe-area-inset-bottom));
-}
-
-/* 内層: ボタンの配置領域。safe-area分を除いたコンテンツ高さのみ */
+/* 内層: ボタンの配置領域。コンテンツ高さのみでoverflow:hiddenによりpeek時は非表示 */
 .app-footer-inner {
   display: flex;
   align-items: center;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -290,25 +290,6 @@ export default function App() {
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
     >
-      <div
-        className={`pull-indicator${refreshing ? ' refreshing' : ''}${pullY >= PULL_THRESHOLD ? ' ready' : ''}`}
-        style={!refreshing ? { height: pullY, opacity: pullY / PULL_THRESHOLD } : undefined}
-      >
-        {refreshing ? (
-          <svg className="pull-spin" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-          </svg>
-        ) : (
-          <svg
-            className={`pull-arrow${pullY >= PULL_THRESHOLD ? ' flip' : ''}`}
-            width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
-          >
-            <line x1="12" y1="5" x2="12" y2="19" />
-            <polyline points="19 12 12 19 5 12" />
-          </svg>
-        )}
-      </div>
-
       <header className="app-header">
         <h1 className="app-title">習慣トラッカー</h1>
         <div className="header-actions">
@@ -357,6 +338,25 @@ export default function App() {
           )}
         </div>
       </header>
+
+      <div
+        className={`pull-indicator${refreshing ? ' refreshing' : ''}${pullY >= PULL_THRESHOLD ? ' ready' : ''}`}
+        style={!refreshing ? { height: pullY, opacity: pullY / PULL_THRESHOLD } : undefined}
+      >
+        {refreshing ? (
+          <svg className="pull-spin" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+          </svg>
+        ) : (
+          <svg
+            className={`pull-arrow${pullY >= PULL_THRESHOLD ? ' flip' : ''}`}
+            width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <polyline points="19 12 12 19 5 12" />
+          </svg>
+        )}
+      </div>
 
       <main className="app-main">
         <section className="section">


### PR DESCRIPTION
## 修正内容

Issue #21 のコメントで報告された2点の残存問題を修正。

### pull-indicator の配置変更
- DOM上の位置をヘッダー前 → ヘッダー直後（mainの前）に移動
- position:fixed を廃止し通常フローに戻す
- refreshing時にヘッダー下でインジケーターが展開するため、ヘッダーが覆われない
- safe-area-inset-top の処理をpull-indicatorから除去（ヘッダーが担当）

### フッターの safe area 処理を変更
- height: calc(content + safe-area) → padding-bottom: env(safe-area-inset-bottom) に変更
- padding-bottom により背景が画面最下端まで確実に届く
- 内層の overflow:hidden がボタン表示を制御するため外層の height 管理が不要に

Closes #21