### PR TITLE
ヘッダー操作をコンパクトに整理

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -96,6 +96,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
   flex-shrink: 0;
   background: var(--color-primary);
   padding: 8px 16px;
@@ -106,6 +107,7 @@
 }
 
 .app-title {
+  flex: 1 1 auto;
   min-width: 0;
   color: #fff;
   font-size: 1.25rem;
@@ -118,21 +120,25 @@
 
 .header-actions {
   display: flex;
-  gap: 6px;
+  flex: 0 0 auto;
+  gap: 4px;
 }
 
 .header-btn {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 2px;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
   color: rgba(255, 255, 255, 0.85);
-  padding: 4px 8px;
+  padding: 0;
   border-radius: 8px;
-  font-size: 0.62rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
   transition: background 0.15s, color 0.15s;
+}
+
+.header-btn svg {
+  width: 20px;
+  height: 20px;
 }
 
 .header-btn:hover {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -312,17 +312,25 @@ export default function App() {
       >
         <h1 className="app-title">{screenTitle}</h1>
         <div className="header-actions">
-          <button className="header-btn" onClick={() => setModal({ type: 'help' })}>
+          <button
+            className="header-btn"
+            onClick={() => setModal({ type: 'help' })}
+            aria-label="ヘルプ"
+            title="ヘルプ"
+          >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="12" cy="12" r="10" /><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" /><line x1="12" y1="17" x2="12.01" y2="17" />
             </svg>
-            <span>ヘルプ</span>
           </button>
-          <button className="header-btn" onClick={() => setModal({ type: 'settings' })}>
+          <button
+            className="header-btn"
+            onClick={() => setModal({ type: 'settings' })}
+            aria-label="設定"
+            title="設定"
+          >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
             </svg>
-            <span>設定</span>
           </button>
         </div>
         <input ref={fileInputRef} type="file" accept=".json" style={{ display: 'none' }} onChange={handleFileChange} />


### PR DESCRIPTION
## 概要
- ヘッダー右側のヘルプ/設定ボタンを icon-only に整理
- 40px のタップ領域を維持しつつ、スマホ幅でタイトルと干渉しにくい配置に変更
- ria-label と 	itle を追加し、アイコンだけでも操作名が伝わるように調整

## 確認
- npm run build
- Vite preview + Playwright/Edge でモバイル幅を確認
- 390px幅でタイトルとアクションに余白があることを確認
- ヘルプ/設定ボタンから各モーダルが開くことを確認

Closes #108