### PR TITLE
iPhoneのヘッダー縮みを抑制

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -98,7 +98,8 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  flex-shrink: 0;
+  flex: 0 0 auto;
+  min-height: calc(56px + env(safe-area-inset-top));
   width: 100%;
   background: var(--color-primary);
   padding: 8px 16px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,6 +70,7 @@ export default function App() {
   const headerRef = useRef(null)
   const footerRef = useRef(null)
   const fileInputRef = useRef(null)
+  const stableViewportRef = useRef({ width: window.innerWidth, height: 0 })
 
   const today = getToday()
   const yesterday = getYesterday()
@@ -113,14 +114,28 @@ export default function App() {
 
   useEffect(() => {
     const setViewportHeight = () => {
-      const height = window.visualViewport?.height || window.innerHeight
+      const visualViewport = window.visualViewport
+      const currentWidth = Math.round(visualViewport?.width || window.innerWidth)
+      const currentHeight = visualViewport?.height || window.innerHeight
+      const activeElement = document.activeElement
+      const inputFocused = activeElement?.matches?.('input, textarea, [contenteditable="true"]')
+
+      if (Math.abs(currentWidth - stableViewportRef.current.width) > 40) {
+        stableViewportRef.current = { width: currentWidth, height: 0 }
+      }
+
+      const height = inputFocused
+        ? currentHeight
+        : Math.max(stableViewportRef.current.height, currentHeight)
+
+      stableViewportRef.current = { width: currentWidth, height }
       document.documentElement.style.setProperty('--app-viewport-height', `${height}px`)
       if (viewportDebug) {
         const appHeight = document.querySelector('.app')?.getBoundingClientRect().height
         const styles = getComputedStyle(document.documentElement)
         const screenHeight = styles.getPropertyValue('--app-screen-height').trim()
         setViewportDebugInfo(
-          `vv:${Math.round(height)} ih:${window.innerHeight} app:${Math.round(appHeight || 0)} shell:${screenHeight}`
+          `vv:${Math.round(currentHeight)} stable:${Math.round(height)} ih:${window.innerHeight} app:${Math.round(appHeight || 0)} shell:${screenHeight}`
         )
       }
     }


### PR DESCRIPTION
## 概要
- visualViewport の一時的な縮みにアプリ高さが追従しないよう、通常時は観測済みの安定した最大 viewport 高さを使うようにしました。
- 画面幅が大きく変わった場合は回転や表示幅変更とみなし、安定高さをリセットします。
- 入力欄フォーカス中はキーボード表示を邪魔しないよう、現在の viewport 高さを使います。
- ヘッダーに実寸の最小高さを持たせ、flex 計算で縦方向に削られないようにしました。

## 背景
- iPhone Safari では、カード外の背景などをスワイプしたときに browser chrome の影響で visual viewport が一時的に変動することがあります。
- その値をそのまま --app-viewport-height に反映すると、アプリシェル全体が縮み、ヘッダーが潰れたように見える可能性がありました。

## 確認
- npm run build
- 390x844 の iPhone 相当 viewport で、背景スワイプ前後ともヘッダー高さ 56px / 幅 390px が維持されることを確認
- デバッグ表示つきプレビューで app height と viewport CSS 変数が安定することを確認
- プレビューサーバー停止確認済み