### PR TITLE
フッター下の見た目上の safe area 余白を抑える

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -39,7 +39,7 @@
 
 .app {
   --footer-height: 34px;
-  --footer-safe-padding: env(safe-area-inset-bottom);
+  --footer-safe-padding: clamp(8px, calc(env(safe-area-inset-bottom) - 18px), 16px);
   min-height: 100%;
   min-height: 100svh;
   display: flex;


### PR DESCRIPTION
## 概要

- issue #21 の追加対応
- 現在の main は bottom: 0 + padding-bottom: env(safe-area-inset-bottom) の基本形になっている
- ただし iPhone 実機では env(safe-area-inset-bottom) が大きく、統計ボタン下の余白が広すぎる
- bottom: 0 は維持し、bottom に safe area を使う実装には戻さない
- 見た目上の footer safe area padding を clamp(8px, env(...) - 18px, 16px) に補正して、余白を最大 16px に抑える

## 確認

- npm run build

Refs #21