### PR TITLE
モーダルの表示アニメーションを滑らかに改善

### DIFF
--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -8,12 +8,12 @@
   align-items: flex-end;
   justify-content: center;
   overflow: hidden;
-  animation: fadeIn 0.18s ease;
+  animation: backdropIn 0.22s ease both;
 }
 
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+@keyframes backdropIn {
+  from { background: rgba(0, 0, 0, 0); }
+  to   { background: rgba(0, 0, 0, 0.45); }
 }
 
 .modal-sheet {
@@ -22,7 +22,7 @@
   padding: 12px 20px calc(24px + env(safe-area-inset-bottom));
   width: 100%;
   max-width: 480px;
-  animation: slideUp 0.22s cubic-bezier(0.34, 1.2, 0.64, 1);
+  animation: slideUp 0.24s cubic-bezier(0.2, 0.8, 0.2, 1) both;
   max-height: calc(var(--app-screen-height) - env(safe-area-inset-top));
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -31,7 +31,7 @@
 
 @keyframes slideUp {
   from { transform: translateY(100%); }
-  to { transform: translateY(0); }
+  to   { transform: translateY(0); }
 }
 
 .modal-handle {

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -6,16 +6,14 @@ const CLOSE_THRESHOLD = 80
 export default function Modal({ onClose, children, title }) {
   const sheetRef = useRef(null)
   const startYRef = useRef(0)
-
-  useEffect(() => {
-    sheetRef.current?.focus()
-  }, [])
   const dragYRef = useRef(0)
-
-  useEffect(() => {
-    sheetRef.current?.focus()
-  }, [])
   const draggingRef = useRef(false)
+
+  // アニメーション完了後にフォーカスを移動（重複effectを解消）
+  useEffect(() => {
+    const timer = setTimeout(() => sheetRef.current?.focus(), 220)
+    return () => clearTimeout(timer)
+  }, [])
 
   const handleTouchStart = (e) => {
     if (sheetRef.current.scrollTop > 0) return


### PR DESCRIPTION
## Summary

close #87

- `Modal.jsx`: 重複していた`useEffect`を1つに統合。`focus()`をアニメーション完了後（220ms後）に実行し競合を解消
- `Modal.css`: `slideUp`のeasingをバウンス系(`cubic-bezier(0.34, 1.2, 0.64, 1)`)→スムーズ(`cubic-bezier(0.2, 0.8, 0.2, 1)`)に変更
- `Modal.css`: backdropアニメーションをopacity単純fadeから`background-color`のfadeに変更し、背景が段階的に暗くなる自然な表示に

## Test plan

- [ ] 設定ボタンを押してシートが下からスムーズに表示されることを確認
- [ ] ヘルプボタンを押して同様に確認
- [ ] backdropが急に暗くならず自然にフェードすることを確認
- [ ] swipe-to-closeが引き続き動作することを確認
- [ ] backdropタップで閉じることを確認
- [ ] `npm run build` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)