### PR TITLE
カレンダーの年月タイトルから任意の月に移動できる月ピッカーを追加

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import SettingsModal, { THEMES, applyTheme } from './components/SettingsModal'
 import Toast from './components/Toast'
 import ArchivedHabitItem from './components/ArchivedHabitItem'
 import AddToHomePrompt from './components/AddToHomePrompt'
+import MonthPickerModal from './components/MonthPickerModal'
 import { getToday, getYesterday } from './utils/date'
 import { calcCurrentStreak } from './utils/stats'
 import { validateImportData } from './utils/validation'
@@ -549,9 +550,18 @@ export default function App() {
             records={records}
             today={today}
             onDayClick={(dateStr) => setModal({ type: 'day', dateStr })}
+            onMonthTitleClick={() => setModal({ type: 'monthPicker' })}
           />
         </section>
       </main>
+
+      {modal?.type === 'monthPicker' && (
+        <MonthPickerModal
+          currentDate={calendarDate}
+          onSelect={(year, month) => setCalendarDate(new Date(year, month, 1))}
+          onClose={closeModal}
+        />
+      )}
 
       {modal?.type === 'add' && (
         <AddHabitModal onSave={addHabit} onClose={closeModal} />

--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -38,6 +38,27 @@
   color: var(--color-text);
 }
 
+.cal-month-title-btn {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-text);
+  padding: 4px 6px;
+  border-radius: 8px;
+  transition: background 0.15s;
+}
+
+.cal-month-title-btn:active {
+  background: var(--color-primary-light);
+}
+
+.cal-month-title-icon {
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
 .today-jump-btn {
   font-size: 0.75rem;
   font-weight: 600;

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -6,7 +6,7 @@ function toDateStr(y, m, d) {
   return `${y}-${String(m + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`
 }
 
-export default function Calendar({ date, onDateChange, habits, records, today, onDayClick }) {
+export default function Calendar({ date, onDateChange, habits, records, today, onDayClick, onMonthTitleClick }) {
   const year = date.getFullYear()
   const month = date.getMonth()
 
@@ -49,7 +49,16 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
       <div className="calendar-nav">
         <button className="cal-nav-btn" onClick={goToPrev} aria-label="前の月">‹</button>
         <div className="cal-month-label">
-          <span>{year}年{month + 1}月</span>
+          <button
+            className="cal-month-title-btn"
+            onClick={onMonthTitleClick}
+            aria-label={`${year}年${month + 1}月 年月を選ぶ`}
+          >
+            {year}年{month + 1}月
+            <svg className="cal-month-title-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
           {!isCurrentMonth && (
             <button className="today-jump-btn" onClick={goToToday} aria-label="今月へ戻る">
               今月へ

--- a/src/components/MonthPickerModal.css
+++ b/src/components/MonthPickerModal.css
@@ -1,0 +1,75 @@
+.month-picker {
+  padding: 8px 0 16px;
+}
+
+.month-picker-year-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  margin-bottom: 20px;
+}
+
+.month-picker-year-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+  transition: opacity 0.15s;
+}
+
+.month-picker-year-btn:disabled {
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+.month-picker-year-btn:active {
+  opacity: 0.6;
+}
+
+.month-picker-year-label {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--color-text);
+  min-width: 80px;
+  text-align: center;
+}
+
+.month-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  padding: 0 4px;
+}
+
+.month-picker-cell {
+  padding: 14px 8px;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text);
+  background: var(--color-primary-light);
+  transition: opacity 0.12s, background 0.12s;
+  text-align: center;
+}
+
+.month-picker-cell:active {
+  opacity: 0.7;
+}
+
+.month-picker-cell.selected {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.month-picker-cell.today {
+  border: 2px solid var(--color-primary);
+  color: var(--color-primary);
+  background: #fff;
+}

--- a/src/components/MonthPickerModal.jsx
+++ b/src/components/MonthPickerModal.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import Modal from './Modal'
+import './MonthPickerModal.css'
+
+const MONTH_LABELS = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月']
+
+export default function MonthPickerModal({ currentDate, onSelect, onClose }) {
+  const [pickerYear, setPickerYear] = useState(currentDate.getFullYear())
+  const currentYear = currentDate.getFullYear()
+  const currentMonth = currentDate.getMonth()
+
+  const today = new Date()
+  const todayYear = today.getFullYear()
+  const todayMonth = today.getMonth()
+
+  // 選択可能な年の範囲: 今年を基準に±5年
+  const MIN_YEAR = todayYear - 5
+  const MAX_YEAR = todayYear + 1
+
+  return (
+    <Modal onClose={onClose} title="年月を選ぶ">
+      <div className="month-picker">
+        <div className="month-picker-year-nav">
+          <button
+            className="month-picker-year-btn"
+            onClick={() => setPickerYear(y => Math.max(MIN_YEAR, y - 1))}
+            disabled={pickerYear <= MIN_YEAR}
+            aria-label="前の年"
+          >
+            ‹
+          </button>
+          <span className="month-picker-year-label">{pickerYear}年</span>
+          <button
+            className="month-picker-year-btn"
+            onClick={() => setPickerYear(y => Math.min(MAX_YEAR, y + 1))}
+            disabled={pickerYear >= MAX_YEAR}
+            aria-label="次の年"
+          >
+            ›
+          </button>
+        </div>
+
+        <div className="month-picker-grid">
+          {MONTH_LABELS.map((label, m) => {
+            const isSelected = pickerYear === currentYear && m === currentMonth
+            const isToday = pickerYear === todayYear && m === todayMonth
+            return (
+              <button
+                key={m}
+                className={[
+                  'month-picker-cell',
+                  isSelected ? 'selected' : '',
+                  isToday && !isSelected ? 'today' : '',
+                ].filter(Boolean).join(' ')}
+                onClick={() => { onSelect(pickerYear, m); onClose() }}
+                aria-label={`${pickerYear}年${m + 1}月`}
+                aria-pressed={isSelected}
+              >
+                {label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </Modal>
+  )
+}


### PR DESCRIPTION
## Summary

close #80

- カレンダー上部の年月表示をタップすると年月選択ボトムシートが開く
- 年ナビゲーション（前の年/次の年）で年を切り替え、12ヶ月のグリッドから月を選択
- 月を選ぶと即座にカレンダーが移動してモーダルが閉じる
- 現在表示中の月をハイライト（紫背景）、今月に別スタイル（紫枠）を適用
- 前月/次月ボタン・今月へ戻るボタンの既存動作は維持

## Test plan

- [ ] 年月タイトルをタップして月ピッカーが開くことを確認
- [ ] 前の年/次の年で年が切り替わることを確認
- [ ] 月を選ぶとカレンダーが移動してモーダルが閉じることを確認
- [ ] backdropタップで閉じられることを確認
- [ ] 現在表示中の月がハイライトされることを確認
- [ ] 前月/次月ボタンの動作が変わっていないことを確認
- [ ] `npm run build` が通ることを確認
- [ ] モバイル幅で月ボタンが押しやすく表示が崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)