### PR TITLE
アクセシビリティ改善: aria-pressed・カラー名・フォーカス管理

### DIFF
--- a/src/components/AddHabitModal.jsx
+++ b/src/components/AddHabitModal.jsx
@@ -3,6 +3,17 @@ import Modal from './Modal'
 import { HABIT_COLORS } from '../utils/date'
 import './AddHabitModal.css'
 
+const COLOR_NAMES = {
+  '#FF6B6B': 'レッド',
+  '#FF9F43': 'オレンジ',
+  '#FECA57': 'イエロー',
+  '#48DBB4': 'グリーン',
+  '#54A0FF': 'ブルー',
+  '#A29BFE': 'ラベンダー',
+  '#FD79A8': 'ピンク',
+  '#6C5CE7': 'パープル',
+}
+
 export default function AddHabitModal({ onSave, onClose, initialHabit = null }) {
   const isEdit = !!initialHabit
   const [name, setName] = useState(initialHabit?.name ?? '')
@@ -41,7 +52,8 @@ export default function AddHabitModal({ onSave, onClose, initialHabit = null }) 
                 className={`color-swatch ${color === c ? 'selected' : ''}`}
                 style={{ backgroundColor: c }}
                 onClick={() => setColor(c)}
-                aria-label={c}
+                aria-label={`${COLOR_NAMES[c] || c}${color === c ? '（選択中）' : ''}`}
+                aria-pressed={color === c}
               />
             ))}
           </div>

--- a/src/components/DayDetailModal.jsx
+++ b/src/components/DayDetailModal.jsx
@@ -52,6 +52,8 @@ export default function DayDetailModal({
                   style={{ '--color': habit.color }}
                   onClick={() => isEditable && onToggle(habit.id)}
                   disabled={!isEditable}
+                  aria-pressed={done}
+                  aria-label={`${habit.name}${done ? '（達成済み）' : '（未達成）'}`}
                 >
                   <span
                     className="day-habit-dot"

--- a/src/components/LongPressModal.jsx
+++ b/src/components/LongPressModal.jsx
@@ -27,6 +27,8 @@ export default function LongPressModal({
               style={{ '--color': habit.color }}
               onClick={() => onSelect(dateStr)}
               disabled={unavailable}
+              aria-pressed={completed}
+              aria-label={`${label}${unavailable ? '（対象外）' : completed ? '（達成済み）' : '（未記録）'}`}
             >
               <div className="lp-day-info">
                 <span className="lp-day-label">{label}</span>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useRef, useEffect } from 'react'
 import './Modal.css'
 
 const CLOSE_THRESHOLD = 80
@@ -6,6 +6,13 @@ const CLOSE_THRESHOLD = 80
 export default function Modal({ onClose, children, title }) {
   const sheetRef = useRef(null)
   const startYRef = useRef(0)
+
+  useEffect(() => {
+    const firstFocusable = sheetRef.current?.querySelector(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    )
+    ;(firstFocusable ?? sheetRef.current)?.focus()
+  }, [])
   const dragYRef = useRef(0)
   const draggingRef = useRef(false)
 
@@ -55,6 +62,7 @@ export default function Modal({ onClose, children, title }) {
         role="dialog"
         aria-modal="true"
         aria-label={title}
+        tabIndex="-1"
         onClick={(e) => e.stopPropagation()}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -29,6 +29,7 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
             className={`theme-swatch${currentThemeId === theme.id ? ' selected' : ''}`}
             onClick={() => onSelectTheme(theme)}
             aria-label={`${theme.label}${currentThemeId === theme.id ? '（選択中）' : ''}`}
+            aria-pressed={currentThemeId === theme.id}
           >
             <div className="swatch-preview">
               <span className="swatch-preview-btn" style={{ background: theme.primary }}>習慣</span>


### PR DESCRIPTION
## 変更内容

- **DayDetailModal / LongPressModal**: 達成トグルボタンに `aria-pressed` と状態を含む `aria-label` を追加
- **SettingsModal**: テーマ選択ボタンに `aria-pressed` を追加（`aria-label` は実装済みだった）
- **AddHabitModal**: カラー見本の `aria-label` を hex コードから日本語色名に変更（レッド・ブルー等）、`aria-pressed` を追加
- **Modal**: モーダル表示時に最初のインタラクティブ要素へ自動フォーカス移動（スクリーンリーダー・キーボード操作改善）

close #14