### PR TITLE
ヘッダーのスクロール問題を修正

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -77,12 +77,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-shrink: 0;
   background: var(--color-primary);
   padding: 8px 16px;
   padding-top: calc(8px + env(safe-area-inset-top));
-  position: sticky;
-  top: 0;
-  z-index: 10;
   box-shadow: 0 2px 8px rgba(99, 102, 241, 0.3);
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -309,6 +309,8 @@ export default function App() {
   }, [modal])
 
   const handleTouchStart = useCallback((e) => {
+    // ヘッダー上のタッチはpull-to-refreshを起動しない
+    if (e.target.closest('.app-header')) return
     // スクロール戻り直後はpull-to-refreshを許可しない
     if ((mainRef.current?.scrollTop ?? 0) === 0 && !justScrolledToTop.current) {
       pullStartY.current = e.touches[0].clientY


### PR DESCRIPTION
## 変更内容

### `.app-header` の `position: sticky` を削除
- `.app` が固定高さ＋`overflow: hidden` の flex column のため sticky は不要かつ誤動作の原因
- `flex-shrink: 0` を明示してレイアウトの意図を明確化

### ヘッダー上のスワイプで pull-to-refresh が発動しないようガード
- `handleTouchStart` で `e.target.closest('.app-header')` を確認し、ヘッダー上のタッチを無視

closes #86