### PR TITLE
iPhoneの固定UI上スワイプ誤発火を抑止

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -82,6 +82,8 @@
   padding: 8px 16px;
   padding-top: calc(8px + env(safe-area-inset-top));
   box-shadow: 0 2px 8px rgba(99, 102, 241, 0.3);
+  /* iOSでヘッダー上のタッチからスクロールが発火しないようにする */
+  touch-action: none;
 }
 
 .app-title {
@@ -298,6 +300,7 @@
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
   padding-bottom: var(--footer-safe-padding);
   z-index: 20;
+  touch-action: none;
 }
 
 .app.browser .app-footer {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,6 +99,8 @@ export default function App() {
   const justScrolledToTop = useRef(false)
   const scrollStopTimer = useRef(null)
   const mainRef = useRef(null)
+  const headerRef = useRef(null)
+  const footerRef = useRef(null)
   const [activeTab, setActiveTab] = useState('habit')
   const PULL_THRESHOLD = 80
 
@@ -113,6 +115,21 @@ export default function App() {
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ habits, records }))
   }, [habits, records])
+
+  useEffect(() => {
+    const preventChromeScroll = (e) => {
+      e.preventDefault()
+    }
+    const chromeEls = [headerRef.current, footerRef.current].filter(Boolean)
+    chromeEls.forEach(el => {
+      el.addEventListener('touchmove', preventChromeScroll, { passive: false })
+    })
+    return () => {
+      chromeEls.forEach(el => {
+        el.removeEventListener('touchmove', preventChromeScroll)
+      })
+    }
+  }, [])
 
   useEffect(() => {
     const setViewportHeight = () => {
@@ -319,6 +336,17 @@ export default function App() {
     }
   }, [])
 
+  const handleChromeTouchStart = useCallback((e) => {
+    pullStartY.current = null
+    setPullY(0)
+    e.stopPropagation()
+  }, [])
+
+  const handleChromeTouchMove = useCallback((e) => {
+    e.preventDefault()
+    e.stopPropagation()
+  }, [])
+
   const handleTouchMove = useCallback((e) => {
     const currentY = e.touches[0].clientY
 
@@ -412,7 +440,12 @@ export default function App() {
       onTouchEnd={handleTouchEnd}
     >
       <AddToHomePrompt />
-      <header className="app-header">
+      <header
+        ref={headerRef}
+        className="app-header"
+        onTouchStart={handleChromeTouchStart}
+        onTouchMove={handleChromeTouchMove}
+      >
         <h1 className="app-title">習慣トラッカー</h1>
         <div className="header-actions">
           <button className="header-btn" onClick={() => setModal({ type: 'help' })}>
@@ -734,7 +767,12 @@ export default function App() {
       )}
       {toast && <Toast message={toast} onDismiss={() => setToast(null)} />}
 
-      <footer className="app-footer">
+      <footer
+        ref={footerRef}
+        className="app-footer"
+        onTouchStart={handleChromeTouchStart}
+        onTouchMove={handleChromeTouchMove}
+      >
         <div className="app-footer-inner">
           {/* 記録: カレンダーへスクロール */}
           <button className={`footer-btn${activeTab === 'record' ? ' active' : ''}`} onClick={() => setActiveTab('record')}>


### PR DESCRIPTION
## 概要

- ヘッダー/フッターに touch-action: none を追加
- 固定UI上の touchmove を passive: false のネイティブリスナーで抑止
- 固定UI上のタッチ開始時に pull-to-refresh の状態をリセット

## 背景

iPhoneでヘッダー上から上スワイプすると、.app-main のスクロールが発火することがありました。iOS Safari系ではCSSの touch-action だけでは固定UIからのジェスチャー流入を止めきれない場合があるため、JS側でも明示的にスクロール開始をキャンセルしています。

## 確認

- npm run build 成功
- iPhone相当viewportでプレビュー表示を確認
- ヘッダー/フッターの touchmove が defaultPrevented: true になることを確認
- プレビューサーバー停止済み