### PR TITLE
モーダル表示中の下端背景をシート色に合わせる

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,6 +110,11 @@ export default function App() {
     return () => document.removeEventListener('click', handler)
   }, [menuOpen])
 
+  useEffect(() => {
+    document.body.classList.toggle('modal-open', Boolean(modal))
+    return () => document.body.classList.remove('modal-open')
+  }, [modal])
+
   const closeModal = useCallback(() => setModal(null), [])
 
   const toggleHabit = useCallback((habitId, dateStr) => {

--- a/src/index.css
+++ b/src/index.css
@@ -62,3 +62,8 @@ input {
   height: 100%;
   background: var(--color-bg);
 }
+
+body.modal-open,
+body.modal-open #root {
+  background: var(--color-surface);
+}


### PR DESCRIPTION
## 概要

- issue #21 の追加対応
- fixed backdrop を bottom safe area まで伸ばしても下端帯が暗くならなかったため、iOS/PWA 側のページ背景キャンバス露出として扱う
- モーダル表示中は body に modal-open クラスを付与
- body.modal-open と #root の背景を --color-surface に切り替え、モーダルシート下端と色を揃える
- モーダルを閉じたら通常の --color-bg に戻る

## 確認

- npm run build

Refs #21