### PR TITLE
fix: #31 今日未達でも昨日まで連続していれば途切れ扱いにしない

### DIFF
--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -6,6 +6,13 @@ export function calcCurrentStreak(habitId, records) {
   let count = 0
   const d = new Date()
   d.setHours(0, 0, 0, 0)
+
+  // 今日が未達なら昨日から遡る（当日中はまだ達成できるため途切れ扱いにしない）
+  const todayStr = formatDate(d)
+  if (!(records[todayStr] || []).includes(habitId)) {
+    d.setDate(d.getDate() - 1)
+  }
+
   while (true) {
     const dateStr = formatDate(d)
     if ((records[dateStr] || []).includes(habitId)) {


### PR DESCRIPTION
## 対応 issue

close #31

## 変更内容

`calcCurrentStreak` で今日が未達の場合、昨日から遡って連続日数を計算するよう修正。

**修正前**: 今日から遡るため、今日が未達の時点で即 0 日になる  
**修正後**:
- 今日達成済み → 今日を含めて遡る
- 今日未達・昨日達成済み → 昨日から遡る（当日中はまだ達成できるため）
- 今日も昨日も未達 → 0 日

## テスト

ブラウザ上でロジックをすべてのケースで確認済み:
- 今日達成・3日連続 → 4日 ✓
- 今日未達・昨日まで3日連続 → 3日 ✓
- 今日も昨日も未達 → 0日 ✓