### PR TITLE
フッタ下の余白を少し増やす

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -47,8 +47,8 @@
 
 .app {
   --footer-height: 52px;
-  --footer-safe-padding: 0px;
-  --footer-browser-shift: 14px;
+  --footer-safe-padding: 6px;
+  --footer-browser-shift: 10px;
   height: var(--app-screen-height);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 概要

Issue #21 のフッタ位置微調整です。

#69 の状態は概ね良くなりましたが、実機確認でフッタ下の余白が少し足りなかったため、フッタ下側の余白を小さく追加します。

## 変更内容

- `--footer-safe-padding` を `0px` から `6px` に変更
- Safari側の下方向シフトを `14px` から `10px` に調整

## 確認

- `npm run build` 成功

Refs #21