### PR TITLE
終了済み習慣の集計・統計・インポート検証を修正

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -73,7 +73,11 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
           const dateStr = toDateStr(y, m, d)
           const isToday = dateStr === today
           const dayRecords = records[dateStr] || []
-          const activeHabits = habits.filter(h => !h.createdAt || dateStr >= h.createdAt)
+          const activeHabits = habits.filter(h => {
+            if (h.createdAt && dateStr < h.createdAt) return false
+            if (h.archivedAt && dateStr > h.archivedAt) return false
+            return true
+          })
           const completedHabits = activeHabits.filter(h => dayRecords.includes(h.id))
           const total = activeHabits.length
           const count = completedHabits.length

--- a/src/components/StatsModal.jsx
+++ b/src/components/StatsModal.jsx
@@ -13,7 +13,7 @@ export default function StatsModal({ habits, records, onClose }) {
         <div className="stats-list">
           {habits.map(habit => {
             const { current, longest, total } = calcStats(habit.id, records)
-            const { monthCount, rate30 } = calcPeriodStats(habit.id, records, today, habit.createdAt)
+            const { monthCount, rate30 } = calcPeriodStats(habit.id, records, today, habit.createdAt, habit.archivedAt)
             return (
               <div key={habit.id} className="stats-card">
                 <div className="stats-habit-name">

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -50,8 +50,10 @@ export function calcStats(habitId, records) {
   return { current, longest, total }
 }
 
-export function calcPeriodStats(habitId, records, today, createdAt) {
+export function calcPeriodStats(habitId, records, today, createdAt, archivedAt) {
   const todayDate = parseLocalDate(today)
+  // 終了済み習慣は archivedAt を集計の上限にする
+  const endDate = archivedAt ? new Date(Math.min(todayDate, parseLocalDate(archivedAt))) : todayDate
 
   function countRange(start, end) {
     let achieved = 0, total = 0
@@ -68,15 +70,15 @@ export function calcPeriodStats(habitId, records, today, createdAt) {
   const habitStart = createdAt ? parseLocalDate(createdAt) : null
 
   // 今月
-  const monthStart = new Date(todayDate.getFullYear(), todayDate.getMonth(), 1)
+  const monthStart = new Date(endDate.getFullYear(), endDate.getMonth(), 1)
   const effectiveMonthStart = habitStart && habitStart > monthStart ? habitStart : monthStart
-  const { achieved: monthCount } = countRange(effectiveMonthStart, todayDate)
+  const { achieved: monthCount } = countRange(effectiveMonthStart, endDate)
 
   // 直近30日
-  const thirtyAgo = new Date(todayDate)
+  const thirtyAgo = new Date(endDate)
   thirtyAgo.setDate(thirtyAgo.getDate() - 29)
   const effective30Start = habitStart && habitStart > thirtyAgo ? habitStart : thirtyAgo
-  const { achieved: r30, total: t30 } = countRange(effective30Start, todayDate)
+  const { achieved: r30, total: t30 } = countRange(effective30Start, endDate)
   const rate30 = t30 > 0 ? Math.round((r30 / t30) * 100) : null
 
   return { monthCount, rate30 }

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -24,6 +24,12 @@ export function validateImportData(data) {
     if (h.createdAt !== undefined && (typeof h.createdAt !== 'string' || !DATE_RE.test(h.createdAt) || !isValidDate(h.createdAt))) {
       return `habits[${i}] の createdAt「${h.createdAt}」が有効な日付ではありません。`
     }
+    if (h.archivedAt != null && (typeof h.archivedAt !== 'string' || !DATE_RE.test(h.archivedAt) || !isValidDate(h.archivedAt))) {
+      return `habits[${i}] の archivedAt「${h.archivedAt}」が有効な日付ではありません。`
+    }
+    if (h.createdAt && h.archivedAt && h.archivedAt < h.createdAt) {
+      return `habits[${i}] の archivedAt が createdAt より前の日付です。`
+    }
   }
   if (!data.records || typeof data.records !== 'object' || Array.isArray(data.records)) {
     return '「records」がオブジェクトではありません。'


### PR DESCRIPTION
## Summary

close #84

| 対象 | 修正内容 |
|------|---------|
| `Calendar.jsx` | `activeHabits`に`archivedAt`フィルタを追加。終了日より後の日はカレンダーの母数・ドットから除外 |
| `stats.js` | `calcPeriodStats`に`archivedAt`引数を追加。集計の終了日を`min(today, archivedAt)`にし、終了後の日付が母数に入らないよう修正 |
| `StatsModal.jsx` | `habit.archivedAt`を`calcPeriodStats`に渡すよう変更 |
| `validation.js` | `archivedAt`の形式・実在日付・`createdAt`との前後関係を検証。不正データをインポート時に拒否 |

## Test plan

- [ ] 習慣をアーカイブし、翌日以降のカレンダーで母数から除外されることを確認
- [ ] アーカイブ習慣の統計で「今月」「直近30日」が終了日以降を含まないことを確認
- [ ] DayDetailModalとCalendarの対象習慣が一致することを確認
- [ ] 不正な`archivedAt`を含むJSONをインポートするとエラーになることを確認
- [ ] 正常な`archivedAt`を含むJSONは正常にインポートできることを確認
- [ ] `npm run build` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)