### PR TITLE
ヘッダーに画面タイトルを表示

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -87,10 +87,14 @@
 }
 
 .app-title {
+  min-width: 0;
   color: #fff;
   font-size: 1.25rem;
   font-weight: 700;
   letter-spacing: 0.04em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .header-actions {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,6 +73,15 @@ export default function App() {
 
   const today = getToday()
   const yesterday = getYesterday()
+  const screenTitle = modal?.type === 'settings'
+    ? '設定'
+    : modal?.type === 'help'
+      ? 'ヘルプ'
+      : activeTab === 'record'
+        ? 'カレンダー'
+        : activeTab === 'stats'
+          ? '分析'
+          : '習慣'
 
   const onRefresh = useCallback(() => {
     const fresh = loadData()
@@ -295,7 +304,7 @@ export default function App() {
         onTouchStart={handleChromeTouchStart}
         onTouchMove={handleChromeTouchMove}
       >
-        <h1 className="app-title">習慣トラッカー</h1>
+        <h1 className="app-title">{screenTitle}</h1>
         <div className="header-actions">
           <button className="header-btn" onClick={() => setModal({ type: 'help' })}>
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">


### PR DESCRIPTION
## 概要
- 左上の固定表示「習慣トラッカー」を現在画面のタイトルに変更
- 習慣 / カレンダー / 分析 / ヘルプ / 設定 の表示に対応
- タイトルが長い場合に備えて省略表示できるCSSを追加

## 確認
- npm run build
- Vite preview + Playwright/Edge でモバイル幅を確認
- フッタータブとヘルプ/設定モーダルでタイトルが切り替わることを確認

Closes #106