### PR TITLE
スクロール時のヘッダーハンバーガーを削除

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -78,13 +78,6 @@
 .header-actions {
   display: flex;
   gap: 6px;
-  transition: opacity 0.2s ease, transform 0.2s ease;
-}
-
-.app.scrolled .header-actions {
-  opacity: 0;
-  transform: translateY(-6px);
-  pointer-events: none;
 }
 
 .header-btn {
@@ -108,77 +101,6 @@
 
 .header-btn:active {
   opacity: 0.7;
-}
-
-/* Hamburger */
-.hamburger-wrapper {
-  position: absolute;
-  right: 16px;
-  top: env(safe-area-inset-top);
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s ease;
-}
-
-.app.scrolled .hamburger-wrapper {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.hamburger-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: rgba(255, 255, 255, 0.9);
-  padding: 6px;
-  border-radius: 8px;
-  transition: background 0.15s;
-}
-
-.hamburger-btn:active {
-  background: rgba(255, 255, 255, 0.15);
-}
-
-
-.header-menu {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-  overflow: hidden;
-  z-index: 20;
-  min-width: 140px;
-}
-
-.header-menu-item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  width: 100%;
-  padding: 12px 16px;
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: var(--color-text);
-  text-align: left;
-  transition: background 0.12s;
-}
-
-.header-menu-item + .header-menu-item {
-  border-top: 1px solid var(--color-border);
-}
-
-.header-menu-item svg {
-  color: var(--color-primary);
-  flex-shrink: 0;
-}
-
-.header-menu-item:active {
-  background: var(--color-primary-light);
 }
 
 .app-main {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,7 +75,6 @@ export default function App() {
   const [pullY, setPullY] = useState(0)
   const [refreshing, setRefreshing] = useState(false)
   const [scrolled, setScrolled] = useState(false)
-  const [menuOpen, setMenuOpen] = useState(false)
   const [viewportDebugInfo, setViewportDebugInfo] = useState('')
   const [undoAction, setUndoAction] = useState(null)
   const undoTimerRef = useRef(null)
@@ -134,7 +133,6 @@ export default function App() {
         clearTimeout(scrollStopTimer.current)
       } else {
         setScrolled(false)
-        setMenuOpen(false)
         scrollStopTimer.current = setTimeout(() => {
           justScrolledToTop.current = false
         }, 300)
@@ -144,13 +142,6 @@ export default function App() {
     onScroll()
     return () => scrollEl.removeEventListener('scroll', onScroll)
   }, [])
-
-  useEffect(() => {
-    if (!menuOpen) return
-    const handler = () => setMenuOpen(false)
-    document.addEventListener('click', handler)
-    return () => document.removeEventListener('click', handler)
-  }, [menuOpen])
 
   const closeModal = useCallback(() => setModal(null), [])
 
@@ -393,29 +384,6 @@ export default function App() {
           </button>
         </div>
         <input ref={fileInputRef} type="file" accept=".json" style={{ display: 'none' }} onChange={handleFileChange} />
-
-        <div className="hamburger-wrapper">
-          <button className="hamburger-btn" onClick={(e) => { e.stopPropagation(); setMenuOpen(v => !v) }} aria-label="メニュー">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
-              <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" />
-            </svg>
-          </button>
-          {menuOpen && (
-            <>
-              <div className="header-menu">
-                {[
-                  { type: 'help', label: 'ヘルプ', icon: <><circle cx="12" cy="12" r="10" /><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" /><line x1="12" y1="17" x2="12.01" y2="17" /></> },
-                  { type: 'settings', label: '設定', icon: <><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></> },
-                ].map(({ type, label, icon }) => (
-                  <button key={type} className="header-menu-item" onClick={() => { setModal({ type }); setMenuOpen(false) }}>
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">{icon}</svg>
-                    <span>{label}</span>
-                  </button>
-                ))}
-              </div>
-            </>
-          )}
-        </div>
       </header>
 
       <div


### PR DESCRIPTION
## 概要

下スクロール時に表示されるヘッダーのハンバーガーアイコンが残っていたため削除します。

## 変更内容

- `menuOpen` state とメニュー開閉処理を削除
- `.hamburger-wrapper` / `.hamburger-btn` / `.header-menu` 関連の JSX/CSS を削除
- スクロール時にヘルプ/設定ボタンを非表示にするCSSを削除し、常にヘッダー右側に表示されるように変更

## 確認

- `rg` で `hamburger` / `menuOpen` / `header-menu` が残っていないことを確認
- `npm run build` 成功

Refs #21