### PR TITLE
fix: #11 バックアップ・復元のUXを改善

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import HelpModal from './components/HelpModal'
 import ConfirmModal from './components/ConfirmModal'
 import StatsModal from './components/StatsModal'
 import SettingsModal, { THEMES, applyTheme } from './components/SettingsModal'
+import Toast from './components/Toast'
 import { getToday, getYesterday } from './utils/date'
 import { calcCurrentStreak } from './utils/stats'
 import { validateImportData } from './utils/validation'
@@ -29,6 +30,7 @@ import './App.css'
 
 const STORAGE_KEY = 'habit-tracker-v1'
 const THEME_STORAGE_KEY = 'habit-tracker-theme'
+const LAST_BACKUP_KEY = 'habit-tracker-last-backup'
 
 function loadData() {
   try {
@@ -64,6 +66,10 @@ export default function App() {
   const [calendarDate, setCalendarDate] = useState(() => new Date())
   const [editMode, setEditMode] = useState(false)
   const [modal, setModal] = useState(null)
+  const [toast, setToast] = useState(null)
+  const [lastBackupDate, setLastBackupDate] = useState(() => {
+    try { return localStorage.getItem(LAST_BACKUP_KEY) || null } catch { return null }
+  })
   const [pullY, setPullY] = useState(0)
   const [refreshing, setRefreshing] = useState(false)
   const [scrolled, setScrolled] = useState(false)
@@ -177,6 +183,9 @@ export default function App() {
     a.download = `habit-tracker-${today}.json`
     a.click()
     URL.revokeObjectURL(url)
+    try { localStorage.setItem(LAST_BACKUP_KEY, today) } catch {}
+    setLastBackupDate(today)
+    setToast(`habit-tracker-${today}.json を保存しました`)
   }, [habits, records, today])
 
   const handleImportClick = () => fileInputRef.current?.click()
@@ -215,9 +224,12 @@ export default function App() {
   }, [])
 
   const handleImportConfirm = useCallback(() => {
+    const habitCount = modal.data.habits.length
+    const dayCount = Object.keys(modal.data.records).length
     setHabits(modal.data.habits)
     setRecords(modal.data.records)
     setModal(null)
+    setToast(`データを復元しました（習慣 ${habitCount}件・記録 ${dayCount}日分）`)
   }, [modal])
 
   const handleTouchStart = useCallback((e) => {
@@ -499,7 +511,7 @@ export default function App() {
       {modal?.type === 'importConfirm' && (
         <ConfirmModal
           title="バックアップから復元"
-          message={`バックアップファイルを選択して復元します。\n現在のデータは上書きされます。`}
+          message={`バックアップファイルを選択してください。\n\n⚠ 現在のデータはすべて上書きされます。\nこの操作は取り消せません。`}
           confirmLabel="ファイルを選択"
           danger={true}
           onConfirm={() => { closeModal(); handleImportClick() }}
@@ -515,9 +527,9 @@ export default function App() {
         return (
           <ConfirmModal
             title="インポートの確認"
-            message={`「${modal.filename}」をインポートします。\n\n習慣: ${modal.data.habits.length}件\n記録日数: ${recordDates.length}日\n期間: ${rangeText}\n\n現在のデータはすべて上書きされます。`}
+            message={`「${modal.filename}」をインポートします。\n\n習慣: ${modal.data.habits.length}件\n記録日数: ${recordDates.length}日\n期間: ${rangeText}\n\n⚠ 現在のデータはすべて上書きされます。\nこの操作は取り消せません。`}
             confirmLabel="インポート"
-            danger={false}
+            danger={true}
             onConfirm={handleImportConfirm}
             onClose={closeModal}
           />
@@ -542,6 +554,7 @@ export default function App() {
           onExport={() => { closeModal(); setTimeout(() => setModal({ type: 'exportConfirm' }), 50) }}
           onImport={() => { closeModal(); setTimeout(() => setModal({ type: 'importConfirm' }), 50) }}
           onClose={closeModal}
+          lastBackupDate={lastBackupDate}
         />
       )}
 
@@ -565,6 +578,8 @@ export default function App() {
           onClose={closeModal}
         />
       )}
+
+      {toast && <Toast message={toast} onDismiss={() => setToast(null)} />}
 
       <footer className="app-footer">
         <div className="app-footer-inner">

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -105,3 +105,15 @@
   background: var(--color-primary-light);
   color: var(--color-primary);
 }
+
+.data-mgmt-btn-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.last-backup-date {
+  font-size: 0.72rem;
+  color: var(--color-text-secondary);
+  font-weight: 400;
+}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -18,7 +18,7 @@ export function applyTheme(theme) {
   root.setProperty('--color-today-dark', theme.todayDark)
 }
 
-export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onClose }) {
+export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onClose, lastBackupDate }) {
   return (
     <Modal title="設定" onClose={onClose}>
       <p className="settings-section-title">テーマカラー</p>
@@ -53,7 +53,10 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line x1="12" y1="15" x2="12" y2="3" />
           </svg>
-          <span>バックアップを保存</span>
+          <span className="data-mgmt-btn-text">
+            バックアップを保存
+            {lastBackupDate && <span className="last-backup-date">最終: {lastBackupDate}</span>}
+          </span>
         </button>
         <button className="data-mgmt-btn" onClick={onImport}>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">

--- a/src/components/Toast.css
+++ b/src/components/Toast.css
@@ -1,0 +1,20 @@
+.toast {
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 80px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(30, 30, 30, 0.88);
+  color: #fff;
+  padding: 10px 18px;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  white-space: nowrap;
+  z-index: 200;
+  pointer-events: none;
+  animation: toast-in 0.2s ease;
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+import './Toast.css'
+
+export default function Toast({ message, onDismiss }) {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, 3000)
+    return () => clearTimeout(timer)
+  }, [message, onDismiss])
+
+  return (
+    <div className="toast" role="status" aria-live="polite">
+      {message}
+    </div>
+  )
+}


### PR DESCRIPTION
## 変更内容

close #11

## 主な改善

- Toastフィードバック追加: バックアップ保存・復元成功時に3秒間トーストを表示
- 最終バックアップ日時表示: 設定モーダルの「バックアップを保存」ボタン下部に表示
- 復元警告の強化: 「取り消せません」を明記
- インポート確認ダイアログ修正: danger=false → danger=true