### PR TITLE
下端に露出するページ背景色をアプリ背景に揃える

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -34,12 +34,12 @@ html, body {
   width: 100%;
   overflow-x: hidden;
   overscroll-behavior: none;
+  background: var(--color-bg);
 }
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Sans', 'Yu Gothic UI',
     'Segoe UI', sans-serif;
-  background: var(--color-surface);
   color: var(--color-text);
   -webkit-font-smoothing: antialiased;
   -webkit-tap-highlight-color: transparent;
@@ -60,4 +60,5 @@ input {
 
 #root {
   height: 100%;
+  background: var(--color-bg);
 }


### PR DESCRIPTION
## 概要

- issue #21 の追加切り分け
- フッター CSS を外しても、ヘルプモーダル表示中でも下端の白い余白が残るため、フッターではなく body/html/#root 側の背景露出を疑う
- html/body/#root の背景色を --color-bg に統一
- body の白背景 --color-surface を削除

## 確認

- npm run build

Refs #21