### PR TITLE
ヘルプ内容を整理して充実

### DIFF
--- a/src/components/HelpModal.css
+++ b/src/components/HelpModal.css
@@ -9,41 +9,91 @@
 .help-content {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 18px;
   margin-bottom: 16px;
 }
 
 .help-section {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
 }
 
 .help-heading {
-  font-size: 0.85rem;
+  font-size: 0.88rem;
   font-weight: 700;
   color: var(--color-primary);
 }
 
-.help-list {
-  list-style: none;
+.help-card-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
 }
 
-.help-list li {
+.help-card {
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+}
+
+.help-step {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.help-card-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.help-card-title {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--color-text);
+  line-height: 1.35;
+}
+
+.help-card-body,
+.help-note {
   font-size: 0.85rem;
   color: var(--color-text);
   line-height: 1.5;
-  padding-left: 12px;
-  position: relative;
 }
 
-.help-list li::before {
-  content: '·';
-  position: absolute;
-  left: 2px;
+.help-card-body {
+  margin-top: 3px;
+}
+
+.help-feature {
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+  font-size: 0.68rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.help-note {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--color-primary-light);
   color: var(--color-text-secondary);
 }
 

--- a/src/components/HelpModal.jsx
+++ b/src/components/HelpModal.jsx
@@ -1,6 +1,57 @@
 import Modal, { useModalClose } from './Modal'
 import './HelpModal.css'
 
+const HOW_TO_ITEMS = [
+  {
+    title: '習慣を追加する',
+    body: '習慣画面の追加ボタンから、毎日記録したい行動を1つ登録します。',
+  },
+  {
+    title: '今日の達成をつける',
+    body: '習慣ボタンをタップすると、今日の記録をオン/オフできます。長押しすると昨日の記録も選べます。',
+  },
+  {
+    title: 'カレンダーで振り返る',
+    body: '記録画面では達成した日が色の点で見えます。日付を開くと、その日の内容を確認できます。',
+  },
+  {
+    title: '分析で流れを見る',
+    body: '分析画面では現在の連続、最長連続、累計、直近30日の達成率を確認できます。',
+  },
+  {
+    title: '設定で整える',
+    body: '設定画面ではテーマカラーを変えたり、バックアップの保存と復元ができます。',
+  },
+]
+
+const TIP_ITEMS = [
+  {
+    title: '小さく始める',
+    feature: '習慣追加',
+    body: '「毎日30分勉強」より「参考書を1ページ開く」のように、すぐできる形で登録します。',
+  },
+  {
+    title: '毎日見る場所に記録する',
+    feature: 'カレンダー',
+    body: '達成した日が見えると、続けている感覚をつかみやすくなります。',
+  },
+  {
+    title: '続かなかった日を責めない',
+    feature: 'カレンダー・分析',
+    body: '空白の日があっても、次の日から再開できれば十分です。流れを見て戻りやすくします。',
+  },
+  {
+    title: 'まとめて振り返る',
+    feature: '分析',
+    body: '週や月の終わりに、連続日数や直近30日の達成率を軽く見直します。',
+  },
+  {
+    title: '増やしすぎない',
+    feature: '習慣一覧・設定',
+    body: 'まずは1〜3個くらいに絞ると、入力が軽くなり続けやすくなります。',
+  },
+]
+
 function HelpCloseButton() {
   const close = useModalClose()
   return <button className="help-close-btn" onClick={close}>閉じる</button>
@@ -11,56 +62,42 @@ export default function HelpModal({ onClose }) {
     <Modal onClose={onClose} title="使い方">
       <div className="help-content">
         <section className="help-section">
-          <h3 className="help-heading">習慣を記録する</h3>
-          <ul className="help-list">
-            <li>習慣ボタンをタップすると今日の達成をオン／オフできます。</li>
-            <li>長押し（0.5秒）すると今日・昨日を選んで記録できます。うっかり忘れたときに便利です。</li>
-            <li>「編集」ボタンで習慣の並び替え・名前変更・削除ができます。</li>
-          </ul>
+          <h3 className="help-heading">最初にやること</h3>
+          <div className="help-card-list">
+            {HOW_TO_ITEMS.map((item, index) => (
+              <article className="help-card" key={item.title}>
+                <span className="help-step">{index + 1}</span>
+                <div>
+                  <h4 className="help-card-title">{item.title}</h4>
+                  <p className="help-card-body">{item.body}</p>
+                </div>
+              </article>
+            ))}
+          </div>
         </section>
 
         <section className="help-section">
-          <h3 className="help-heading">カレンダーで振り返る</h3>
-          <ul className="help-list">
-            <li>達成した習慣がその色のドットで表示されます。</li>
-            <li>日付をタップするとその日の記録を確認できます。</li>
-            <li>当日と前日だけ、タップした画面から記録を修正できます。</li>
-          </ul>
+          <h3 className="help-heading">続けるためのヒント</h3>
+          <div className="help-card-list">
+            {TIP_ITEMS.map(item => (
+              <article className="help-card help-tip-card" key={item.title}>
+                <div>
+                  <div className="help-card-title-row">
+                    <h4 className="help-card-title">{item.title}</h4>
+                    <span className="help-feature">{item.feature}</span>
+                  </div>
+                  <p className="help-card-body">{item.body}</p>
+                </div>
+              </article>
+            ))}
+          </div>
         </section>
 
         <section className="help-section">
-          <h3 className="help-heading">画面を切り替える</h3>
-          <ul className="help-list">
-            <li>画面下のタブで「習慣」「記録」「分析」を切り替えられます。</li>
-            <li>「習慣」: 今日の習慣が表示されます。</li>
-            <li>「記録」: カレンダーで過去の達成状況を確認できます。</li>
-            <li>「分析」: 習慣ごとの連続日数・累計・達成率が確認できます。今日がまだ未達でも、昨日まで連続していれば連続日数は維持されます。</li>
-          </ul>
-        </section>
-
-        <section className="help-section">
-          <h3 className="help-heading">画面を更新する</h3>
-          <ul className="help-list">
-            <li>画面を下に引っ張って離すと最新の状態に更新されます。</li>
-            <li>「更新中...」と表示されたら離してください。アプリの更新があれば自動で反映されます。</li>
-          </ul>
-        </section>
-
-        <section className="help-section">
-          <h3 className="help-heading">データのバックアップ・復元</h3>
-          <ul className="help-list">
-            <li>設定の「バックアップを保存」でデータをファイルとしてダウンロードできます。</li>
-            <li>「バックアップから復元」でファイルを読み込んでデータを元に戻せます。機種変更のときにも使えます。</li>
-            <li>復元すると現在のデータはすべて上書きされます。</li>
-          </ul>
-        </section>
-
-        <section className="help-section">
-          <h3 className="help-heading">プライバシーについて</h3>
-          <ul className="help-list">
-            <li>データはこの端末のブラウザだけに保存されます。外部サーバーには送られないので、他の人に見られる心配はありません。</li>
-            <li>ブラウザの「サイトデータを消去」を行うとデータが消えます。定期的にバックアップをおすすめします。</li>
-          </ul>
+          <h3 className="help-heading">データについて</h3>
+          <p className="help-note">
+            記録はこの端末のブラウザに保存されます。機種変更やブラウザのデータ削除に備えて、設定画面からバックアップを保存できます。
+          </p>
         </section>
       </div>
 


### PR DESCRIPTION
## 概要
- ヘルプ画面を「最初にやること」「続けるためのヒント」「データについて」に整理
- 習慣追加、今日の達成、カレンダー、分析、設定の使い方を短く説明
- 習慣継続のヒントに、使う機能が分かるタグを追加
- スマホで読みやすいカード形式のレイアウトに調整

## 確認
- npm run build
- Vite preview + Playwright/Edge でモバイル幅を確認
- ヘルプカード10件、ヒントタグ5件が表示されることを確認
- 横はみ出しがないことを確認
- 閉じるボタンが動作することを確認

Closes #102