### PR TITLE
更新後のタブロック残留を修正

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -93,7 +93,7 @@ export default function App() {
     pullY, pullReturning, refreshing, refreshComplete, scrolled,
     handleTouchStart, handleTouchMove, handleTouchEnd,
   } = usePullToRefresh({ mainRef, onRefresh })
-  const tabsLocked = refreshing || pullReturning
+  const tabsLocked = refreshing && !refreshComplete
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),

--- a/src/hooks/usePullToRefresh.js
+++ b/src/hooks/usePullToRefresh.js
@@ -71,7 +71,15 @@ export function usePullToRefresh({ mainRef, onRefresh }) {
           if (reg) {
             swUpdated = await new Promise(resolve => {
               let done = false
-              const finish = (val) => { if (!done) { done = true; resolve(val) } }
+              let fallbackTimer
+              const finish = (val) => {
+                if (!done) {
+                  done = true
+                  clearTimeout(fallbackTimer)
+                  resolve(val)
+                }
+              }
+              fallbackTimer = setTimeout(() => finish(false), 1500)
 
               // controllerchange: skipWaiting+clients.claim で即座にアクティベートされた場合も検知できる
               navigator.serviceWorker.addEventListener('controllerchange', () => finish(true), { once: true })


### PR DESCRIPTION
## 概要
- pull-to-refresh 後にフッタータブが disabled のまま残る可能性を修正
- タブロック条件を「更新中...」の間だけに限定し、完了表示・戻り演出中は遷移できるように変更
- Service Worker の update() が返らない場合でも更新状態から抜けるよう、外側タイムアウトを追加

## 原因
#100 で efreshing || pullReturning をタブロック条件にしたため、戻り演出や Service Worker 更新確認の詰まりで disabled が残ると、更新後もタブ遷移できなくなる可能性がありました。

## 確認
- npm run build
- Vite preview + Playwright/Edge でモバイル幅を確認
- 更新中はタブ遷移しないことを確認
- 更新完了表示後に disabled が外れ、分析タブへ遷移できることを確認