### PR TITLE
下端キャンバスをフッターとモーダル面に合わせる

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -38,7 +38,7 @@
 }
 
 .app {
-  --footer-height: 48px;
+  --footer-height: 38px;
   --footer-safe-padding: env(safe-area-inset-bottom);
   min-height: 100%;
   min-height: 100svh;
@@ -346,20 +346,20 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
-  flex: 0 1 112px;
+  gap: 0;
+  flex: 0 1 96px;
   color: var(--color-text-secondary);
-  padding: 5px 4px;
-  border-radius: 10px;
-  font-size: 0.62rem;
+  padding: 2px 4px;
+  border-radius: 8px;
+  font-size: 0.58rem;
   font-weight: 600;
   letter-spacing: 0.03em;
   transition: color 0.15s, background 0.15s;
 }
 
 .footer-btn svg {
-  width: 19px;
-  height: 19px;
+  width: 17px;
+  height: 17px;
 }
 
 .footer-btn:active {

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -17,14 +17,14 @@
 .modal-sheet {
   background: var(--color-surface);
   border-radius: 24px 24px 0 0;
-  padding: 12px 20px calc(24px + env(safe-area-inset-bottom));
+  padding: 12px 20px calc(96px + env(safe-area-inset-bottom));
   width: 100%;
   max-width: 480px;
   animation: slideUp 0.22s cubic-bezier(0.34, 1.2, 0.64, 1);
   max-height: calc(100svh - env(safe-area-inset-top));
   overflow-y: auto;
   overscroll-behavior: contain;
-  scroll-padding-bottom: calc(24px + env(safe-area-inset-bottom));
+  scroll-padding-bottom: calc(96px + env(safe-area-inset-bottom));
 }
 
 @keyframes slideUp {

--- a/src/index.css
+++ b/src/index.css
@@ -34,7 +34,7 @@ html, body {
   width: 100%;
   overflow-x: hidden;
   overscroll-behavior: none;
-  background: var(--color-bg);
+  background: var(--color-surface);
 }
 
 body {
@@ -60,5 +60,5 @@ input {
 
 #root {
   height: 100%;
-  background: var(--color-bg);
+  background: var(--color-surface);
 }


### PR DESCRIPTION
## 概要

- issue #21 の追加対応
- iOS/PWA の最下部に残る帯は fixed 要素で覆えないページキャンバスとして扱う
- html/body/#root の背景を --color-surface に戻し、フッターやモーダル下端と色をつなげる
- .app 自体は --color-bg のままなので、画面中段のアプリ背景は維持
- ヘルプ本文が下端帯に隠れないよう、modal-sheet の padding-bottom と scroll-padding-bottom を 96px + safe area に拡張
- フッター本体を 48px から 38px に縮小し、統計ボタン周りの余白・アイコン・文字サイズを詰める

## 確認

- npm run build

Refs #21