### PR TITLE
フッターCSSを外して余白原因を切り分け

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -34,7 +34,8 @@
 .app {
   --footer-height: 48px;
   --footer-safe-padding: env(safe-area-inset-bottom);
-  min-height: 100dvh;
+  min-height: 100%;
+  min-height: 100svh;
   display: flex;
   flex-direction: column;
   max-width: 480px;


### PR DESCRIPTION
## 概要

- issue #21 の原因切り分け用 PR
- .app の 100dvh を 100% + 100svh に変更
- フッター関連 CSS を一時的に削除
- app-main のフッター避け padding も削除
- fixed footer / safe area / footer padding のどれが下部余白に影響しているか確認するための trial

## 確認

- npm run build

Refs #21