### PR TITLE
iPhoneの実表示高をアプリシェルへ反映

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,20 +40,13 @@
 .app {
   --footer-height: 34px;
   --footer-safe-padding: clamp(8px, calc(env(safe-area-inset-bottom) - 18px), 16px);
-  height: 100vh;
-  height: 100svh;
+  height: var(--app-viewport-height);
   display: flex;
   flex-direction: column;
   max-width: 480px;
   margin: 0 auto;
   background: var(--color-bg);
   overflow: hidden;
-}
-
-@supports (height: 100dvh) {
-  .app {
-    height: 100dvh;
-  }
 }
 
 .app-header {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,6 +77,7 @@ export default function App() {
   const pullStartY = useRef(null)
   const justScrolledToTop = useRef(false)
   const scrollStopTimer = useRef(null)
+  const mainRef = useRef(null)
   const PULL_THRESHOLD = 80
 
   const today = getToday()
@@ -92,8 +93,29 @@ export default function App() {
   }, [habits, records])
 
   useEffect(() => {
+    const setViewportHeight = () => {
+      const height = window.visualViewport?.height || window.innerHeight
+      document.documentElement.style.setProperty('--app-viewport-height', `${height}px`)
+    }
+
+    setViewportHeight()
+    window.visualViewport?.addEventListener('resize', setViewportHeight)
+    window.visualViewport?.addEventListener('scroll', setViewportHeight)
+    window.addEventListener('resize', setViewportHeight)
+
+    return () => {
+      window.visualViewport?.removeEventListener('resize', setViewportHeight)
+      window.visualViewport?.removeEventListener('scroll', setViewportHeight)
+      window.removeEventListener('resize', setViewportHeight)
+    }
+  }, [])
+
+  useEffect(() => {
+    const scrollEl = mainRef.current
+    if (!scrollEl) return
+
     const onScroll = () => {
-      if (window.scrollY > 0) {
+      if (scrollEl.scrollTop > 0) {
         setScrolled(true)
         justScrolledToTop.current = true
         clearTimeout(scrollStopTimer.current)
@@ -105,8 +127,9 @@ export default function App() {
         }, 300)
       }
     }
-    window.addEventListener('scroll', onScroll, { passive: true })
-    return () => window.removeEventListener('scroll', onScroll)
+    scrollEl.addEventListener('scroll', onScroll, { passive: true })
+    onScroll()
+    return () => scrollEl.removeEventListener('scroll', onScroll)
   }, [])
 
   useEffect(() => {
@@ -234,7 +257,7 @@ export default function App() {
 
   const handleTouchStart = useCallback((e) => {
     // スクロール戻り直後はpull-to-refreshを許可しない
-    if (window.scrollY === 0 && !justScrolledToTop.current) {
+    if ((mainRef.current?.scrollTop ?? 0) === 0 && !justScrolledToTop.current) {
       pullStartY.current = e.touches[0].clientY
     }
   }, [])
@@ -379,7 +402,7 @@ export default function App() {
         )}
       </div>
 
-      <main className="app-main">
+      <main ref={mainRef} className="app-main">
         <section className="section">
           <div className="section-header">
             <h2 className="section-title">今日の習慣</h2>

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -1,6 +1,7 @@
 .modal-backdrop {
   position: fixed;
   inset: 0;
+  height: var(--app-viewport-height);
   background: rgba(0, 0, 0, 0.45);
   z-index: 100;
   display: flex;
@@ -22,16 +23,10 @@
   width: 100%;
   max-width: 480px;
   animation: slideUp 0.22s cubic-bezier(0.34, 1.2, 0.64, 1);
-  max-height: calc(100svh - env(safe-area-inset-top));
+  max-height: calc(var(--app-viewport-height) - env(safe-area-inset-top));
   overflow-y: auto;
   overscroll-behavior: contain;
   scroll-padding-bottom: calc(24px + env(safe-area-inset-bottom));
-}
-
-@supports (height: 100dvh) {
-  .modal-sheet {
-    max-height: calc(100dvh - env(safe-area-inset-top));
-  }
 }
 
 @keyframes slideUp {

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,7 @@ input, textarea, [contenteditable] {
 }
 
 :root {
+  --app-viewport-height: 100svh;
   --color-bg: #F0F2F5;
   --color-surface: #FFFFFF;
   --color-primary: #6366F1;
@@ -27,6 +28,12 @@ input, textarea, [contenteditable] {
   --shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.16);
   font-size: 16px;
+}
+
+@supports (height: 100dvh) {
+  :root {
+    --app-viewport-height: 100dvh;
+  }
 }
 
 html, body {


### PR DESCRIPTION
## 概要

Issue #21 の追加修正です。

#60 後も下端余白が残るため、CSS の `100svh` / `100dvh` だけでは iPhone の実表示領域を正しく取れていない可能性を潰します。

## 変更内容

- `window.visualViewport.height` を `--app-viewport-height` に反映
- `.app` とモーダルの高さ計算を `--app-viewport-height` ベースに変更
- #60 で `.app-main` がスクロール領域になったため、既存の `window.scrollY` 判定を `.app-main.scrollTop` 判定に変更
- pull-to-refresh の開始判定も `.app-main` のスクロール位置を見るよう変更

## 狙い

iOS Safari / PWA で viewport 単位と実表示領域がズレた場合でも、アプリ全体とモーダルが実際に見えている高さへ追従するようにします。

## 確認

- `npm run build` 成功

Refs #21