### PR TITLE
上スワイプ時もヘッダー幅を維持

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -79,6 +79,7 @@
   height: var(--app-screen-height);
   display: flex;
   flex-direction: column;
+  width: 100%;
   max-width: 480px;
   margin: 0 auto;
   background: var(--color-bg);
@@ -98,6 +99,7 @@
   justify-content: space-between;
   gap: 12px;
   flex-shrink: 0;
+  width: 100%;
   background: var(--color-primary);
   padding: 8px 16px;
   padding-top: calc(8px + env(safe-area-inset-top));


### PR DESCRIPTION
## 概要
- アプリシェルとヘッダーに width: 100% を明示しました。
- モバイル viewport の再計算やスワイプ後も、ヘッダーがアプリ幅いっぱいの見た目を維持しやすくします。

## 原因
- .app は max-width による制約のみで、ヘッダー幅は flex item の stretch に依存していました。環境によって viewport 変化時に幅の再計算が揺れる余地がありました。

## 確認
- npm run build
- 390px モバイル幅のプレビューで、上スワイプ前後ともヘッダー幅とアプリ幅が 390px のまま維持されることを確認
- スクリーンショットでヘッダー、safe area、フッター表示に崩れがないことを確認

Closes #119