### PR TITLE
フッターの safe area 処理を iPhone 向けに再調整

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,8 +32,8 @@
 }
 
 .app {
-  --footer-height: 45px;
-  --footer-safe-padding: min(env(safe-area-inset-bottom), 16px);
+  --footer-height: 48px;
+  --footer-safe-offset: env(safe-area-inset-bottom);
   min-height: 100dvh;
   display: flex;
   flex-direction: column;
@@ -177,7 +177,7 @@
 .app-main {
   flex: 1;
   padding: 16px 16px;
-  padding-bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
+  padding-bottom: calc(var(--footer-height) + var(--footer-safe-offset) + 16px);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -316,7 +316,7 @@
 /* Footer */
 .app-footer {
   position: fixed;
-  bottom: 0;
+  bottom: var(--footer-safe-offset);
   left: 0;
   right: 0;
   margin: 0 auto;
@@ -324,8 +324,17 @@
   background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-  padding-bottom: var(--footer-safe-padding);
   z-index: 20;
+}
+
+.app-footer::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  height: var(--footer-safe-offset);
+  background: var(--color-surface);
 }
 
 .app-footer-inner {
@@ -339,20 +348,20 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1px;
+  gap: 2px;
   flex: 0 1 112px;
   color: var(--color-text-secondary);
-  padding: 4px;
+  padding: 5px 4px;
   border-radius: 10px;
-  font-size: 0.6rem;
+  font-size: 0.62rem;
   font-weight: 600;
   letter-spacing: 0.03em;
   transition: color 0.15s, background 0.15s;
 }
 
 .footer-btn svg {
-  width: 18px;
-  height: 18px;
+  width: 19px;
+  height: 19px;
 }
 
 .footer-btn:active {

--- a/src/App.css
+++ b/src/App.css
@@ -33,7 +33,7 @@
 
 .app {
   --footer-height: 48px;
-  --footer-safe-offset: env(safe-area-inset-bottom);
+  --footer-safe-padding: env(safe-area-inset-bottom);
   min-height: 100dvh;
   display: flex;
   flex-direction: column;
@@ -177,7 +177,7 @@
 .app-main {
   flex: 1;
   padding: 16px 16px;
-  padding-bottom: calc(var(--footer-height) + var(--footer-safe-offset) + 16px);
+  padding-bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -316,7 +316,7 @@
 /* Footer */
 .app-footer {
   position: fixed;
-  bottom: var(--footer-safe-offset);
+  bottom: 0;
   left: 0;
   right: 0;
   margin: 0 auto;
@@ -324,17 +324,8 @@
   background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
+  padding-bottom: var(--footer-safe-padding);
   z-index: 20;
-}
-
-.app-footer::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 100%;
-  height: var(--footer-safe-offset);
-  background: var(--color-surface);
 }
 
 .app-footer-inner {


### PR DESCRIPTION
## 概要

- #37 マージ後に未反映だった追加修正を follow-up PR として出し直し
- 参考: https://web-design-textbook.com/recipe/iphone-design/
- viewport-fit=cover が入っている前提で、フッターを bottom: 0 + padding-bottom: env(safe-area-inset-bottom) の定番パターンに合わせる
- #37 の safe area 上限 16px は外し、iPhone のホームバー分をそのまま確保する
- 切り分けとして .app の min-height を 100dvh から 100% + 100svh に変更し、Safari の動的 viewport 変化による footer のズレを避ける

## 確認

- npm run build

Refs #21