### PR TITLE
feat: #9 #15 #32 統計集計・テーマプレビュー・習慣終了機能

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import ConfirmModal from './components/ConfirmModal'
 import StatsModal from './components/StatsModal'
 import SettingsModal, { THEMES, applyTheme } from './components/SettingsModal'
 import Toast from './components/Toast'
+import ArchivedHabitItem from './components/ArchivedHabitItem'
 import { getToday, getYesterday } from './utils/date'
 import { calcCurrentStreak } from './utils/stats'
 import { validateImportData } from './utils/validation'
@@ -157,6 +158,16 @@ export default function App() {
     setModal(null)
   }, [])
 
+  const archiveHabit = useCallback((habitId) => {
+    setHabits(prev => prev.map(h => h.id === habitId ? { ...h, archivedAt: today } : h))
+    setModal(null)
+  }, [today])
+
+  const restoreHabit = useCallback((habitId) => {
+    setHabits(prev => prev.map(h => h.id === habitId ? { ...h, archivedAt: null } : h))
+    setModal(null)
+  }, [])
+
   const handleDragEnd = useCallback(({ active, over }) => {
     if (over && active.id !== over.id) {
       setHabits(prev => {
@@ -169,6 +180,8 @@ export default function App() {
 
   const isEditableDate = (dateStr) => dateStr === today || dateStr === yesterday
 
+  const activeHabits = habits.filter(h => !h.archivedAt)
+  const archivedHabits = habits.filter(h => h.archivedAt)
   const todayRecords = records[today] || []
 
   // --- Export / Import ---
@@ -411,15 +424,16 @@ export default function App() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext
-                  items={habits.map(h => h.id)}
+                  items={activeHabits.map(h => h.id)}
                   strategy={verticalListSortingStrategy}
                 >
                   <div className="habits-edit-list">
-                    {habits.map(habit => (
+                    {activeHabits.map(habit => (
                       <HabitEditItem
                         key={habit.id}
                         habit={habit}
                         onEdit={(h) => setModal({ type: 'edit', habit: h })}
+                        onArchive={(h) => setModal({ type: 'archiveConfirm', habitId: h.id, habitName: h.name })}
                         onDelete={(h) => setModal({ type: 'deleteConfirm', habitId: h.id, habitName: h.name })}
                       />
                     ))}
@@ -432,10 +446,23 @@ export default function App() {
               >
                 ＋ 習慣を追加
               </button>
+              {archivedHabits.length > 0 && (
+                <div className="archived-section">
+                  <p className="archived-section-title">終了した習慣</p>
+                  {archivedHabits.map(habit => (
+                    <ArchivedHabitItem
+                      key={habit.id}
+                      habit={habit}
+                      onRestore={(h) => restoreHabit(h.id)}
+                      onDelete={(h) => setModal({ type: 'deleteConfirm', habitId: h.id, habitName: h.name })}
+                    />
+                  ))}
+                </div>
+              )}
             </>
           ) : (
             <div className="habits-grid">
-              {habits.map(habit => (
+              {activeHabits.map(habit => (
                 <HabitButton
                   key={habit.id}
                   habit={habit}
@@ -558,11 +585,22 @@ export default function App() {
         />
       )}
 
+      {modal?.type === 'archiveConfirm' && (
+        <ConfirmModal
+          title="習慣を終了"
+          message={`「${modal.habitName}」を終了しますか？\n\n過去の記録は保持されます。\nいつでも再開できます。`}
+          confirmLabel="終了する"
+          danger={false}
+          onConfirm={() => archiveHabit(modal.habitId)}
+          onClose={closeModal}
+        />
+      )}
+
       {modal?.type === 'deleteConfirm' && (
         <ConfirmModal
-          title="習慣の削除"
-          message={`「${modal.habitName}」を削除しますか？\n過去の記録もすべて削除されます。`}
-          confirmLabel="削除"
+          title="習慣を完全に削除"
+          message={`「${modal.habitName}」を完全に削除しますか？\n\n⚠ 過去の記録もすべて削除されます。\nこの操作は取り消せません。`}
+          confirmLabel="完全に削除"
           onConfirm={() => deleteHabit(modal.habitId)}
           onClose={closeModal}
         />

--- a/src/components/ArchivedHabitItem.css
+++ b/src/components/ArchivedHabitItem.css
@@ -1,0 +1,83 @@
+.archived-section {
+  margin-top: 20px;
+}
+
+.archived-section-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  padding: 0 2px;
+}
+
+.archived-habit-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  margin-bottom: 6px;
+  opacity: 0.75;
+}
+
+.archived-habit-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.archived-habit-name {
+  flex: 1;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.archived-habit-date {
+  font-size: 0.7rem;
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+}
+
+.archived-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 8px;
+  transition: background 0.12s, color 0.12s;
+}
+
+.archived-action.restore {
+  padding: 5px 10px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+.archived-action.restore:active {
+  opacity: 0.6;
+}
+
+.archived-action.delete {
+  width: 32px;
+  height: 32px;
+  color: var(--color-danger);
+}
+
+.archived-action.delete:hover {
+  background: #FEF2F2;
+}
+
+.archived-action.delete:active {
+  opacity: 0.6;
+}

--- a/src/components/ArchivedHabitItem.jsx
+++ b/src/components/ArchivedHabitItem.jsx
@@ -1,0 +1,32 @@
+import './ArchivedHabitItem.css'
+
+export default function ArchivedHabitItem({ habit, onRestore, onDelete }) {
+  return (
+    <div className="archived-habit-item">
+      <span className="archived-habit-dot" style={{ backgroundColor: habit.color }} />
+      <span className="archived-habit-name">{habit.name}</span>
+      {habit.archivedAt && (
+        <span className="archived-habit-date">{habit.archivedAt}</span>
+      )}
+      <button
+        className="archived-action restore"
+        onClick={() => onRestore(habit)}
+        aria-label={`${habit.name}を再開`}
+      >
+        再開
+      </button>
+      <button
+        className="archived-action delete"
+        onClick={() => onDelete(habit)}
+        aria-label={`${habit.name}を削除`}
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="3 6 5 6 21 6" />
+          <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+          <path d="M10 11v6M14 11v6" />
+          <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/src/components/DayDetailModal.jsx
+++ b/src/components/DayDetailModal.jsx
@@ -17,7 +17,11 @@ export default function DayDetailModal({
     dateStr === today ? '今日' :
     dateStr === yesterday ? '昨日' : null
 
-  const activeHabits = habits.filter(h => !h.createdAt || dateStr >= h.createdAt)
+  const activeHabits = habits.filter(h => {
+    if (h.createdAt && dateStr < h.createdAt) return false
+    if (h.archivedAt && dateStr > h.archivedAt) return false
+    return true
+  })
   const completedCount = activeHabits.filter(h => completedIds.includes(h.id)).length
 
   return (

--- a/src/components/HabitEditItem.css
+++ b/src/components/HabitEditItem.css
@@ -81,6 +81,19 @@
   opacity: 0.6;
 }
 
+.habit-edit-action.archive {
+  color: var(--color-text-secondary);
+}
+
+.habit-edit-action.archive:hover {
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+.habit-edit-action.archive:active {
+  opacity: 0.6;
+}
+
 .habit-edit-action.delete {
   color: var(--color-danger);
 }

--- a/src/components/HabitEditItem.jsx
+++ b/src/components/HabitEditItem.jsx
@@ -2,7 +2,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import './HabitEditItem.css'
 
-export default function HabitEditItem({ habit, onEdit, onDelete }) {
+export default function HabitEditItem({ habit, onEdit, onArchive, onDelete }) {
   const {
     attributes,
     listeners,
@@ -54,6 +54,18 @@ export default function HabitEditItem({ habit, onEdit, onDelete }) {
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
           <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+        </svg>
+      </button>
+
+      <button
+        className="habit-edit-action archive"
+        onClick={() => onArchive(habit)}
+        aria-label={`${habit.name}を終了`}
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="2" y="3" width="20" height="5" rx="1" />
+          <path d="M4 8v11a2 2 0 002 2h12a2 2 0 002-2V8" />
+          <path d="M10 12h4" />
         </svg>
       </button>
 

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -21,13 +21,14 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
-  padding: 14px 8px;
+  gap: 8px;
+  padding: 14px 8px 12px;
   border-radius: var(--radius-sm);
   border: 2px solid var(--color-border);
   background: var(--color-surface);
-  transition: border-color 0.15s;
+  transition: border-color 0.15s, background 0.15s;
   position: relative;
+  cursor: pointer;
 }
 
 .theme-swatch.selected {
@@ -36,15 +37,32 @@
   background: var(--color-primary-light);
 }
 
-.swatch-circle {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  display: block;
+.swatch-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  width: 100%;
+}
+
+.swatch-preview-btn {
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: white;
+  letter-spacing: 0.02em;
+}
+
+.swatch-preview-today {
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 0.65rem;
+  font-weight: 700;
 }
 
 .swatch-label {
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   color: var(--color-text-secondary);
   font-weight: 500;
   transition: color 0.15s, font-weight 0.15s;
@@ -55,17 +73,6 @@
   font-weight: 700;
 }
 
-.swatch-chips {
-  display: flex;
-  gap: 4px;
-}
-
-.swatch-chip {
-  width: 14px;
-  height: 7px;
-  border-radius: 3px;
-}
-
 .swatch-check {
   position: absolute;
   top: 6px;
@@ -73,7 +80,6 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: var(--color-primary);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -30,12 +30,11 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
             onClick={() => onSelectTheme(theme)}
             aria-label={`${theme.label}${currentThemeId === theme.id ? '（選択中）' : ''}`}
           >
-            <span className="swatch-circle" style={{ background: theme.primary }} />
-            <span className="swatch-label">{theme.label}</span>
-            <div className="swatch-chips">
-              <span className="swatch-chip" style={{ background: theme.primary }} />
-              <span className="swatch-chip" style={{ background: theme.today }} />
+            <div className="swatch-preview">
+              <span className="swatch-preview-btn" style={{ background: theme.primary }}>習慣</span>
+              <span className="swatch-preview-today" style={{ background: theme.today, color: theme.todayDark }}>今日</span>
             </div>
+            <span className="swatch-label">{theme.label}</span>
             {currentThemeId === theme.id && (
               <span className="swatch-check" style={{ background: theme.primary }}>
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">

--- a/src/components/StatsModal.css
+++ b/src/components/StatsModal.css
@@ -38,6 +38,10 @@
   gap: 8px;
 }
 
+.stats-row-period {
+  margin-top: 8px;
+}
+
 .stats-item {
   flex: 1;
   display: flex;

--- a/src/components/StatsModal.css
+++ b/src/components/StatsModal.css
@@ -78,6 +78,18 @@
   text-align: center;
 }
 
+.stats-archived-badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  margin-left: 4px;
+  flex-shrink: 0;
+}
+
 .stats-close-wrap {
   padding: 4px 16px 24px;
 }

--- a/src/components/StatsModal.jsx
+++ b/src/components/StatsModal.jsx
@@ -19,6 +19,7 @@ export default function StatsModal({ habits, records, onClose }) {
                 <div className="stats-habit-name">
                   <span className="stats-dot" style={{ backgroundColor: habit.color }} />
                   <span>{habit.name}</span>
+                  {habit.archivedAt && <span className="stats-archived-badge">終了</span>}
                 </div>
                 <div className="stats-row">
                   <div className="stats-item">

--- a/src/components/StatsModal.jsx
+++ b/src/components/StatsModal.jsx
@@ -1,8 +1,10 @@
 import Modal from './Modal'
-import { calcStats } from '../utils/stats'
+import { calcStats, calcPeriodStats } from '../utils/stats'
+import { getToday } from '../utils/date'
 import './StatsModal.css'
 
 export default function StatsModal({ habits, records, onClose }) {
+  const today = getToday()
   return (
     <Modal onClose={onClose} title="統計">
       {habits.length === 0 ? (
@@ -11,6 +13,7 @@ export default function StatsModal({ habits, records, onClose }) {
         <div className="stats-list">
           {habits.map(habit => {
             const { current, longest, total } = calcStats(habit.id, records)
+            const { monthCount, rate30 } = calcPeriodStats(habit.id, records, today, habit.createdAt)
             return (
               <div key={habit.id} className="stats-card">
                 <div className="stats-habit-name">
@@ -38,6 +41,22 @@ export default function StatsModal({ habits, records, onClose }) {
                       <span className="stats-unit">回</span>
                     </div>
                     <span className="stats-label">累計達成</span>
+                  </div>
+                </div>
+                <div className="stats-row stats-row-period">
+                  <div className="stats-item">
+                    <div className="stats-value-row">
+                      <span className="stats-value">{monthCount}</span>
+                      <span className="stats-unit">日</span>
+                    </div>
+                    <span className="stats-label">今月達成</span>
+                  </div>
+                  <div className="stats-item">
+                    <div className="stats-value-row">
+                      <span className="stats-value">{rate30 !== null ? rate30 : '-'}</span>
+                      {rate30 !== null && <span className="stats-unit">%</span>}
+                    </div>
+                    <span className="stats-label">直近30日</span>
                   </div>
                 </div>
               </div>

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -49,3 +49,35 @@ export function calcStats(habitId, records) {
   const current = calcCurrentStreak(habitId, records)
   return { current, longest, total }
 }
+
+export function calcPeriodStats(habitId, records, today, createdAt) {
+  const todayDate = parseLocalDate(today)
+
+  function countRange(start, end) {
+    let achieved = 0, total = 0
+    const d = new Date(start)
+    while (d <= end) {
+      const dateStr = formatDate(d)
+      total++
+      if ((records[dateStr] || []).includes(habitId)) achieved++
+      d.setDate(d.getDate() + 1)
+    }
+    return { achieved, total }
+  }
+
+  const habitStart = createdAt ? parseLocalDate(createdAt) : null
+
+  // 今月
+  const monthStart = new Date(todayDate.getFullYear(), todayDate.getMonth(), 1)
+  const effectiveMonthStart = habitStart && habitStart > monthStart ? habitStart : monthStart
+  const { achieved: monthCount } = countRange(effectiveMonthStart, todayDate)
+
+  // 直近30日
+  const thirtyAgo = new Date(todayDate)
+  thirtyAgo.setDate(thirtyAgo.getDate() - 29)
+  const effective30Start = habitStart && habitStart > thirtyAgo ? habitStart : thirtyAgo
+  const { achieved: r30, total: t30 } = countRange(effective30Start, todayDate)
+  const rate30 = t30 > 0 ? Math.round((r30 / t30) * 100) : null
+
+  return { monthCount, rate30 }
+}


### PR DESCRIPTION
## 変更内容

close #9 close #15 close #32

## #9 統計画面に達成率と期間別集計を追加

- 今月達成日数を各習慣の統計カードに追加
- 直近30日の達成率（%）を表示
- 習慣のcreatedAt以前の日を母数に含めない

## #15 テーマ設定のプレビューと選択状態を改善

- スウォッチの大円+小チップ → 「習慣」ボタン+「今日」タグのプレビューに変更
- 選択前から配色の実際の雰囲気が分かるデザインに

## #32 習慣の終了/非表示と削除を分ける

- 編集モードの各習慣に「終了」ボタン（アーカイブアイコン）を追加
- 終了した習慣は今日の習慣一覧から非表示
- 編集モード下部に「終了した習慣」セクションを表示（再開/削除のみ）
- カレンダー・日別詳細・統計では終了日以前の記録を引き続き表示
- 統計に「終了」バッジを表示
- 削除確認モーダルの警告文を強化（取り消せない旨を明記）