### PR TITLE
モーダルを閉じる動きを追加

### DIFF
--- a/src/components/HelpModal.jsx
+++ b/src/components/HelpModal.jsx
@@ -1,5 +1,10 @@
-import Modal from './Modal'
+import Modal, { useModalClose } from './Modal'
 import './HelpModal.css'
+
+function HelpCloseButton() {
+  const close = useModalClose()
+  return <button className="help-close-btn" onClick={close}>閉じる</button>
+}
 
 export default function HelpModal({ onClose }) {
   return (
@@ -60,7 +65,7 @@ export default function HelpModal({ onClose }) {
       </div>
 
       <p className="help-version">バージョン {__APP_VERSION__}</p>
-      <button className="help-close-btn" onClick={onClose}>閉じる</button>
+      <HelpCloseButton />
     </Modal>
   )
 }

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -11,9 +11,18 @@
   animation: backdropIn 0.22s ease both;
 }
 
+.modal-backdrop.closing {
+  animation: backdropOut 0.2s ease both;
+}
+
 @keyframes backdropIn {
   from { background: rgba(0, 0, 0, 0); }
   to   { background: rgba(0, 0, 0, 0.45); }
+}
+
+@keyframes backdropOut {
+  from { background: rgba(0, 0, 0, 0.45); }
+  to   { background: rgba(0, 0, 0, 0); }
 }
 
 .modal-sheet {
@@ -29,9 +38,18 @@
   scroll-padding-bottom: calc(24px + env(safe-area-inset-bottom));
 }
 
+.modal-sheet[data-closing="true"] {
+  animation: slideDown 0.2s ease both;
+}
+
 @keyframes slideUp {
   from { transform: translateY(100%); }
   to   { transform: translateY(0); }
+}
+
+@keyframes slideDown {
+  from { transform: translateY(0); }
+  to   { transform: translateY(100%); }
 }
 
 .modal-handle {
@@ -48,4 +66,13 @@
   color: var(--color-text);
   margin-bottom: 18px;
   text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal-backdrop,
+  .modal-backdrop.closing,
+  .modal-sheet,
+  .modal-sheet[data-closing="true"] {
+    animation: none;
+  }
 }

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,13 +1,21 @@
-import { useRef, useEffect } from 'react'
+import { createContext, useContext, useRef, useEffect, useState, useCallback } from 'react'
 import './Modal.css'
 
 const CLOSE_THRESHOLD = 80
+const CLOSE_DURATION = 200
+const ModalCloseContext = createContext(null)
+
+export function useModalClose() {
+  return useContext(ModalCloseContext)
+}
 
 export default function Modal({ onClose, children, title }) {
+  const [closing, setClosing] = useState(false)
   const sheetRef = useRef(null)
   const startYRef = useRef(0)
   const dragYRef = useRef(0)
   const draggingRef = useRef(false)
+  const closeTimerRef = useRef(null)
 
   // アニメーション完了後にフォーカスを移動（重複effectを解消）
   useEffect(() => {
@@ -15,7 +23,22 @@ export default function Modal({ onClose, children, title }) {
     return () => clearTimeout(timer)
   }, [])
 
+  useEffect(() => {
+    return () => clearTimeout(closeTimerRef.current)
+  }, [])
+
+  const requestClose = useCallback(() => {
+    if (closing) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      onClose()
+      return
+    }
+    setClosing(true)
+    closeTimerRef.current = setTimeout(onClose, CLOSE_DURATION)
+  }, [closing, onClose])
+
   const handleTouchStart = (e) => {
+    if (closing) return
     if (sheetRef.current.scrollTop > 0) return
     startYRef.current = e.touches[0].clientY
     dragYRef.current = 0
@@ -24,6 +47,7 @@ export default function Modal({ onClose, children, title }) {
 
   const handleTouchMove = (e) => {
     e.stopPropagation()
+    if (closing) return
     if (!draggingRef.current) return
     if (sheetRef.current.scrollTop > 0) {
       draggingRef.current = false
@@ -37,12 +61,13 @@ export default function Modal({ onClose, children, title }) {
   }
 
   const handleTouchEnd = () => {
+    if (closing) return
     if (!draggingRef.current) return
     draggingRef.current = false
     if (dragYRef.current > CLOSE_THRESHOLD) {
-      sheetRef.current.style.transition = 'transform 0.2s ease'
-      sheetRef.current.style.transform = 'translateY(100%)'
-      setTimeout(onClose, 200)
+      sheetRef.current.style.transition = ''
+      sheetRef.current.style.transform = ''
+      requestClose()
     } else {
       sheetRef.current.style.transition = 'transform 0.2s ease'
       sheetRef.current.style.transform = 'translateY(0)'
@@ -51,8 +76,8 @@ export default function Modal({ onClose, children, title }) {
 
   return (
     <div
-      className="modal-backdrop"
-      onClick={onClose}
+      className={`modal-backdrop${closing ? ' closing' : ''}`}
+      onClick={requestClose}
       onTouchMove={(e) => e.stopPropagation()}
     >
       <div
@@ -62,14 +87,17 @@ export default function Modal({ onClose, children, title }) {
         aria-modal="true"
         aria-label={title}
         tabIndex="-1"
+        data-closing={closing ? 'true' : undefined}
         onClick={(e) => e.stopPropagation()}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
       >
-        <div className="modal-handle" />
-        {title && <h2 className="modal-title">{title}</h2>}
-        {children}
+        <ModalCloseContext.Provider value={requestClose}>
+          <div className="modal-handle" />
+          {title && <h2 className="modal-title">{title}</h2>}
+          {children}
+        </ModalCloseContext.Provider>
       </div>
     </div>
   )


### PR DESCRIPTION
## 概要
- モーダルを閉じる時に backdrop をフェードアウトし、シートを下方向へスライドアウトするように変更
- backdrop クリック、スワイプ閉じ、ヘルプ画面の閉じるボタンで同じ閉じ方を使うよう整理
- prefers-reduced-motion: reduce では開閉アニメーションを無効化

## 確認
- npm run build
- Vite preview + Playwright/Edge でモバイル幅を確認
- ヘルプの閉じるボタンで slideDown が走り、その後モーダルが消えることを確認
- 設定モーダルの backdrop クリックでも閉じるアニメーションが走ることを確認
- reduced motion では animation が none になることを確認

Closes #103