### PR TITLE
viewportのズーム制限を解除する

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#6366F1" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />


### PR DESCRIPTION
## 変更内容

- `maximum-scale=1.0` と `user-scalable=no` を viewport から削除し、ピンチズームを許可

## 理由

アクセシビリティ上の問題（ズーム不可）および issue #56 の修正方針に対応。

close #56