### PR TITLE
下端safe-areaまでアプリシェルを伸ばす

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -48,7 +48,7 @@
 .app {
   --footer-height: 34px;
   --footer-safe-padding: clamp(8px, calc(env(safe-area-inset-bottom) - 18px), 16px);
-  height: var(--app-viewport-height);
+  height: var(--app-screen-height);
   display: flex;
   flex-direction: column;
   max-width: 480px;
@@ -360,6 +360,17 @@
   height: 10px;
   pointer-events: none;
   background: #ff1744;
+}
+
+.viewport-debug-shell-bar {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 9998;
+  height: 10px;
+  pointer-events: none;
+  background: #00e676;
 }
 
 .viewport-debug-panel {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -103,8 +103,10 @@ export default function App() {
       document.documentElement.style.setProperty('--app-viewport-height', `${height}px`)
       if (viewportDebug) {
         const appHeight = document.querySelector('.app')?.getBoundingClientRect().height
+        const styles = getComputedStyle(document.documentElement)
+        const screenHeight = styles.getPropertyValue('--app-screen-height').trim()
         setViewportDebugInfo(
-          `vv:${Math.round(height)} ih:${window.innerHeight} app:${Math.round(appHeight || 0)}`
+          `vv:${Math.round(height)} ih:${window.innerHeight} app:${Math.round(appHeight || 0)} shell:${screenHeight}`
         )
       }
     }
@@ -671,6 +673,7 @@ export default function App() {
 
       {viewportDebug && (
         <>
+          <div className="viewport-debug-shell-bar" />
           <div className="viewport-debug-fixed-bar" />
           <div className="viewport-debug-panel">{viewportDebugInfo}</div>
         </>

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -1,7 +1,7 @@
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  height: var(--app-viewport-height);
+  height: var(--app-screen-height);
   background: rgba(0, 0, 0, 0.45);
   z-index: 100;
   display: flex;
@@ -23,7 +23,7 @@
   width: 100%;
   max-width: 480px;
   animation: slideUp 0.22s cubic-bezier(0.34, 1.2, 0.64, 1);
-  max-height: calc(var(--app-viewport-height) - env(safe-area-inset-top));
+  max-height: calc(var(--app-screen-height) - env(safe-area-inset-top));
   overflow-y: auto;
   overscroll-behavior: contain;
   scroll-padding-bottom: calc(24px + env(safe-area-inset-bottom));

--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,9 @@ input, textarea, [contenteditable] {
 }
 
 :root {
+  --app-safe-area-bottom: env(safe-area-inset-bottom, 0px);
   --app-viewport-height: 100svh;
+  --app-screen-height: calc(var(--app-viewport-height) + var(--app-safe-area-bottom));
   --color-bg: #F0F2F5;
   --color-surface: #FFFFFF;
   --color-primary: #6366F1;
@@ -41,7 +43,7 @@ html, body {
   width: 100%;
   overflow-x: hidden;
   overscroll-behavior: none;
-  background: var(--color-surface);
+  background: var(--color-bg);
 }
 
 body {
@@ -67,5 +69,5 @@ input {
 
 #root {
   min-height: 100%;
-  background: var(--color-surface);
+  background: var(--color-bg);
 }


### PR DESCRIPTION
## 概要

Issue #21 の追加切り分けです。

フッタ下、ヘルプモーダル、統計画面で同じ下端余白が残るため、フッタ単体ではなく iOS standalone PWA の viewport / safe-area 計算の問題として扱います。

## 参考にした近い事例

- iOS standalone PWA で `100dvh` がホームインジケータ分を除いた高さになり、BottomNav下に白いギャップが出る事例
- WebKit Bugzilla で、root scrollable area にホームインジケータ相当の空白が残る報告

## 変更内容

- `--app-safe-area-bottom` を追加
- `--app-screen-height = visualViewport height + safe-area-inset-bottom` を追加
- `.app` の高さを `--app-screen-height` に変更
- `.modal-backdrop` と `.modal-sheet` の高さ計算も `--app-screen-height` ベースに変更
- `html/body/#root` の背景をアプリ背景色に合わせ、root側の露出も目立ちにくくする
- debug時に fixed下端の赤バーに加え、アプリシェル下端の緑バーを表示

## 確認

- `npm run build` 成功

Refs #21