### PR TITLE
年月選択に記録あり表示を追加

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -512,6 +512,7 @@ export default function App() {
       {modal?.type === 'monthPicker' && (
         <MonthPickerModal
           currentDate={calendarDate}
+          records={records}
           onSelect={(year, month) => setCalendarDate(new Date(year, month, 1))}
           onClose={closeModal}
         />

--- a/src/components/MonthPickerModal.css
+++ b/src/components/MonthPickerModal.css
@@ -65,6 +65,10 @@
 }
 
 .month-picker-cell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 14px 8px;
   border-radius: 12px;
   font-size: 0.95rem;
@@ -87,5 +91,19 @@
 .month-picker-cell.today {
   border: 2px solid var(--color-primary);
   color: var(--color-primary);
+  background: #fff;
+}
+
+.month-record-dot {
+  position: absolute;
+  right: 10px;
+  bottom: 8px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--color-primary);
+}
+
+.month-picker-cell.selected .month-record-dot {
   background: #fff;
 }

--- a/src/components/MonthPickerModal.jsx
+++ b/src/components/MonthPickerModal.jsx
@@ -1,10 +1,10 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import Modal from './Modal'
 import './MonthPickerModal.css'
 
 const MONTH_LABELS = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月']
 
-export default function MonthPickerModal({ currentDate, onSelect, onClose }) {
+export default function MonthPickerModal({ currentDate, records, onSelect, onClose }) {
   const [pickerYear, setPickerYear] = useState(currentDate.getFullYear())
   const currentYear = currentDate.getFullYear()
   const currentMonth = currentDate.getMonth()
@@ -16,6 +16,13 @@ export default function MonthPickerModal({ currentDate, onSelect, onClose }) {
   // 選択可能な年の範囲: 今年を基準に±5年
   const MIN_YEAR = todayYear - 5
   const MAX_YEAR = todayYear + 1
+  const recordMonths = useMemo(() => {
+    const months = new Set()
+    for (const [date, ids] of Object.entries(records)) {
+      if (ids.length > 0) months.add(date.slice(0, 7))
+    }
+    return months
+  }, [records])
 
   return (
     <Modal onClose={onClose} title="年月を選ぶ">
@@ -51,6 +58,8 @@ export default function MonthPickerModal({ currentDate, onSelect, onClose }) {
           {MONTH_LABELS.map((label, m) => {
             const isSelected = pickerYear === currentYear && m === currentMonth
             const isToday = pickerYear === todayYear && m === todayMonth
+            const monthKey = `${pickerYear}-${String(m + 1).padStart(2, '0')}`
+            const hasRecords = recordMonths.has(monthKey)
             return (
               <button
                 key={m}
@@ -60,10 +69,11 @@ export default function MonthPickerModal({ currentDate, onSelect, onClose }) {
                   isToday && !isSelected ? 'today' : '',
                 ].filter(Boolean).join(' ')}
                 onClick={() => { onSelect(pickerYear, m); onClose() }}
-                aria-label={`${pickerYear}年${m + 1}月`}
+                aria-label={`${pickerYear}年${m + 1}月${hasRecords ? '、記録あり' : ''}`}
                 aria-pressed={isSelected}
               >
-                {label}
+                <span>{label}</span>
+                {hasRecords && <span className="month-record-dot" aria-hidden="true" />}
               </button>
             )
           })}


### PR DESCRIPTION
## 概要
- 年月選択モーダルで、記録がある月に控えめなドットを表示するようにしました。
- 月ごとの記録有無は ecords から YYYY-MM 単位で集計します。
- スクリーンリーダー向けに、記録がある月の aria-label に『記録あり』を追加しました。

## 確認
- npm run build
- プレビューで記録がある 2026年3月・5月にドットが出ることを確認
- 空配列だけの 2026年4月にはドットが出ず、aria-label にも『記録あり』が付かないことを確認
- モバイル幅で年月選択モーダルの表示が崩れないことを確認
- プレビューサーバー停止確認済み

Closes #122