### PR TITLE
フッター操作部を safe area キャンバスから分離

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -323,7 +323,7 @@
 /* Footer */
 .app-footer {
   position: fixed;
-  bottom: 0;
+  bottom: var(--footer-safe-padding);
   left: 0;
   right: 0;
   margin: 0 auto;
@@ -331,7 +331,6 @@
   background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-  padding-bottom: var(--footer-safe-padding);
   z-index: 20;
 }
 

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -17,14 +17,14 @@
 .modal-sheet {
   background: var(--color-surface);
   border-radius: 24px 24px 0 0;
-  padding: 12px 20px calc(96px + env(safe-area-inset-bottom));
+  padding: 12px 20px calc(140px + env(safe-area-inset-bottom));
   width: 100%;
   max-width: 480px;
   animation: slideUp 0.22s cubic-bezier(0.34, 1.2, 0.64, 1);
   max-height: calc(100svh - env(safe-area-inset-top));
   overflow-y: auto;
   overscroll-behavior: contain;
-  scroll-padding-bottom: calc(96px + env(safe-area-inset-bottom));
+  scroll-padding-bottom: calc(140px + env(safe-area-inset-bottom));
 }
 
 @keyframes slideUp {


### PR DESCRIPTION
## 概要

- issue #21 の追加対応
- フッターの統計ボタン下の余白が広すぎるため、フッター要素自体に safe area padding を持たせるのをやめる
- app-footer を bottom: env(safe-area-inset-bottom) に置き、操作部を safe area の上へ分離
- 下端キャンバスは html/body/#root の白背景に任せる
- ヘルプ本文が下端に隠れにくいよう、modal-sheet の padding-bottom と scroll-padding-bottom を 140px + safe area に拡張

## 確認

- npm run build

Refs #21