### PR TITLE
fix: #21 フッターを常時表示に変更・safe-area余白を根本解決

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,8 +32,7 @@
 }
 
 .app {
-  --footer-peek-height: 10px;
-  --footer-open-height: 64px;
+  --footer-height: 64px;
   min-height: 100dvh;
   display: flex;
   flex-direction: column;
@@ -177,14 +176,10 @@
 .app-main {
   flex: 1;
   padding: 16px 16px;
-  padding-bottom: calc(var(--footer-peek-height) + env(safe-area-inset-bottom) + 16px);
+  padding-bottom: calc(var(--footer-height) + env(safe-area-inset-bottom) + 16px);
   display: flex;
   flex-direction: column;
   gap: 16px;
-}
-
-.app.scrolled .app-main {
-  padding-bottom: calc(var(--footer-open-height) + env(safe-area-inset-bottom) + 16px);
 }
 
 /* Section */
@@ -318,7 +313,6 @@
 }
 
 /* Footer */
-/* 外層: padding-bottomでsafe-area分を確保し背景を画面最下端まで塗る */
 .app-footer {
   position: fixed;
   bottom: 0;
@@ -326,27 +320,18 @@
   right: 0;
   margin: 0 auto;
   max-width: 480px;
-  background: rgba(255, 255, 255, 0.94);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
   padding-bottom: env(safe-area-inset-bottom);
   z-index: 20;
 }
 
-/* 内層: ボタンの配置領域。コンテンツ高さのみでoverflow:hiddenによりpeek時は非表示 */
 .app-footer-inner {
   display: flex;
   align-items: center;
   justify-content: space-around;
-  height: var(--footer-peek-height);
-  overflow: hidden;
-  transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.app.scrolled .app-footer-inner {
-  height: var(--footer-open-height);
+  height: var(--footer-height);
 }
 
 .footer-btn {
@@ -361,16 +346,7 @@
   font-size: 0.62rem;
   font-weight: 600;
   letter-spacing: 0.03em;
-  opacity: 0;
-  transform: translateY(8px);
-  transition: opacity 0.2s ease 0.1s, transform 0.2s ease 0.1s, color 0.15s, background 0.15s;
-  pointer-events: none;
-}
-
-.app.scrolled .footer-btn {
-  opacity: 1;
-  transform: translateY(0);
-  pointer-events: auto;
+  transition: color 0.15s, background 0.15s;
 }
 
 .footer-btn:active {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,10 +60,8 @@ export default function App() {
   const [scrolled, setScrolled] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const pullStartY = useRef(null)
-  const gestureStartY = useRef(null)
   const justScrolledToTop = useRef(false)
   const scrollStopTimer = useRef(null)
-  const scrolledRef = useRef(false)
   const PULL_THRESHOLD = 80
 
   const today = getToday()
@@ -81,12 +79,10 @@ export default function App() {
   useEffect(() => {
     const onScroll = () => {
       if (window.scrollY > 0) {
-        scrolledRef.current = true
         setScrolled(true)
         justScrolledToTop.current = true
         clearTimeout(scrollStopTimer.current)
       } else {
-        scrolledRef.current = false
         setScrolled(false)
         setMenuOpen(false)
         scrollStopTimer.current = setTimeout(() => {
@@ -216,31 +212,14 @@ export default function App() {
   }, [modal])
 
   const handleTouchStart = useCallback((e) => {
-    gestureStartY.current = e.touches[0].clientY
-    // フッター表示中・スクロール戻り直後はpull-to-refreshを許可しない
-    if (window.scrollY === 0 && !justScrolledToTop.current && !scrolledRef.current) {
+    // スクロール戻り直後はpull-to-refreshを許可しない
+    if (window.scrollY === 0 && !justScrolledToTop.current) {
       pullStartY.current = e.touches[0].clientY
     }
   }, [])
 
   const handleTouchMove = useCallback((e) => {
     const currentY = e.touches[0].clientY
-
-    if (gestureStartY.current !== null) {
-      const dy = currentY - gestureStartY.current
-      if (!scrolledRef.current && dy < -20) {
-        // 上スワイプ → フッター展開
-        scrolledRef.current = true
-        setScrolled(true)
-        pullStartY.current = null
-      } else if (scrolledRef.current && dy > 20) {
-        // 下スワイプ → フッター閉じる
-        scrolledRef.current = false
-        setScrolled(false)
-        setMenuOpen(false)
-        gestureStartY.current = null
-      }
-    }
 
     // pull-to-refresh
     if (pullStartY.current === null) return
@@ -254,7 +233,6 @@ export default function App() {
   }, [])
 
   const handleTouchEnd = useCallback(async () => {
-    gestureStartY.current = null
     if (pullY >= PULL_THRESHOLD) {
       setRefreshing(true)
       setPullY(0)
@@ -293,12 +271,6 @@ export default function App() {
       <header className="app-header">
         <h1 className="app-title">習慣トラッカー</h1>
         <div className="header-actions">
-          <button className="header-btn" onClick={() => setModal({ type: 'stats' })}>
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-              <line x1="18" y1="20" x2="18" y2="10" /><line x1="12" y1="20" x2="12" y2="4" /><line x1="6" y1="20" x2="6" y2="14" />
-            </svg>
-            <span>統計</span>
-          </button>
           <button className="header-btn" onClick={() => setModal({ type: 'help' })}>
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="12" cy="12" r="10" /><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" /><line x1="12" y1="17" x2="12.01" y2="17" />
@@ -324,7 +296,6 @@ export default function App() {
             <>
               <div className="header-menu">
                 {[
-                  { type: 'stats', label: '統計', icon: <><line x1="18" y1="20" x2="18" y2="10" /><line x1="12" y1="20" x2="12" y2="4" /><line x1="6" y1="20" x2="6" y2="14" /></> },
                   { type: 'help', label: 'ヘルプ', icon: <><circle cx="12" cy="12" r="10" /><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" /><line x1="12" y1="17" x2="12.01" y2="17" /></> },
                   { type: 'settings', label: '設定', icon: <><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></> },
                 ].map(({ type, label, icon }) => (
@@ -559,18 +530,6 @@ export default function App() {
               <line x1="18" y1="20" x2="18" y2="10" /><line x1="12" y1="20" x2="12" y2="4" /><line x1="6" y1="20" x2="6" y2="14" />
             </svg>
             <span>統計</span>
-          </button>
-          <button className="footer-btn" onClick={() => setModal({ type: 'help' })}>
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="12" cy="12" r="10" /><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" /><line x1="12" y1="17" x2="12.01" y2="17" />
-            </svg>
-            <span>ヘルプ</span>
-          </button>
-          <button className="footer-btn" onClick={() => setModal({ type: 'settings' })}>
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-            </svg>
-            <span>設定</span>
           </button>
         </div>
       </footer>

--- a/src/index.css
+++ b/src/index.css
@@ -39,7 +39,7 @@ html, body {
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Sans', 'Yu Gothic UI',
     'Segoe UI', sans-serif;
-  background: var(--color-bg);
+  background: var(--color-surface);
   color: var(--color-text);
   -webkit-font-smoothing: antialiased;
   -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
## 概要

- フッター下のグレー余白（issue #21）を根本的に解消
- フッターを常時フルオープン表示に変更（peek mode 廃止）
- 統計をフッターの主要ナビに移動

## 変更内容

### safe-area ギャップ修正

- `body` 背景を `var(--color-bg)` → `var(--color-surface)`（白）に変更。iOS Safari/PWA でフッター背景が safe area まで届かない場合、body のグレーが透けて見えていた問題を解消
- `backdrop-filter` を除去し solid white 背景に変更（描画の不確実性を排除）

### フッター常時表示

- `--footer-peek-height` を廃止し `--footer-height: 64px` に統一
- `.app-footer-inner` の高さを常に 64px に固定
- `.footer-btn` の opacity/transform アニメーションを撤廃し常時表示
- `.app-main` の `padding-bottom` を常時固定値に統一

### ナビゲーション整理

- 統計をフッターの主要ナビとして配置
- ヘッダーは「ヘルプ」「設定」のみに整理
- ハンバーガーメニューも「ヘルプ」「設定」のみ

### コードクリーンアップ

- `gestureStartY` / `scrolledRef` を除去（スワイプによるフッター開閉ロジック廃止）

## テスト観点

- [ ] iPhone 実機 Safari / PWA でフッター下に余白（グレー）が出ないことを確認
- [ ] フッターが常時表示されていること
- [ ] 統計はフッターから開けること
- [ ] ヘルプ・設定はヘッダーから開けること
- [ ] pull-to-refresh が引き続き動作すること

Closes #21