### PR TITLE
モーダルを常に上部から表示されるよう修正

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useRef, useEffect } from 'react'
 import './Modal.css'
 
 const CLOSE_THRESHOLD = 80
@@ -7,6 +7,10 @@ export default function Modal({ onClose, children, title }) {
   const sheetRef = useRef(null)
   const startYRef = useRef(0)
   const dragYRef = useRef(0)
+
+  useEffect(() => {
+    sheetRef.current?.focus()
+  }, [])
   const draggingRef = useRef(false)
 
   const handleTouchStart = (e) => {
@@ -55,6 +59,7 @@ export default function Modal({ onClose, children, title }) {
         role="dialog"
         aria-modal="true"
         aria-label={title}
+        tabIndex="-1"
         onClick={(e) => e.stopPropagation()}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}


### PR DESCRIPTION
モーダル表示時のフォーカスをシートコンテナ自体に当てるよう変更。HelpModal等で一番下の「閉じる」ボタンにフォーカスが移り最下部にスクロールされる問題を修正。