### PR TITLE
fix: #54 pull-to-refresh戻りアニメーション改善・連続日数ラベル追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,10 @@
   transition: height 0.2s ease, opacity 0.2s ease;
 }
 
+.pull-indicator.returning {
+  transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease;
+}
+
 .pull-arrow {
   transition: transform 0.2s ease;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,6 +71,7 @@ export default function App() {
     try { return localStorage.getItem(LAST_BACKUP_KEY) || null } catch { return null }
   })
   const [pullY, setPullY] = useState(0)
+  const [pullReturning, setPullReturning] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [scrolled, setScrolled] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
@@ -314,11 +315,22 @@ export default function App() {
       setHabits(fresh.habits)
       setRecords(fresh.records)
       setTimeout(() => {
+        // refreshing終了時: inline styleに切り替えてから0へ遷移させる
+        setPullReturning(true)
+        setPullY(PULL_THRESHOLD)
         setRefreshing(false)
         if (swUpdated) window.location.reload()
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            setPullY(0)
+            setTimeout(() => setPullReturning(false), 350)
+          })
+        })
       }, 700)
     } else {
+      setPullReturning(true)
       setPullY(0)
+      setTimeout(() => setPullReturning(false), 350)
     }
     pullStartY.current = null
   }, [pullY])
@@ -373,7 +385,7 @@ export default function App() {
       </header>
 
       <div
-        className={`pull-indicator${refreshing ? ' refreshing' : ''}${pullY >= PULL_THRESHOLD ? ' ready' : ''}`}
+        className={`pull-indicator${refreshing ? ' refreshing' : ''}${pullY >= PULL_THRESHOLD ? ' ready' : ''}${pullReturning ? ' returning' : ''}`}
         style={!refreshing ? { height: pullY, opacity: pullY / PULL_THRESHOLD } : undefined}
       >
         {refreshing ? (

--- a/src/components/HabitButton.jsx
+++ b/src/components/HabitButton.jsx
@@ -69,7 +69,7 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
         style={{ backgroundColor: completed ? '#fff' : habit.color }}
       />
       <span className="habit-name">{habit.name}</span>
-      {streak > 1 && <span className="habit-streak">{streak}日</span>}
+      {streak > 1 && <span className="habit-streak">{streak}日継続</span>}
       {completed && <span className="habit-check">✓</span>}
     </button>
   )


### PR DESCRIPTION
## 対応 issue

- ref #54

## 変更内容

### pull-to-refresh戻りアニメーション
指を離したとき・リフレッシュ完了後に `.returning` クラスを付与して cubic-bezier トランジション（0.35s）でスムーズに縮小する。

- pull離し（閾値未満）: `pullReturning=true` と同時に `pullY=0` → height が滑らかに折り畳まれる
- リフレッシュ完了後: `pullY=PULL_THRESHOLD` で inline style を橋渡し → rAF 2段で `pullY=0` に遷移

### 連続日数ラベル
`{N}日` → `{N}日継続` に変更し、数値の意味が一目でわかるようにする。

## 受け入れ条件

- [x] pull離し後にインジケーターがスッと縮む
- [x] リフレッシュ完了後もスムーズに縮む
- [x] 連続日数に「継続」ラベルが表示される
- [x] `npm run build` が通る