### PR TITLE
fix: #54 pull-to-refresh戻り時の膨張バグを修正

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -16,7 +16,11 @@
 }
 
 .pull-indicator.returning {
-  transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease;
+  transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.pull-indicator.returning > * {
+  opacity: 0;
 }
 
 .pull-arrow {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -352,22 +352,21 @@ export default function App() {
       setHabits(fresh.habits)
       setRecords(fresh.records)
       setTimeout(() => {
-        // refreshing終了時: inline styleに切り替えてから0へ遷移させる
+        // .returning を先に付与してから refreshing を落とすことで
+        // CSS height: 44px → inline 0px のトランジションを確実に起動する
         setPullReturning(true)
-        setPullY(PULL_THRESHOLD)
-        setRefreshing(false)
-        if (swUpdated) window.location.reload()
         requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            setPullY(0)
-            setTimeout(() => setPullReturning(false), 350)
-          })
+          setRefreshing(false)
+          if (swUpdated) window.location.reload()
+          setTimeout(() => setPullReturning(false), 400)
         })
       }, 700)
     } else {
       setPullReturning(true)
-      setPullY(0)
-      setTimeout(() => setPullReturning(false), 350)
+      requestAnimationFrame(() => {
+        setPullY(0)
+        setTimeout(() => setPullReturning(false), 400)
+      })
     }
     pullStartY.current = null
   }, [pullY])


### PR DESCRIPTION
## 概要

PR #64 マージ後に push した修正が main に未反映だったため、cherry-pick で適用。

## 問題

`setPullY(PULL_THRESHOLD)` によるブリッジ処理が height 44px → 80px の膨張を引き起こし、戻り時に pull-to-refresh が再び引き出されているように見えていた。

## 修正内容

- ブリッジを廃止し、rAF 1段で `.returning` クラス付与 → `setRefreshing(false)` / `setPullY(0)` の順に変化させることで CSS `height 0.35s` トランジションを確実に起動
- `.pull-indicator.returning > *` を `opacity: 0` にして縮小中に内容（矢印・スピナー）が見えないようにした

## ref

- #54