### PR TITLE
feat: #13 #10 達成取り消しUndoトースト・編集モードドラッグヒント

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -341,6 +341,47 @@
   height: var(--footer-height);
 }
 
+.undo-toast {
+  position: fixed;
+  bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 12px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #1e293b;
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  z-index: 30;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  animation: toast-in 0.2s ease;
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
+.undo-btn {
+  background: none;
+  border: none;
+  color: var(--color-today);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.edit-mode-hint {
+  font-size: 0.75rem;
+  color: var(--color-text-sub);
+  text-align: center;
+  margin: 4px 0 8px;
+}
+
 .footer-btn {
   display: flex;
   flex-direction: column;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,6 +68,8 @@ export default function App() {
   const [refreshing, setRefreshing] = useState(false)
   const [scrolled, setScrolled] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [undoAction, setUndoAction] = useState(null)
+  const undoTimerRef = useRef(null)
   const pullStartY = useRef(null)
   const justScrolledToTop = useRef(false)
   const scrollStopTimer = useRef(null)
@@ -113,17 +115,35 @@ export default function App() {
   const closeModal = useCallback(() => setModal(null), [])
 
   const toggleHabit = useCallback((habitId, dateStr) => {
+    const wasOn = (records[dateStr] || []).includes(habitId)
     setRecords(prev => {
-      const dayRecords = prev[dateStr] || []
-      const isOn = dayRecords.includes(habitId)
+      const dr = prev[dateStr] || []
+      const on = dr.includes(habitId)
       return {
         ...prev,
-        [dateStr]: isOn
-          ? dayRecords.filter(id => id !== habitId)
-          : [...dayRecords, habitId],
+        [dateStr]: on ? dr.filter(id => id !== habitId) : [...dr, habitId],
       }
     })
-  }, [])
+    clearTimeout(undoTimerRef.current)
+    if (wasOn) {
+      setUndoAction({ habitId, dateStr })
+      undoTimerRef.current = setTimeout(() => setUndoAction(null), 4000)
+    } else {
+      setUndoAction(null)
+    }
+  }, [records])
+
+  const handleUndo = useCallback(() => {
+    if (!undoAction) return
+    clearTimeout(undoTimerRef.current)
+    const { habitId, dateStr } = undoAction
+    setRecords(prev => {
+      const dr = prev[dateStr] || []
+      if (dr.includes(habitId)) return prev
+      return { ...prev, [dateStr]: [...dr, habitId] }
+    })
+    setUndoAction(null)
+  }, [undoAction])
 
   const addHabit = useCallback(({ name, color }) => {
     const id = `h_${Date.now()}`
@@ -414,6 +434,7 @@ export default function App() {
                   </div>
                 </SortableContext>
               </DndContext>
+              <p className="edit-mode-hint">⠿ をドラッグして並び替え</p>
               <button
                 className="add-in-edit-btn"
                 onClick={() => { setEditMode(false); setModal({ type: 'add' }) }}
@@ -564,6 +585,13 @@ export default function App() {
           onToggle={(habitId) => toggleHabit(habitId, modal.dateStr)}
           onClose={closeModal}
         />
+      )}
+
+      {undoAction && (
+        <div className="undo-toast">
+          <span className="undo-message">達成を取り消しました</span>
+          <button className="undo-btn" onClick={handleUndo}>元に戻す</button>
+        </div>
       )}
 
       <footer className="app-footer">


### PR DESCRIPTION
## 対応 issue

- close #13
- close #10

## 変更内容

### #13 — 達成取り消し時のUndoトースト
習慣ボタンで未達成に戻したとき、フッター上部に「達成を取り消しました / 元に戻す」トーストを4秒間表示。

- 「元に戻す」を押すと即座に達成状態へ戻る
- 連続タップ時はタイマーをリセットして最後のトグルにだけUndoを提供
- 達成方向のタップではトーストを出さない（誤操作対策は取り消し時のみ）
- フッターとかぶらない位置に fixed 表示、スライドインアニメーション付き

### #10 — 編集モードのドラッグヒント
編集リストの下に「⠿ をドラッグして並び替え」のヒントテキストを追加。初見ユーザーがドラッグハンドルに気づきやすくなる。

## 動作確認

- 達成済み習慣をクリック → 未達成になりトーストが表示される ✓
- トースト内「元に戻す」クリック → 達成状態に戻りトーストが消える ✓
- 4秒後にトーストが自動で消える（タイマー動作）