### PR TITLE
pull-to-refresh更新中UIの余白・グラデーション・トランジションを改善

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,23 +4,37 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
   background: var(--color-primary);
   color: rgba(255, 255, 255, 0.9);
   height: 0;
 }
 
 .pull-indicator.refreshing {
-  height: 44px;
+  height: 60px;
   opacity: 1;
   transition: height 0.2s ease, opacity 0.2s ease;
 }
 
+/* ヘッダーとの境目を柔らかくする底面グラデーション */
+.pull-indicator.refreshing::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 12px;
+  background: linear-gradient(to bottom, transparent, rgba(67, 56, 202, 0.25));
+  pointer-events: none;
+}
+
 .pull-indicator.returning {
-  transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .pull-indicator.returning > * {
   opacity: 0;
+  transition: opacity 0.15s ease;
 }
 
 .pull-arrow {


### PR DESCRIPTION
## Summary

close #83

- `refreshing`時の高さを44px→60pxに拡大し、上下余白を確保
- `::after`疑似要素でヘッダー下端へ底面グラデーションを追加（紫の境界が柔らかくつながる）
- `returning`時のheightトランジションを0.35s→0.4sに延長（より自然な収縮）
- `returning`時のchildren fade-outに明示的な`transition: opacity 0.15s`を追加

## Test plan

- [ ] 下に引っ張って更新を発動し、更新中インジケーターの上下余白が広くなっていることを確認
- [ ] 更新完了後、インジケーターがヘッダーへ自然に吸い込まれるように収縮することを確認
- [ ] 通常時の背景色・ヘッダー表示が崩れていないことを確認
- [ ] `npm run build` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)