### PR TITLE
fix: #27 #16 カレンダーキーボード対応・ヘルプ内容更新

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -47,7 +47,7 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
   return (
     <div className="calendar">
       <div className="calendar-nav">
-        <button className="cal-nav-btn" onClick={goToPrev}>‹</button>
+        <button className="cal-nav-btn" onClick={goToPrev} aria-label="前の月">‹</button>
         <div className="cal-month-label">
           <span>{year}年{month + 1}月</span>
           {!isCurrentMonth && (
@@ -56,7 +56,7 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
             </button>
           )}
         </div>
-        <button className="cal-nav-btn" onClick={goToNext}>›</button>
+        <button className="cal-nav-btn" onClick={goToNext} aria-label="次の月">›</button>
       </div>
 
       <div className="calendar-grid">
@@ -79,6 +79,7 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
           const count = completedHabits.length
           const allDone = total > 0 && count === total
 
+          const label = `${y}年${m + 1}月${d}日${count > 0 ? `、${count}件達成` : ''}`
           return (
             <div
               key={dateStr}
@@ -89,7 +90,11 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
                 dow === 0 ? 'sun' : '',
                 dow === 6 ? 'sat' : '',
               ].filter(Boolean).join(' ')}
+              role="button"
+              tabIndex={other ? -1 : 0}
+              aria-label={label}
               onClick={() => onDayClick(dateStr)}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onDayClick(dateStr) } }}
             >
               <span className="cal-day-num">{d}</span>
               <div className="cal-dots">

--- a/src/components/HelpModal.jsx
+++ b/src/components/HelpModal.jsx
@@ -26,8 +26,9 @@ export default function HelpModal({ onClose }) {
         <section className="help-section">
           <h3 className="help-heading">統計を見る</h3>
           <ul className="help-list">
-            <li>統計アイコンから習慣ごとの記録を確認できます。</li>
+            <li>画面下の「統計」ボタンから習慣ごとの記録を確認できます。</li>
             <li>「現在の連続日数」「最長連続日数」「累計達成回数」が表示されます。</li>
+            <li>今日がまだ未達でも、昨日まで連続していれば連続日数は維持されます。</li>
           </ul>
         </section>
 
@@ -35,15 +36,15 @@ export default function HelpModal({ onClose }) {
           <h3 className="help-heading">画面を更新する</h3>
           <ul className="help-list">
             <li>画面を下に引っ張って離すと最新の状態に更新されます。</li>
-            <li>アプリを開いたまま日付が変わったときなどに使えます。</li>
+            <li>「更新中...」と表示されたら離してください。アプリの更新があれば自動で反映されます。</li>
           </ul>
         </section>
 
         <section className="help-section">
           <h3 className="help-heading">データのバックアップ・復元</h3>
           <ul className="help-list">
-            <li>「保存」でデータをファイルとしてダウンロードできます。</li>
-            <li>「復元」でファイルを読み込んでデータを元に戻せます。機種変更のときにも使えます。</li>
+            <li>設定の「バックアップを保存」でデータをファイルとしてダウンロードできます。</li>
+            <li>「バックアップから復元」でファイルを読み込んでデータを元に戻せます。機種変更のときにも使えます。</li>
             <li>復元すると現在のデータはすべて上書きされます。</li>
           </ul>
         </section>


### PR DESCRIPTION
## 対応 issue

- close #27
- close #16

## 変更内容

### #27 — カレンダーのキーボード・アクセシビリティ対応
- 日付セルに `role=button` / `tabIndex={0}` / `aria-label`（例: 2026年5月4日、2件達成）/ `onKeyDown`（Enter・Space）を追加
- 隣月セルは `tabIndex={-1}` でフォーカス順から除外
- 前月・次月ボタンに `aria-label=前の月` / `aria-label=次の月` を追加

### #16 — ヘルプ内容を現在の実装に合わせて更新
- 統計の説明に「今日未達でも昨日まで連続していれば連続日数を維持」を追記
- バックアップのボタン名を実際のラベル（「バックアップを保存」「バックアップから復元」）に統一
- pull-to-refresh の説明を現在の表示テキストに合わせて更新