### PR TITLE
フッター復元とモーダル下端スクロールを調整

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -38,6 +38,8 @@
 }
 
 .app {
+  --footer-height: 48px;
+  --footer-safe-padding: env(safe-area-inset-bottom);
   min-height: 100%;
   min-height: 100svh;
   display: flex;
@@ -182,6 +184,7 @@
 .app-main {
   flex: 1;
   padding: 16px 16px;
+  padding-bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -315,5 +318,52 @@
 
 .add-in-edit-btn:active {
   opacity: 0.6;
+}
+
+/* Footer */
+.app-footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  max-width: 480px;
+  background: var(--color-surface);
+  border-top: 2px solid var(--color-primary);
+  box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
+  padding-bottom: var(--footer-safe-padding);
+  z-index: 20;
+}
+
+.app-footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  height: var(--footer-height);
+}
+
+.footer-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  flex: 0 1 112px;
+  color: var(--color-text-secondary);
+  padding: 5px 4px;
+  border-radius: 10px;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  transition: color 0.15s, background 0.15s;
+}
+
+.footer-btn svg {
+  width: 19px;
+  height: 19px;
+}
+
+.footer-btn:active {
+  background: var(--color-primary-light);
+  color: var(--color-primary);
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,11 +110,6 @@ export default function App() {
     return () => document.removeEventListener('click', handler)
   }, [menuOpen])
 
-  useEffect(() => {
-    document.body.classList.toggle('modal-open', Boolean(modal))
-    return () => document.body.classList.remove('modal-open')
-  }, [modal])
-
   const closeModal = useCallback(() => setModal(null), [])
 
   const toggleHabit = useCallback((habitId, dateStr) => {

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -1,9 +1,6 @@
 .modal-backdrop {
   position: fixed;
-  top: 0;
-  right: 0;
-  bottom: calc(-1 * env(safe-area-inset-bottom));
-  left: 0;
+  inset: 0;
   background: rgba(0, 0, 0, 0.45);
   z-index: 100;
   display: flex;
@@ -20,14 +17,14 @@
 .modal-sheet {
   background: var(--color-surface);
   border-radius: 24px 24px 0 0;
-  padding: 12px 20px 24px;
-  padding-bottom: calc(24px + env(safe-area-inset-bottom));
+  padding: 12px 20px calc(24px + env(safe-area-inset-bottom));
   width: 100%;
   max-width: 480px;
   animation: slideUp 0.22s cubic-bezier(0.34, 1.2, 0.64, 1);
-  max-height: 90dvh;
+  max-height: calc(100svh - env(safe-area-inset-top));
   overflow-y: auto;
   overscroll-behavior: contain;
+  scroll-padding-bottom: calc(24px + env(safe-area-inset-bottom));
 }
 
 @keyframes slideUp {

--- a/src/index.css
+++ b/src/index.css
@@ -62,8 +62,3 @@ input {
   height: 100%;
   background: var(--color-bg);
 }
-
-body.modal-open,
-body.modal-open #root {
-  background: var(--color-surface);
-}


### PR DESCRIPTION
## 概要

- issue #21 の追加対応
- #49 のモーダル中だけ body 背景を白へ変える処理は、ヘルプ下だけ白くなり体験が悪かったため撤回
- フッター CSS を復元し、通常画面では下部ナビとして表示する
- app-main の下余白をフッター高さ + safe area に合わせて復元
- モーダルは max-height を 100svh 基準に変更し、scroll-padding-bottom と padding-bottom で最後の文字が下端に隠れにくいよう調整
- modal-backdrop の safe area 下への拡張は効かなかったため inset: 0 に戻す

## 確認

- npm run build

Refs #21