### PR TITLE
iPhoneのフッタ下余白を少し増やす

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -58,6 +58,13 @@
   overflow: hidden;
 }
 
+@supports (-webkit-touch-callout: none) {
+  .app {
+    --footer-safe-padding: 12px;
+    --footer-browser-shift: 8px;
+  }
+}
+
 .app-header {
   display: flex;
   align-items: center;
@@ -118,7 +125,7 @@
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding: 16px 16px;
-  padding-bottom: calc(var(--footer-height) + 16px);
+  padding-bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
   display: flex;
   flex-direction: column;
   gap: 16px;


### PR DESCRIPTION
## 概要

Issue #21 のフッタ下余白の微調整です。

PCなどでは現在の見た目がちょうどよいため、デスクトップの余白は維持しつつ、iPhone系だけ画面下の丸みを考慮して少し余白を増やします。

## 変更内容

- デフォルト値は維持
  - `--footer-safe-padding: 6px`
  - `--footer-browser-shift: 10px`
- iOS系だけ `@supports (-webkit-touch-callout: none)` で上書き
  - `--footer-safe-padding: 12px`
  - `--footer-browser-shift: 8px`
- `.app-main` の下paddingにも `--footer-safe-padding` を反映

## 確認

- `npm run build` 成功

Refs #21