### PR TITLE
ルート高さとフッタ配置をアプリシェル構造に変更

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,13 +40,20 @@
 .app {
   --footer-height: 34px;
   --footer-safe-padding: clamp(8px, calc(env(safe-area-inset-bottom) - 18px), 16px);
-  min-height: 100%;
-  min-height: 100svh;
+  height: 100vh;
+  height: 100svh;
   display: flex;
   flex-direction: column;
   max-width: 480px;
   margin: 0 auto;
   background: var(--color-bg);
+  overflow: hidden;
+}
+
+@supports (height: 100dvh) {
+  .app {
+    height: 100dvh;
+  }
 }
 
 .app-header {
@@ -182,9 +189,12 @@
 }
 
 .app-main {
-  flex: 1;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   padding: 16px 16px;
-  padding-bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
+  padding-bottom: 16px;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -322,10 +332,7 @@
 
 /* Footer */
 .app-footer {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  flex: 0 0 auto;
   margin: 0 auto;
   width: 100%;
   max-width: 480px;

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -6,6 +6,7 @@
   display: flex;
   align-items: flex-end;
   justify-content: center;
+  overflow: hidden;
   animation: fadeIn 0.18s ease;
 }
 
@@ -17,14 +18,20 @@
 .modal-sheet {
   background: var(--color-surface);
   border-radius: 24px 24px 0 0;
-  padding: 12px 20px calc(140px + env(safe-area-inset-bottom));
+  padding: 12px 20px calc(24px + env(safe-area-inset-bottom));
   width: 100%;
   max-width: 480px;
   animation: slideUp 0.22s cubic-bezier(0.34, 1.2, 0.64, 1);
   max-height: calc(100svh - env(safe-area-inset-top));
   overflow-y: auto;
   overscroll-behavior: contain;
-  scroll-padding-bottom: calc(140px + env(safe-area-inset-bottom));
+  scroll-padding-bottom: calc(24px + env(safe-area-inset-bottom));
+}
+
+@supports (height: 100dvh) {
+  .modal-sheet {
+    max-height: calc(100dvh - env(safe-area-inset-top));
+  }
 }
 
 @keyframes slideUp {

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 import './Modal.css'
 
 const CLOSE_THRESHOLD = 80
@@ -8,12 +8,6 @@ export default function Modal({ onClose, children, title }) {
   const startYRef = useRef(0)
   const dragYRef = useRef(0)
   const draggingRef = useRef(false)
-
-  useEffect(() => {
-    const prev = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    return () => { document.body.style.overflow = prev }
-  }, [])
 
   const handleTouchStart = (e) => {
     if (sheetRef.current.scrollTop > 0) return

--- a/src/index.css
+++ b/src/index.css
@@ -30,7 +30,7 @@ input, textarea, [contenteditable] {
 }
 
 html, body {
-  height: 100%;
+  min-height: 100%;
   width: 100%;
   overflow-x: hidden;
   overscroll-behavior: none;
@@ -59,6 +59,6 @@ input {
 }
 
 #root {
-  height: 100%;
+  min-height: 100%;
   background: var(--color-surface);
 }


### PR DESCRIPTION
## 概要

Issue #21 の追加切り分けです。

これまでの検証で、フッタCSSを外しても下端の余白が残り、ヘルプモーダルでも同じ余白が出ていたため、フッタ単体ではなく大枠のスクロール/viewport構造が原因候補と判断しました。

## 変更内容

- `html/body/#root` の `height: 100%` 固定を `min-height: 100%` に変更
- `.app` を `100svh`/対応環境では `100dvh` のアプリシェルに変更
- `.app-main` だけをスクロール領域に変更
- フッタを `position: fixed` から外し、アプリシェル末尾に常駐する構造へ変更
- モーダルで `document.body.style.overflow = 'hidden'` を直接入れる処理を削除
- ヘルプモーダルの過剰な下paddingを縮め、`100dvh` 対応を追加

## 確認

- `npm run build` 成功

Refs #21