### PR TITLE
モーダル背景を bottom safe area まで延長

### DIFF
--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -1,6 +1,9 @@
 .modal-backdrop {
   position: fixed;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: calc(-1 * env(safe-area-inset-bottom));
+  left: 0;
   background: rgba(0, 0, 0, 0.45);
   z-index: 100;
   display: flex;


### PR DESCRIPTION
## 概要

- issue #21 の追加切り分け
- body 背景色変更により、下端に露出しているのが app 外側の背景だと確認できた
- ヘルプモーダル表示中にも下端の帯が残るため、modal backdrop が iOS の bottom safe area まで届いていない仮説を検証
- .modal-backdrop の bottom を -env(safe-area-inset-bottom) まで延長

## 確認

- npm run build

Refs #21