### PR TITLE
pull-to-refresh未発火時の更新中表示を抑制

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -340,7 +340,7 @@ export default function App() {
         className={`pull-indicator${refreshing ? ' refreshing' : ''}${pullY >= PULL_THRESHOLD ? ' ready' : ''}${pullReturning ? ' returning' : ''}`}
         style={!refreshing ? { height: pullY, ...(pullY > 0 && { opacity: pullY / PULL_THRESHOLD }) } : undefined}
       >
-        {(refreshing || pullReturning) ? (
+        {(refreshing || refreshComplete) ? (
           refreshComplete ? (
             <>
               <svg className="pull-check" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">


### PR DESCRIPTION
## 概要
- pull-to-refresh の戻り演出中だけでは「更新中...」を表示しないようにしました。
- 実際に更新が発火した efreshing と、更新完了表示の efreshComplete のときだけ更新状態の表示に入ります。

## 原因
- 戻り演出を示す pullReturning を更新中表示の条件に含めていたため、しきい値未満で離した場合も一瞬「更新中...」側の表示になっていました。

## 確認
- npm run build
- プレビューでしきい値未満の pull 後に「下に引っ張って更新」のままで、更新中 class が付かないことを確認
- プレビューでしきい値以上の pull 後に「更新中...」と更新中 class が付くことを確認

Closes #120