### PR TITLE
分析画面の更新表示幅を揃える

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,8 +2,12 @@
 .pull-indicator {
   overflow: hidden;
   display: flex;
+  flex: 0 0 auto;
   align-items: flex-end;
+  align-self: stretch;
   justify-content: center;
+  box-sizing: border-box;
+  width: 100%;
   padding-bottom: 10px;
   background: var(--color-bg);
   color: var(--color-primary);
@@ -42,6 +46,7 @@
   font-size: 0.8rem;
   margin-left: 6px;
   letter-spacing: 0.02em;
+  white-space: nowrap;
 }
 
 @keyframes pull-check-in {


### PR DESCRIPTION
## 概要
- pull-to-refresh のインジケーターをアプリ幅いっぱいに伸びるよう調整
- 更新ラベルが折り返されないようにして、分析画面でも詰まって見えないように変更

## 確認
- npm run build
- Vite preview + Playwright/Edge でモバイル幅を確認
- 分析画面で更新中表示の幅が app/header と同じ 390px になることを確認

Closes #105