### PR TITLE
初回起動時のウェルカムカードを追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -215,6 +215,29 @@
   font-size: 0.95rem;
 }
 
+.welcome-card {
+  width: 100%;
+  background: var(--color-primary-light);
+  border-radius: var(--radius-sm);
+  padding: 16px 18px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.welcome-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.welcome-body {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
 .add-first-btn {
   background: var(--color-primary);
   color: #fff;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,7 @@ import './App.css'
 const STORAGE_KEY = 'habit-tracker-v1'
 const THEME_STORAGE_KEY = 'habit-tracker-theme'
 const LAST_BACKUP_KEY = 'habit-tracker-last-backup'
+const ONBOARDING_KEY = 'habit-tracker-onboarding-done'
 
 function loadData() {
   try {
@@ -66,6 +67,14 @@ export default function App() {
   const isStandalone =
     window.matchMedia('(display-mode: standalone)').matches ||
     window.navigator.standalone === true
+  const [showWelcome, setShowWelcome] = useState(() => {
+    try { return !localStorage.getItem(ONBOARDING_KEY) } catch { return false }
+  })
+  const dismissWelcome = useCallback(() => {
+    try { localStorage.setItem(ONBOARDING_KEY, '1') } catch {}
+    setShowWelcome(false)
+  }, [])
+
   const [habits, setHabits] = useState(_initial.habits)
   const [records, setRecords] = useState(_initial.records)
   const [themeId, setThemeId] = useState(() => { const t = loadTheme(); applyTheme(t); return t.id })
@@ -187,7 +196,8 @@ export default function App() {
     const id = `h_${Date.now()}`
     setHabits(prev => [...prev, { id, name, color, createdAt: today }])
     setModal(null)
-  }, [today])
+    dismissWelcome()
+  }, [today, dismissWelcome])
 
   const updateHabit = useCallback(({ name, color }) => {
     setHabits(prev =>
@@ -447,13 +457,24 @@ export default function App() {
 
           {habits.length === 0 ? (
             <div className="empty-state">
-              <p className="empty-text">習慣を追加してみよう</p>
+              {showWelcome ? (
+                <div className="welcome-card">
+                  <p className="welcome-title">ようこそ！</p>
+                  <p className="welcome-body">まず最初の習慣を1つ追加してみましょう。毎日の記録がここに並びます。</p>
+                </div>
+              ) : (
+                <p className="empty-text">習慣を追加してみよう</p>
+              )}
               <button className="add-first-btn" onClick={() => setModal({ type: 'add' })}>
                 + 最初の習慣を追加
               </button>
-              <button className="help-link-btn" onClick={() => setModal({ type: 'help' })}>
-                使い方を見る
-              </button>
+              {showWelcome ? (
+                <button className="help-link-btn" onClick={dismissWelcome}>スキップ</button>
+              ) : (
+                <button className="help-link-btn" onClick={() => setModal({ type: 'help' })}>
+                  使い方を見る
+                </button>
+              )}
             </div>
           ) : editMode ? (
             <>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -8,10 +8,7 @@ export default function Modal({ onClose, children, title }) {
   const startYRef = useRef(0)
 
   useEffect(() => {
-    const firstFocusable = sheetRef.current?.querySelector(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    )
-    ;(firstFocusable ?? sheetRef.current)?.focus()
+    sheetRef.current?.focus()
   }, [])
   const dragYRef = useRef(0)
   const draggingRef = useRef(false)


### PR DESCRIPTION
## 変更内容

習慣が0件かつ初回訪問時に、空状態エリアにウェルカムカードを表示します。

**表示条件**
- `habits.length === 0`（習慣未登録）
- `localStorage` に `habit-tracker-onboarding-done` がない（初回のみ）

**非表示になる条件**
- 「スキップ」ボタンをタップ
- 最初の習慣を追加したとき（auto-dismiss）

**変更なし**
- 2回目以降の訪問時は通常の「習慣を追加してみよう」に戻る
- 既存ユーザーには表示されない

close #12