### PR TITLE
下端余白のviewportデバッグを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="習慣" />
-    <link rel="manifest" href="/manifest.webmanifest" />
-    <link rel="apple-touch-icon" href="/icon.svg" />
+    <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="%BASE_URL%icon.svg" />
     <title>習慣トラッカー</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -368,3 +368,40 @@
   color: var(--color-primary);
 }
 
+.viewport-debug-enabled {
+  background: #ff00ff !important;
+}
+
+.viewport-debug-enabled body {
+  background: #00ffff !important;
+}
+
+.viewport-debug-enabled #root {
+  background: #ffff00 !important;
+}
+
+.viewport-debug-fixed-bar {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 9999;
+  height: 10px;
+  pointer-events: none;
+  background: #ff1744;
+}
+
+.viewport-debug-panel {
+  position: fixed;
+  right: 8px;
+  bottom: 14px;
+  z-index: 9999;
+  padding: 4px 6px;
+  border-radius: 4px;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  font-size: 10px;
+  line-height: 1.2;
+}
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,6 +60,7 @@ function loadTheme() {
 }
 
 export default function App() {
+  const viewportDebug = new URLSearchParams(window.location.search).has('debugViewport')
   const [habits, setHabits] = useState(_initial.habits)
   const [records, setRecords] = useState(_initial.records)
   const [themeId, setThemeId] = useState(() => { const t = loadTheme(); applyTheme(t); return t.id })
@@ -74,6 +75,7 @@ export default function App() {
   const [refreshing, setRefreshing] = useState(false)
   const [scrolled, setScrolled] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [viewportDebugInfo, setViewportDebugInfo] = useState('')
   const pullStartY = useRef(null)
   const justScrolledToTop = useRef(false)
   const scrollStopTimer = useRef(null)
@@ -96,19 +98,27 @@ export default function App() {
     const setViewportHeight = () => {
       const height = window.visualViewport?.height || window.innerHeight
       document.documentElement.style.setProperty('--app-viewport-height', `${height}px`)
+      if (viewportDebug) {
+        const appHeight = document.querySelector('.app')?.getBoundingClientRect().height
+        setViewportDebugInfo(
+          `vv:${Math.round(height)} ih:${window.innerHeight} app:${Math.round(appHeight || 0)}`
+        )
+      }
     }
 
+    document.documentElement.classList.toggle('viewport-debug-enabled', viewportDebug)
     setViewportHeight()
     window.visualViewport?.addEventListener('resize', setViewportHeight)
     window.visualViewport?.addEventListener('scroll', setViewportHeight)
     window.addEventListener('resize', setViewportHeight)
 
     return () => {
+      document.documentElement.classList.remove('viewport-debug-enabled')
       window.visualViewport?.removeEventListener('resize', setViewportHeight)
       window.visualViewport?.removeEventListener('scroll', setViewportHeight)
       window.removeEventListener('resize', setViewportHeight)
     }
-  }, [])
+  }, [viewportDebug])
 
   useEffect(() => {
     const scrollEl = mainRef.current
@@ -614,6 +624,13 @@ export default function App() {
           </button>
         </div>
       </footer>
+
+      {viewportDebug && (
+        <>
+          <div className="viewport-debug-fixed-bar" />
+          <div className="viewport-debug-panel">{viewportDebugInfo}</div>
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 概要

Issue #21 の追加切り分けです。

#62 でもフッタ下・ヘルプ下の余白に変化がないため、これ以上 CSS を推測で重ねる前に、下端余白が DOM 内なのか iOS Safari / PWA の外側キャンバスなのかを実機で判定できるようにします。

## 変更内容

- `?debugViewport=1` を付けたときだけ、画面下端に赤い fixed バーを表示
- 同じく `?debugViewport=1` のとき、`visualViewport.height` / `innerHeight` / `.app` height を表示
- debug時だけ `html` / `body` / `#root` の背景色を分け、余白がどのレイヤー由来か見えるようにする
- `base: /habit-tracker/` に合わせ、manifest/apple-touch-icon の参照を `%BASE_URL%...` に修正

## 確認方法

マージ後、以下で開いてスクリーンショットを確認します。

`https://junkoma2.github.io/habit-tracker/?debugViewport=1`

赤いバーが余白の一番下まで来るか、余白の上で止まるかを見ます。

## 確認

- `npm run build` 成功

Refs #21