### PR TITLE
ヘルプ・設定表示時のヘッダータイトルを維持

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,15 +73,11 @@ export default function App() {
 
   const today = getToday()
   const yesterday = getYesterday()
-  const screenTitle = modal?.type === 'settings'
-    ? '設定'
-    : modal?.type === 'help'
-      ? 'ヘルプ'
-      : activeTab === 'record'
-        ? 'カレンダー'
-        : activeTab === 'stats'
-          ? '分析'
-          : '習慣'
+  const screenTitle = activeTab === 'record'
+    ? 'カレンダー'
+    : activeTab === 'stats'
+      ? '分析'
+      : '習慣'
 
   const onRefresh = useCallback(() => {
     const fresh = loadData()


### PR DESCRIPTION
## 概要
- ヘルプ・設定モーダル表示時にヘッダータイトルをモーダル名へ切り替えないようにしました。
- ヘッダーは現在のタブ名を表示し、モーダルのタイトルはボトムシート内の見出しで示します。

## 原因
- App.jsx の screenTitle が modal.type を参照しており、help/settings の表示中だけヘッダー文言を上書きしていました。

## 確認
- npm run build
- プレビューでヘルプ表示時にヘッダーが「習慣」、モーダル見出しが「使い方」のままになることを確認
- プレビューで設定表示時にヘッダーが「習慣」、モーダル見出しが「設定」のままになることを確認

Closes #121