### PR TITLE
通常フロー化 trial 後に固定フッターを復元

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -184,6 +184,7 @@
 .app-main {
   flex: 1;
   padding: 16px 16px;
+  padding-bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -321,6 +322,10 @@
 
 /* Footer */
 .app-footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
   margin: 0 auto;
   width: 100%;
   max-width: 480px;
@@ -328,6 +333,7 @@
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
   padding-bottom: var(--footer-safe-padding);
+  z-index: 20;
 }
 
 .app-footer-inner {


### PR DESCRIPTION
## 概要

- issue #21 の切り分け結果を反映
- #58 で固定フッターをやめても下端余白は残ったため、fixed footer は主因ではないと判断
- 通常フロー化によりスクロールしないとフッターが見えなくなったため、固定フッターを復元
- .app-footer に position: fixed / bottom: 0 / left/right: 0 / z-index を戻す
- .app-main にフッター分の padding-bottom を戻す

## 現時点の整理

- 下端余白は footer 固有ではなく、iOS/PWA のページキャンバス露出として残る
- html/body/#root の白背景で下端キャンバスをフッター面と合わせる方針は維持
- bottom に safe-area を使う実装はコンテンツ潜り込みが出たため不採用

## 確認

- npm run build

Refs #21