### PR TITLE
更新中のタブ遷移を抑止

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -53,6 +53,20 @@
   animation: pull-check-in 0.2s cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .pull-indicator.refreshing,
+  .pull-indicator.returning,
+  .pull-indicator.returning > *,
+  .pull-arrow {
+    transition: none;
+  }
+
+  .pull-spin,
+  .pull-check {
+    animation: none;
+  }
+}
+
 .app {
   --footer-height: 60px;
   --footer-safe-padding: 10px;
@@ -381,6 +395,11 @@
 
 .footer-btn.active {
   color: var(--color-primary);
+}
+
+.footer-btn:disabled {
+  cursor: default;
+  opacity: 0.55;
 }
 
 .footer-btn:active {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,6 +84,7 @@ export default function App() {
     pullY, pullReturning, refreshing, refreshComplete, scrolled,
     handleTouchStart, handleTouchMove, handleTouchEnd,
   } = usePullToRefresh({ mainRef, onRefresh })
+  const tabsLocked = refreshing || pullReturning
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -134,6 +135,11 @@ export default function App() {
   }, [viewportDebug])
 
   const closeModal = useCallback(() => setModal(null), [])
+
+  const handleTabSelect = useCallback((tab) => {
+    if (tabsLocked) return
+    setActiveTab(tab)
+  }, [tabsLocked])
 
   const toggleHabit = useCallback((habitId, dateStr) => {
     const wasOn = (records[dateStr] || []).includes(habitId)
@@ -623,20 +629,35 @@ export default function App() {
         onTouchMove={handleChromeTouchMove}
       >
         <div className="app-footer-inner">
-          <button className={`footer-btn${activeTab === 'record' ? ' active' : ''}`} onClick={() => setActiveTab('record')}>
+          <button
+            className={`footer-btn${activeTab === 'record' ? ' active' : ''}`}
+            onClick={() => handleTabSelect('record')}
+            disabled={tabsLocked}
+            aria-disabled={tabsLocked}
+          >
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
               <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
               <line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
             </svg>
             <span>記録</span>
           </button>
-          <button className={`footer-btn main${activeTab === 'habit' ? ' active' : ''}`} onClick={() => setActiveTab('habit')}>
+          <button
+            className={`footer-btn main${activeTab === 'habit' ? ' active' : ''}`}
+            onClick={() => handleTabSelect('habit')}
+            disabled={tabsLocked}
+            aria-disabled={tabsLocked}
+          >
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
               <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /><polyline points="9 22 9 12 15 12 15 22" />
             </svg>
             <span>習慣</span>
           </button>
-          <button className={`footer-btn${activeTab === 'stats' ? ' active' : ''}`} onClick={() => setActiveTab('stats')}>
+          <button
+            className={`footer-btn${activeTab === 'stats' ? ' active' : ''}`}
+            onClick={() => handleTabSelect('stats')}
+            disabled={tabsLocked}
+            aria-disabled={tabsLocked}
+          >
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
               <line x1="18" y1="20" x2="18" y2="10" /><line x1="12" y1="20" x2="12" y2="4" /><line x1="6" y1="20" x2="6" y2="14" />
             </svg>


### PR DESCRIPTION
## 概要
- pull-to-refresh の更新中と戻り演出中はフッタータブを disabled にして画面遷移を抑止
- prefers-reduced-motion: reduce で更新スピナーと戻り演出のアニメーションを無効化

## 確認
- npm run build
- Vite preview + Playwright/Edge でモバイル幅を確認
- 更新中にタブをクリックしても active タブが変わらないことを確認
- reduced motion で pull-to-refresh の animation/transition が無効化されることを確認

Closes #100