### PR TITLE
固定フッターをやめて通常フローで切り分け

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -184,7 +184,6 @@
 .app-main {
   flex: 1;
   padding: 16px 16px;
-  padding-bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -322,17 +321,13 @@
 
 /* Footer */
 .app-footer {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
   margin: 0 auto;
+  width: 100%;
   max-width: 480px;
   background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
   padding-bottom: var(--footer-safe-padding);
-  z-index: 20;
 }
 
 .app-footer-inner {


### PR DESCRIPTION
## 概要

- issue #21 の原因切り分け
- iOS Safari/PWA の position: fixed + safe area + viewport 変動の影響を外すため、フッターを通常 document flow に変更
- .app-footer から position: fixed / bottom / left / right / z-index を削除
- .app-main の固定フッター避け padding-bottom を削除
- フッターは main の後ろに自然に表示される

## 注意

- これは原因切り分け優先の trial です
- 統計ボタンは常時固定表示ではなくなります

## 確認

- npm run build

Refs #21