### PR TITLE
今月へ操作を年月選択に移動

### DIFF
--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -59,20 +59,6 @@
   flex-shrink: 0;
 }
 
-.today-jump-btn {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--color-primary);
-  background: var(--color-primary-light);
-  padding: 2px 8px;
-  border-radius: 20px;
-  transition: opacity 0.15s;
-}
-
-.today-jump-btn:active {
-  opacity: 0.6;
-}
-
 .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -39,10 +39,6 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
 
   const goToPrev = () => onDateChange(new Date(year, month - 1, 1))
   const goToNext = () => onDateChange(new Date(year, month + 1, 1))
-  const goToToday = () => onDateChange(new Date())
-
-  const pad = (n) => String(n).padStart(2, '0')
-  const isCurrentMonth = today.startsWith(`${year}-${pad(month + 1)}`)
 
   return (
     <div className="calendar">
@@ -59,11 +55,6 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
               <polyline points="6 9 12 15 18 9" />
             </svg>
           </button>
-          {!isCurrentMonth && (
-            <button className="today-jump-btn" onClick={goToToday} aria-label="今月へ戻る">
-              今月へ
-            </button>
-          )}
         </div>
         <button className="cal-nav-btn" onClick={goToNext} aria-label="次の月">›</button>
       </div>

--- a/src/components/MonthPickerModal.css
+++ b/src/components/MonthPickerModal.css
@@ -41,6 +41,22 @@
   text-align: center;
 }
 
+.month-picker-today-btn {
+  display: block;
+  margin: -8px auto 18px;
+  padding: 7px 16px;
+  border-radius: 8px;
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+  font-size: 0.85rem;
+  font-weight: 700;
+  transition: opacity 0.12s;
+}
+
+.month-picker-today-btn:active {
+  opacity: 0.7;
+}
+
 .month-picker-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/src/components/MonthPickerModal.jsx
+++ b/src/components/MonthPickerModal.jsx
@@ -40,6 +40,13 @@ export default function MonthPickerModal({ currentDate, onSelect, onClose }) {
           </button>
         </div>
 
+        <button
+          className="month-picker-today-btn"
+          onClick={() => { onSelect(todayYear, todayMonth); onClose() }}
+        >
+          今月へ
+        </button>
+
         <div className="month-picker-grid">
           {MONTH_LABELS.map((label, m) => {
             const isSelected = pickerYear === currentYear && m === currentMonth


### PR DESCRIPTION
## 概要
- カレンダー画面上の「今月へ」ボタンを削除
- 年月選択モーダル内に「今月へ」ボタンを追加
- 押下時に現在年月へ戻り、モーダルを閉じるように変更

## 確認
- npm run build
- Vite preview + Playwright/Edge でモバイル幅を確認
- カレンダー上に「今月へ」が表示されないことを確認
- 前月へ移動後、年月選択モーダル内の「今月へ」で 2026年5月 に戻ることを確認

Closes #107