### PR TITLE
fix: データ検証・SWキャッシュ・更新検知・デプロイ安定化 (#25 #17 #33 #28)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/public/sw.js
+++ b/public/sw.js
@@ -26,11 +26,14 @@ self.addEventListener('activate', (e) => {
 
 self.addEventListener('fetch', (e) => {
   if (e.request.method !== 'GET') return
+  if (new URL(e.request.url).origin !== location.origin) return
   e.respondWith(
     fetch(e.request)
       .then(res => {
-        const clone = res.clone()
-        caches.open(CACHE).then(c => c.put(e.request, clone))
+        if (res.ok && res.type === 'basic') {
+          const clone = res.clone()
+          caches.open(CACHE).then(c => c.put(e.request, clone))
+        }
         return res
       })
       .catch(() =>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,7 +33,16 @@ const THEME_STORAGE_KEY = 'habit-tracker-theme'
 function loadData() {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (raw) return JSON.parse(raw)
+    if (raw) {
+      const data = JSON.parse(raw)
+      if (
+        data && typeof data === 'object' && !Array.isArray(data) &&
+        Array.isArray(data.habits) &&
+        data.records && typeof data.records === 'object' && !Array.isArray(data.records)
+      ) {
+        return data
+      }
+    }
   } catch {}
   return { habits: [], records: {} }
 }
@@ -242,8 +251,29 @@ export default function App() {
         try {
           const reg = await navigator.serviceWorker.getRegistration()
           if (reg) {
-            await reg.update()
-            swUpdated = !!(reg.installing || reg.waiting)
+            swUpdated = await new Promise(resolve => {
+              let done = false
+              const finish = (val) => { if (!done) { done = true; resolve(val) } }
+
+              // controllerchange: skipWaiting+clients.claim で即座にアクティベートされた場合も検知できる
+              navigator.serviceWorker.addEventListener('controllerchange', () => finish(true), { once: true })
+
+              reg.update()
+                .then(() => {
+                  const sw = reg.installing || reg.waiting
+                  if (sw) {
+                    sw.addEventListener('statechange', function handler() {
+                      if (this.state === 'activated') {
+                        sw.removeEventListener('statechange', handler)
+                        finish(true)
+                      }
+                    })
+                  }
+                  // update()完了から1秒待ってもchangeがなければ更新なし
+                  setTimeout(() => finish(false), 1000)
+                })
+                .catch(() => finish(false))
+            })
           }
         } catch {}
       }


### PR DESCRIPTION
## 対応 issue

- close #25
- close #17
- close #33
- close #28

## 変更内容

### #25 — loadData() にデータ形状検証を追加
localStorage から読み込んだデータが `habits: 配列 / records: オブジェクト` の形式でない場合、アプリ全体がクラッシュする問題を修正。不正な形状のデータは安全な初期値へフォールバックします。

### #17 — sw.js のキャッシュ対象を制限
fetch ハンドラでオリジンチェックおよび `res.ok && res.type === basic` の確認を追加。外部リクエストやエラーレスポンスが誤ってキャッシュされないよう修正しました。

### #33 — pull-to-refresh の SW 更新検知を安定化
skipWaiting() + clients.claim() で installing/waiting を一瞬で通過するケースを controllerchange イベントで確実に捕捉できるよう変更。statechange も併用し、update() 完了から 1 秒のフォールバックタイムアウトを設けています。

### #28 — deploy.yml に fetch-depth: 0 を追加
ビルド時の git describe --tags --always が正しいタグを参照できるよう、checkout ステップに fetch-depth: 0 を追加。バージョン表示と SW キャッシュ名が意図したリリース単位と一致するようになります。

## 確認観点

- 壊れた JSON を localStorage に入れてもアプリが起動できる
- iPhone Safari / PWA での pull-to-refresh で新バージョンが確実に反映される
- 更新なしの pull-to-refresh で不要な reload が起きない
- main push 後のデプロイでバージョン表示がタグ形式になる