### PR TITLE
iOS Safariにホーム画面追加の導線を追加

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ import StatsModal from './components/StatsModal'
 import SettingsModal, { THEMES, applyTheme } from './components/SettingsModal'
 import Toast from './components/Toast'
 import ArchivedHabitItem from './components/ArchivedHabitItem'
+import AddToHomePrompt from './components/AddToHomePrompt'
 import { getToday, getYesterday } from './utils/date'
 import { calcCurrentStreak } from './utils/stats'
 import { validateImportData } from './utils/validation'
@@ -383,6 +384,7 @@ export default function App() {
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
     >
+      <AddToHomePrompt />
       <header className="app-header">
         <h1 className="app-title">習慣トラッカー</h1>
         <div className="header-actions">

--- a/src/components/AddToHomePrompt.css
+++ b/src/components/AddToHomePrompt.css
@@ -1,0 +1,39 @@
+.add-to-home-prompt {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px 8px 14px;
+  background: var(--color-primary-light);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-primary) 20%, transparent);
+  font-size: 0.78rem;
+  color: var(--color-primary);
+  flex-wrap: wrap;
+}
+
+.add-to-home-text {
+  flex: 1;
+  min-width: 0;
+  font-weight: 500;
+}
+
+.add-to-home-hint {
+  font-size: 0.72rem;
+  opacity: 0.75;
+  white-space: nowrap;
+}
+
+.add-to-home-dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  color: var(--color-primary);
+  opacity: 0.6;
+  line-height: 0;
+  margin-left: auto;
+}
+
+.add-to-home-dismiss:active {
+  opacity: 1;
+}

--- a/src/components/AddToHomePrompt.jsx
+++ b/src/components/AddToHomePrompt.jsx
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+import './AddToHomePrompt.css'
+
+const DISMISSED_KEY = 'add-to-home-dismissed'
+
+function shouldShow() {
+  // navigator.standalone は iOS Safari のみ存在する
+  if (!('standalone' in window.navigator)) return false
+  if (window.navigator.standalone) return false
+  if (window.matchMedia('(display-mode: standalone)').matches) return false
+  try { return !localStorage.getItem(DISMISSED_KEY) } catch { return false }
+}
+
+export default function AddToHomePrompt() {
+  const [visible, setVisible] = useState(shouldShow)
+
+  if (!visible) return null
+
+  const handleDismiss = () => {
+    try { localStorage.setItem(DISMISSED_KEY, '1') } catch {}
+    setVisible(false)
+  }
+
+  return (
+    <div className="add-to-home-prompt" role="banner">
+      <span className="add-to-home-text">
+        ホーム画面に追加するとアプリとして快適に使えます
+      </span>
+      <span className="add-to-home-hint">「共有」→「ホーム画面に追加」</span>
+      <button className="add-to-home-dismiss" onClick={handleDismiss} aria-label="閉じる">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+          <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## 変更内容

iOS Safari（非standalone）のみ、ヘッダー直上に控えめなバナーを表示します。

**表示条件**
- iOS Safari で開いている（`navigator.standalone` が存在する）
- PWA/standalone モードではない
- 過去に「閉じる」を押していない（localStorage で記憶）

**バナー内容**
- 「ホーム画面に追加するとアプリとして快適に使えます」
- 「共有 → ホーム画面に追加」のヒント
- ✕ ボタンで閉じる（以降は表示しない）

**変更なし**
- Safari での閲覧はブロックしない
- デスクトップ/Android/PWA モードでは何も表示しない

close #71