### PR TITLE
終了当日の習慣母数を調整

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -75,7 +75,7 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
           const dayRecords = records[dateStr] || []
           const activeHabits = habits.filter(h => {
             if (h.createdAt && dateStr < h.createdAt) return false
-            if (h.archivedAt && dateStr > h.archivedAt) return false
+            if (h.archivedAt && dateStr >= h.archivedAt) return false
             return true
           })
           const completedHabits = activeHabits.filter(h => dayRecords.includes(h.id))

--- a/src/components/DayDetailModal.jsx
+++ b/src/components/DayDetailModal.jsx
@@ -19,7 +19,7 @@ export default function DayDetailModal({
 
   const activeHabits = habits.filter(h => {
     if (h.createdAt && dateStr < h.createdAt) return false
-    if (h.archivedAt && dateStr > h.archivedAt) return false
+    if (h.archivedAt && dateStr >= h.archivedAt) return false
     return true
   })
   const completedCount = activeHabits.filter(h => completedIds.includes(h.id)).length


### PR DESCRIPTION
## 概要
- カレンダーと日付詳細で、終了済み習慣を rchivedAt 当日から母数に含めないようにしました。
- 過去日についてはこれまで通り、終了前の習慣として母数に含まれます。
- カレンダーと DayDetailModal の表示基準を揃えています。

## 確認
- npm run build
- アーカイブ当日のカレンダー表示が 1/1 になることを確認
- 同じ日の日付詳細が 1 / 1 習慣達成 になり、終了済み習慣が一覧から外れることを確認
- プレビューサーバー停止確認済み

Closes #124