### PR TITLE
ローカル作業用ファイルをGit管理対象外にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,11 @@ dist/
 .env.*
 
 .claude/
+.codex/
+.cursor/
+.windsurf/
 
 CLAUDE.md
+CODEX.md
+AGENTS.md
+GEMINI.md


### PR DESCRIPTION
## 概要

- ローカル作業用の AI / エディタ支援ファイルを .gitignore に追加しました。
- 指示ファイルや作業用設定の中身が誤って公開リポジトリに入らないようにします。

## 対象

- .claude/
- .codex/
- .cursor/
- .windsurf/
- CLAUDE.md
- CODEX.md
- AGENTS.md
- GEMINI.md

## 確認

- git check-ignore -v で対象ファイルが無視されることを確認しました。
- npm run build が成功することを確認しました。