### PR TITLE
fix: #21 フッター高さを49pxに縮小しsafe-area余白の視覚的問題を解消

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,7 +32,7 @@
 }
 
 .app {
-  --footer-height: 64px;
+  --footer-height: 49px;
   min-height: 100dvh;
   display: flex;
   flex-direction: column;
@@ -338,10 +338,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 3px;
+  gap: 2px;
   flex: 1;
   color: var(--color-text-secondary);
-  padding: 8px 4px;
+  padding: 6px 4px;
   border-radius: 10px;
   font-size: 0.62rem;
   font-weight: 600;


### PR DESCRIPTION
## 概要

issue #21 のフッター下余白問題に対応。

## 変更内容

- --footer-height を 64px から 49px に縮小（iOS標準タブバー相当）
- .footer-btn の gap を 3px から 2px、padding を 8px 4px から 6px 4px に詰める
- app-main の padding-bottom は var(--footer-height) 参照のため自動調整

## 背景

前回の修正でフッターは常時表示・二層構造（app-footer + app-footer-inner）になったが、64px という高さが safe-area-inset-bottom と合わさって画面下部を過剰に占有していた。49px にすることで iOS 実機での白い余白感を解消する。

## 確認観点

- iPhone 実機 Safari / PWA でフッター下の余白が目立たないこと
- ホームインジケータ領域とフッター内容が重ならないこと
- カレンダー最下部などのコンテンツがフッターに隠れないこと

Closes #21