### PR TITLE
フッターCSSを外して余白原因を切り分け

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,8 +32,6 @@
 }
 
 .app {
-  --footer-height: 48px;
-  --footer-safe-padding: env(safe-area-inset-bottom);
   min-height: 100%;
   min-height: 100svh;
   display: flex;
@@ -178,7 +176,6 @@
 .app-main {
   flex: 1;
   padding: 16px 16px;
-  padding-bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -314,49 +311,3 @@
   opacity: 0.6;
 }
 
-/* Footer */
-.app-footer {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  margin: 0 auto;
-  max-width: 480px;
-  background: var(--color-surface);
-  border-top: 2px solid var(--color-primary);
-  box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-  padding-bottom: var(--footer-safe-padding);
-  z-index: 20;
-}
-
-.app-footer-inner {
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-  height: var(--footer-height);
-}
-
-.footer-btn {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-  flex: 0 1 112px;
-  color: var(--color-text-secondary);
-  padding: 5px 4px;
-  border-radius: 10px;
-  font-size: 0.62rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  transition: color 0.15s, background 0.15s;
-}
-
-.footer-btn svg {
-  width: 19px;
-  height: 19px;
-}
-
-.footer-btn:active {
-  background: var(--color-primary-light);
-  color: var(--color-primary);
-}


### PR DESCRIPTION
## 概要

- issue #21 の原因切り分け用 PR
- .app の 100dvh を 100% + 100svh に変更
- フッター関連 CSS を一時的に削除
- app-main のフッター避け padding も削除
- fixed footer / safe area / footer padding のどれが下部余白に影響しているか確認するための trial

## 確認

- npm run build

Refs #21