### PR TITLE
バックアップ保存時に不明な記録を除外

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -316,7 +316,8 @@ export default function App() {
 
   // --- Export / Import ---
   const handleExport = useCallback(() => {
-    const json = JSON.stringify({ habits, records }, null, 2)
+    const sanitized = sanitizeImportData({ habits, records })
+    const json = JSON.stringify(sanitized.data, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -326,7 +327,10 @@ export default function App() {
     URL.revokeObjectURL(url)
     try { localStorage.setItem(LAST_BACKUP_KEY, today) } catch {}
     setLastBackupDate(today)
-    setToast(`habit-tracker-${today}.json を保存しました`)
+    const skippedText = sanitized.skippedUnknownRecords > 0
+      ? `（不明な記録 ${sanitized.skippedUnknownRecords}件を除外）`
+      : ''
+    setToast(`habit-tracker-${today}.json を保存しました${skippedText}`)
   }, [habits, records, today])
 
   const handleImportClick = () => fileInputRef.current?.click()


### PR DESCRIPTION
## 概要
- バックアップ保存時にも sanitizeImportData() を通し、habits に存在しない古い habitId の記録をJSONへ書き出さないようにしました。
- 不明な記録を除外した場合は、保存完了トーストに除外件数を表示します。

## 背景
- ホーム画面アイコン削除後にバックアップをインポートし直した際、records に残っていた孤立 habitId が原因で復元エラーになっていました。
- 復元時だけでなく保存時にもクリーンなJSONを作ることで、同じ不整合を次のバックアップへ持ち越さないようにします。

## 確認
- npm run build
- 未知ID h_177619102174 を含むバックアップ相当データで、未知ID記録だけ除外されることを確認