### PR TITLE
PWAのヘッダー上部余白を安定化

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#6366F1" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="習慣" />
     <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
     <link rel="apple-touch-icon" href="%BASE_URL%icon.svg" />

--- a/src/App.css
+++ b/src/App.css
@@ -99,11 +99,11 @@
   justify-content: space-between;
   gap: 12px;
   flex: 0 0 auto;
-  min-height: calc(56px + env(safe-area-inset-top));
+  min-height: calc(56px + var(--app-safe-area-top));
   width: 100%;
   background: var(--color-primary);
   padding: 8px 16px;
-  padding-top: calc(8px + env(safe-area-inset-top));
+  padding-top: calc(8px + var(--app-safe-area-top));
   box-shadow: 0 2px 8px rgba(99, 102, 241, 0.3);
   /* iOSでヘッダー上のタッチからスクロールが発火しないようにする */
   touch-action: none;

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -32,7 +32,7 @@
   width: 100%;
   max-width: 480px;
   animation: slideUp 0.24s cubic-bezier(0.2, 0.8, 0.2, 1) both;
-  max-height: calc(var(--app-screen-height) - env(safe-area-inset-top));
+  max-height: calc(var(--app-screen-height) - var(--app-safe-area-top));
   overflow-y: auto;
   overscroll-behavior: contain;
   scroll-padding-bottom: calc(24px + env(safe-area-inset-bottom));

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,7 @@ input, textarea, [contenteditable] {
 }
 
 :root {
+  --app-safe-area-top: env(safe-area-inset-top, 0px);
   --app-safe-area-bottom: env(safe-area-inset-bottom, 0px);
   --app-viewport-height: 100svh;
   --app-screen-height: calc(var(--app-viewport-height) + var(--app-safe-area-bottom));


### PR DESCRIPTION
## 概要
- iOS PWA の pple-mobile-web-app-status-bar-style を lack-translucent から default に変更しました。
- ホーム画面追加後に WebView がカメラ/ステータスバー領域の下まで広がり、ヘッダーが上へ潜る状態を避けます。
- safe-area-inset-top を --app-safe-area-top として共通変数化し、ヘッダーとモーダルの上部計算を揃えました。

## 背景
- ブラウザでは発生せず、ホーム画面追加後だけ起きるため、PWA standalone のステータスバー透過指定が原因候補です。
- lack-translucent はiOSでコンテンツをステータスバー領域まで伸ばすため、safe area top が期待通り認識されない環境ではカメラ領域にヘッダーが入り込みます。

## 確認
- npm run build
- プレビューで pple-mobile-web-app-status-bar-style が default になっていることを確認
- 390x844 のモバイル相当表示でヘッダー高さ 56px / 幅 390px を維持することを確認
- プレビューサーバー停止確認済み

## 実機確認メモ
- この変更はホーム画面追加後の iOS PWA に効く指定なので、マージ後は一度アプリを完全終了して再起動、必要ならホーム画面アイコンの再追加で確認してください。