### PR TITLE
モーダル表示中の背面スクロールを抑制

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -162,6 +162,10 @@
   gap: 16px;
 }
 
+.modal-open .app-main {
+  overflow: hidden;
+}
+
 /* Section */
 .section {
   background: var(--color-surface);

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -24,6 +24,11 @@ export default function Modal({ onClose, children, title }) {
   }, [])
 
   useEffect(() => {
+    document.documentElement.classList.add('modal-open')
+    return () => document.documentElement.classList.remove('modal-open')
+  }, [])
+
+  useEffect(() => {
     return () => clearTimeout(closeTimerRef.current)
   }, [])
 
@@ -78,7 +83,10 @@ export default function Modal({ onClose, children, title }) {
     <div
       className={`modal-backdrop${closing ? ' closing' : ''}`}
       onClick={requestClose}
-      onTouchMove={(e) => e.stopPropagation()}
+      onTouchMove={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      }}
     >
       <div
         ref={sheetRef}


### PR DESCRIPTION
## 概要
- モーダル表示中に modal-open クラスを付与し、背面の .app-main スクロールを止めるようにしました。
- backdrop 上の touchmove は preventDefault して、背景側へのスワイプ漏れを抑制します。
- モーダルシート自身のスクロールとスワイプ閉じは維持しています。

## 原因
- モーダル側でイベント伝播は止めていましたが、背面のスクロールコンテナ自体はスクロール可能なままで、環境によって前面操作が背面に漏れる余地がありました。

## 確認
- npm run build
- 日付詳細モーダル表示中に .app-main が overflow: hidden になり、モーダル上スワイプ後も背面 scrollTop が変化しないことを確認
- スクリーンショットで日付詳細モーダル表示に崩れがないことを確認

Closes #118