### PR TITLE
フッタ下の白い面を最小化する

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -47,7 +47,7 @@
 
 .app {
   --footer-height: 34px;
-  --footer-safe-padding: clamp(8px, calc(env(safe-area-inset-bottom) - 18px), 16px);
+  --footer-safe-padding: 0px;
   height: var(--app-screen-height);
   display: flex;
   flex-direction: column;
@@ -259,9 +259,8 @@
   margin: 0 auto;
   width: 100%;
   max-width: 480px;
-  background: var(--color-surface);
+  background: transparent;
   border-top: 2px solid var(--color-primary);
-  box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
   padding-bottom: var(--footer-safe-padding);
   z-index: 20;
 }
@@ -271,6 +270,8 @@
   align-items: center;
   justify-content: space-around;
   height: var(--footer-height);
+  background: var(--color-surface);
+  box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
 }
 
 .undo-toast {


### PR DESCRIPTION
## 概要

Issue #21 の追加切り分けです。

`?debugViewport=1` の実機結果で `vv:695 ih:695 app:695 shell:calc(695px + 0px)` と出ており、今回の表示では `safe-area-inset-bottom` が 0px でした。つまり safe-area を足す修正は効く材料がなく、通常画面で見えている白い下端は `.app-footer` 自体の白背景/高さとして見えている可能性があります。

## 変更内容

- `--footer-safe-padding` を一旦 `0px` に固定
- `.app-footer` 本体の背景を透明化
- 白背景と影を `.app-footer-inner` の 34px 高さ部分だけへ移動

## 狙い

「統計」下に見える白い面がフッタ自身か、別レイヤー/ブラウザ側かを切り分けます。

## 確認

- `npm run build` 成功

Refs #21