### PR TITLE
SafariとPWAでフッタ位置を分ける

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -46,8 +46,9 @@
 }
 
 .app {
-  --footer-height: 34px;
+  --footer-height: 52px;
   --footer-safe-padding: 0px;
+  --footer-browser-shift: 14px;
   height: var(--app-screen-height);
   display: flex;
   flex-direction: column;
@@ -117,7 +118,7 @@
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding: 16px 16px;
-  padding-bottom: 16px;
+  padding-bottom: calc(var(--footer-height) + 16px);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -255,14 +256,26 @@
 
 /* Footer */
 .app-footer {
-  flex: 0 0 auto;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
   margin: 0 auto;
   width: 100%;
   max-width: 480px;
-  background: transparent;
+  background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
+  box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
   padding-bottom: var(--footer-safe-padding);
   z-index: 20;
+}
+
+.app.browser .app-footer {
+  transform: translateY(var(--footer-browser-shift));
+}
+
+.app.standalone .app-footer {
+  transform: none;
 }
 
 .app-footer-inner {
@@ -270,8 +283,6 @@
   align-items: center;
   justify-content: space-around;
   height: var(--footer-height);
-  background: var(--color-surface);
-  box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
 }
 
 .undo-toast {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,6 +62,9 @@ function loadTheme() {
 
 export default function App() {
   const viewportDebug = new URLSearchParams(window.location.search).has('debugViewport')
+  const isStandalone =
+    window.matchMedia('(display-mode: standalone)').matches ||
+    window.navigator.standalone === true
   const [habits, setHabits] = useState(_initial.habits)
   const [records, setRecords] = useState(_initial.records)
   const [themeId, setThemeId] = useState(() => { const t = loadTheme(); applyTheme(t); return t.id })
@@ -375,7 +378,7 @@ export default function App() {
 
   return (
     <div
-      className={`app${scrolled ? ' scrolled' : ''}`}
+      className={`app ${isStandalone ? 'standalone' : 'browser'}${scrolled ? ' scrolled' : ''}`}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}


### PR DESCRIPTION
## 概要

Issue #21 の追加修正です。

実機確認で、Safari表示とホーム画面追加後のPWA表示では下部UIの条件が違うことが分かりました。

- Safari: 下部検索欄/ツールバーの影響で、フッタ位置を少し調整する必要がある
- PWA: 下部検索欄がないため、フッタは下端配置でよい
- これまで検索欄を一律に考慮していたため、PWA側では下に余白が出ていた可能性がある
- フッタ自体も低すぎたため高さを増やす

## 変更内容

- standalone判定を追加
  - `display-mode: standalone`
  - `window.navigator.standalone`
- `.app.browser` / `.app.standalone` を付与
- フッタを `position: fixed` に戻し、初期表示で見えない問題を避ける
- PWAは `bottom: 0`
- Safariは `translateY(14px)` で少し下に寄せる
- フッタ高さを `34px` から `52px` に変更
- main下paddingをフッタ高さぶん確保

## 確認

- `npm run build` 成功

Refs #21