### PR TITLE
PWAヘッダーと復元データを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#6366F1" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="習慣" />
     <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
     <link rel="apple-touch-icon" href="%BASE_URL%icon.svg" />

--- a/src/App.css
+++ b/src/App.css
@@ -73,6 +73,7 @@
 }
 
 .app {
+  --app-header-height: calc(56px + var(--app-safe-area-top));
   --footer-height: 60px;
   --footer-safe-padding: 10px;
   --footer-browser-shift: 10px;
@@ -82,6 +83,7 @@
   width: 100%;
   max-width: 480px;
   margin: 0 auto;
+  padding-top: var(--app-header-height);
   background: var(--color-bg);
   overflow: hidden;
 }
@@ -94,17 +96,23 @@
 }
 
 .app-header {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  flex: 0 0 auto;
-  min-height: calc(56px + var(--app-safe-area-top));
+  height: var(--app-header-height);
   width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
   background: var(--color-primary);
   padding: 8px 16px;
   padding-top: calc(8px + var(--app-safe-area-top));
   box-shadow: 0 2px 8px rgba(99, 102, 241, 0.3);
+  z-index: 30;
   /* iOSでヘッダー上のタッチからスクロールが発火しないようにする */
   touch-action: none;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,7 +32,7 @@ import { useTheme } from './hooks/useTheme'
 import { usePullToRefresh, PULL_THRESHOLD } from './hooks/usePullToRefresh'
 import { getToday, getYesterday } from './utils/date'
 import { calcCurrentStreak } from './utils/stats'
-import { validateImportData } from './utils/validation'
+import { sanitizeImportData, validateImportData } from './utils/validation'
 import './App.css'
 
 const LAST_BACKUP_KEY = 'habit-tracker-last-backup'
@@ -100,6 +100,11 @@ export default function App() {
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
   )
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('pwa-standalone', isStandalone)
+    return () => document.documentElement.classList.remove('pwa-standalone')
+  }, [isStandalone])
 
   useEffect(() => {
     const preventChromeScroll = (e) => {
@@ -343,7 +348,13 @@ export default function App() {
         if (error) {
           setModal({ type: 'importError', message: error })
         } else {
-          setModal({ type: 'importFile', data, filename: file.name })
+          const sanitized = sanitizeImportData(data)
+          setModal({
+            type: 'importFile',
+            data: sanitized.data,
+            filename: file.name,
+            skippedUnknownRecords: sanitized.skippedUnknownRecords,
+          })
         }
       } catch {
         setModal({ type: 'importError', message: 'JSONの解析に失敗しました。\nファイルが壊れているか、形式が正しくありません。' })
@@ -654,13 +665,16 @@ export default function App() {
 
       {modal?.type === 'importFile' && (() => {
         const recordDates = Object.keys(modal.data.records).sort()
+        const skippedText = modal.skippedUnknownRecords > 0
+          ? `\n\n※ バックアップ内に存在しない習慣IDの記録 ${modal.skippedUnknownRecords}件は除外して復元します。`
+          : ''
         const rangeText = recordDates.length > 0
           ? `${recordDates[0]} 〜 ${recordDates[recordDates.length - 1]}`
           : 'なし'
         return (
           <ConfirmModal
             title="インポートの確認"
-            message={`「${modal.filename}」をインポートします。\n\n習慣: ${modal.data.habits.length}件\n記録日数: ${recordDates.length}日\n期間: ${rangeText}\n\n⚠ 現在のデータはすべて上書きされます。\nこの操作は取り消せません。`}
+            message={`「${modal.filename}」をインポートします。\n\n習慣: ${modal.data.habits.length}件\n記録日数: ${recordDates.length}日\n期間: ${rangeText}${skippedText}\n\n⚠ 現在のデータはすべて上書きされます。\nこの操作は取り消せません。`}
             confirmLabel="インポート"
             danger={true}
             onConfirm={handleImportConfirm}

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,12 @@ html, body {
   background: var(--color-bg);
 }
 
+html.pwa-standalone,
+html.pwa-standalone body,
+html.pwa-standalone #root {
+  background: var(--color-primary);
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Sans', 'Yu Gothic UI',
     'Segoe UI', sans-serif;

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -39,8 +39,29 @@ export function validateImportData(data) {
     if (!isValidDate(date)) return `records のキー「${date}」は存在しない日付です。`
     if (!Array.isArray(ids)) return `records[${date}] が配列ではありません。`
     if (ids.some(id => typeof id !== 'string')) return `records[${date}] に文字列以外の値が含まれています。`
-    const unknown = ids.find(id => !habitIds.has(id))
-    if (unknown !== undefined) return `records[${date}] に未知の習慣 ID「${unknown}」が含まれています。`
   }
   return null
+}
+
+export function sanitizeImportData(data) {
+  const habitIds = new Set(data.habits.map(h => h.id))
+  const records = {}
+  let skippedUnknownRecords = 0
+
+  for (const [date, ids] of Object.entries(data.records)) {
+    const knownIds = ids.filter(id => {
+      const known = habitIds.has(id)
+      if (!known) skippedUnknownRecords += 1
+      return known
+    })
+    if (knownIds.length > 0) records[date] = knownIds
+  }
+
+  return {
+    data: {
+      habits: data.habits,
+      records,
+    },
+    skippedUnknownRecords,
+  }
 }


### PR DESCRIPTION
## 概要
- iOS PWA のステータスバー設定を lack-translucent に戻し、ヘッダーを固定配置にしました。
- standalone 起動時は html/body/#root の背景もヘッダー色にして、カメラ領域側に白い帯が出ないようにしました。
- アプリ本体にはヘッダー高さぶんの padding を持たせ、固定ヘッダーと本文が重ならないようにしました。
- バックアップ復元時、records に habits に存在しない古い habitId が混じっていても復元全体を止めず、未知IDの記録だけ除外するようにしました。

## 確認
- npm run build
- モバイル相当表示で status bar style が black-translucent になっていることを確認
- スワイプ前後でヘッダーが top 0 / 高さ 56px / 幅 390px を維持することを確認
- standalone クラス時に html/body/#root の背景がヘッダー色になることを確認
- 未知ID h_177619102174 を含むバックアップ相当データで validate が通り、未知ID記録だけ除外されることを確認
- プレビューサーバー停止確認済み

## 実機確認メモ
- マージ後、PWAを完全終了して再起動してください。古いメタ指定が残る場合はホーム画面アイコンの再追加が必要になる可能性があります。