### PR TITLE
iOSのフッター下余白を調整する

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -60,7 +60,7 @@
 
 @supports (-webkit-touch-callout: none) {
   .app {
-    --footer-safe-padding: 12px;
+    --footer-safe-padding: 20px;
     --footer-browser-shift: 8px;
   }
 }


### PR DESCRIPTION
## 概要

- iOS / Safari 向けのフッター下余白を 12px から 20px に増やしました。
- ホーム画面追加後やアプリスイッチャー表示時に、フッターの表示が下端に寄りすぎないようにします。

## 確認

- npm run build が成功することを確認しました。
- npm run preview で表示を確認し、確認後に preview サーバーを停止しました。