### PR TITLE
fix: pull表示テキスト・今月ボタン・インポート検証の改善 (#34 #23 #29)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,12 @@
   animation: pull-spin 0.8s linear infinite;
 }
 
+.pull-label {
+  font-size: 0.8rem;
+  margin-left: 6px;
+  letter-spacing: 0.02em;
+}
+
 .app {
   --footer-height: 45px;
   --footer-safe-padding: min(env(safe-area-inset-bottom), 16px);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -345,17 +345,25 @@ export default function App() {
         style={!refreshing ? { height: pullY, opacity: pullY / PULL_THRESHOLD } : undefined}
       >
         {refreshing ? (
-          <svg className="pull-spin" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-          </svg>
+          <>
+            <svg className="pull-spin" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+              <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            </svg>
+            <span className="pull-label">更新中...</span>
+          </>
         ) : (
-          <svg
-            className={`pull-arrow${pullY >= PULL_THRESHOLD ? ' flip' : ''}`}
-            width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
-          >
-            <line x1="12" y1="5" x2="12" y2="19" />
-            <polyline points="19 12 12 19 5 12" />
-          </svg>
+          <>
+            <svg
+              className={`pull-arrow${pullY >= PULL_THRESHOLD ? ' flip' : ''}`}
+              width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+            >
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <polyline points="19 12 12 19 5 12" />
+            </svg>
+            <span className="pull-label">
+              {pullY >= PULL_THRESHOLD ? '離して更新' : '下に引っ張って更新'}
+            </span>
+          </>
         )}
       </div>
 

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -51,8 +51,8 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
         <div className="cal-month-label">
           <span>{year}年{month + 1}月</span>
           {!isCurrentMonth && (
-            <button className="today-jump-btn" onClick={goToToday}>
-              今月
+            <button className="today-jump-btn" onClick={goToToday} aria-label="今月へ戻る">
+              今月へ
             </button>
           )}
         </div>

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,5 +1,11 @@
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 
+function isValidDate(dateStr) {
+  const [y, m, d] = dateStr.split('-').map(Number)
+  const dt = new Date(y, m - 1, d)
+  return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d
+}
+
 export function validateImportData(data) {
   if (!data || typeof data !== 'object' || Array.isArray(data)) {
     return 'データの形式が正しくありません。'
@@ -7,19 +13,28 @@ export function validateImportData(data) {
   if (!Array.isArray(data.habits)) {
     return '「habits」が配列ではありません。'
   }
+  const habitIds = new Set()
   for (const [i, h] of data.habits.entries()) {
     if (!h || typeof h !== 'object') return `habits[${i}] がオブジェクトではありません。`
     if (typeof h.id !== 'string' || !h.id) return `habits[${i}] に有効な id がありません。`
+    if (habitIds.has(h.id)) return `habits に重複した id「${h.id}」があります。`
+    habitIds.add(h.id)
     if (typeof h.name !== 'string' || !h.name.trim()) return `habits[${i}] に有効な name がありません。`
     if (typeof h.color !== 'string' || !h.color) return `habits[${i}] に有効な color がありません。`
+    if (h.createdAt !== undefined && (typeof h.createdAt !== 'string' || !DATE_RE.test(h.createdAt) || !isValidDate(h.createdAt))) {
+      return `habits[${i}] の createdAt「${h.createdAt}」が有効な日付ではありません。`
+    }
   }
   if (!data.records || typeof data.records !== 'object' || Array.isArray(data.records)) {
     return '「records」がオブジェクトではありません。'
   }
   for (const [date, ids] of Object.entries(data.records)) {
     if (!DATE_RE.test(date)) return `records のキー「${date}」が日付形式（YYYY-MM-DD）ではありません。`
+    if (!isValidDate(date)) return `records のキー「${date}」は存在しない日付です。`
     if (!Array.isArray(ids)) return `records[${date}] が配列ではありません。`
     if (ids.some(id => typeof id !== 'string')) return `records[${date}] に文字列以外の値が含まれています。`
+    const unknown = ids.find(id => !habitIds.has(id))
+    if (unknown !== undefined) return `records[${date}] に未知の習慣 ID「${unknown}」が含まれています。`
   }
   return null
 }


### PR DESCRIPTION
## 対応 issue

- close #34
- close #23
- close #29

## 変更内容

### #34 — pull-to-refresh に日本語テキストを追加
状態に応じて表示を切り替え:
- 引っ張り中: 「下に引っ張って更新」
- 閾値到達: 「離して更新」
- 更新中: 「更新中...」

### #23 — カレンダーの「今月」ボタンをアクションとして明確化
「今月」→「今月へ」に変更し、`aria-label=今月へ戻る` を付与。状態表示と誤解されにくくなる。

### #29 — インポートデータの整合性検証を強化
- 日付の実在確認（`2026-99-99` などを検出）
- 習慣 ID の重複チェック
- `records` 内 ID が `habits` に存在するか確認
- `createdAt` の日付形式・実在チェック