### PR TITLE
PWAの本文バウンドを抑制

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -165,6 +165,7 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   padding: 16px 16px;
   padding-bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 16px);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,6 +122,39 @@ export default function App() {
   }, [])
 
   useEffect(() => {
+    const scrollEl = mainRef.current
+    if (!scrollEl) return undefined
+
+    let touchStartY = 0
+
+    const handleMainTouchStart = (e) => {
+      if (e.touches.length !== 1) return
+      touchStartY = e.touches[0].clientY
+    }
+
+    const handleMainTouchMove = (e) => {
+      if (e.touches.length !== 1) return
+
+      const deltaY = e.touches[0].clientY - touchStartY
+      const atTop = scrollEl.scrollTop <= 0
+      const atBottom =
+        scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - 1
+
+      if ((atTop && deltaY > 0) || (atBottom && deltaY < 0)) {
+        e.preventDefault()
+      }
+    }
+
+    scrollEl.addEventListener('touchstart', handleMainTouchStart, { passive: true })
+    scrollEl.addEventListener('touchmove', handleMainTouchMove, { passive: false })
+
+    return () => {
+      scrollEl.removeEventListener('touchstart', handleMainTouchStart)
+      scrollEl.removeEventListener('touchmove', handleMainTouchMove)
+    }
+  }, [])
+
+  useEffect(() => {
     const setViewportHeight = () => {
       const visualViewport = window.visualViewport
       const currentWidth = Math.round(visualViewport?.width || window.innerWidth)

--- a/src/index.css
+++ b/src/index.css
@@ -40,8 +40,9 @@ input, textarea, [contenteditable] {
 }
 
 html, body {
-  min-height: 100%;
+  height: 100%;
   width: 100%;
+  overflow: hidden;
   overflow-x: hidden;
   overscroll-behavior: none;
   background: var(--color-bg);
@@ -75,6 +76,7 @@ input {
 }
 
 #root {
-  min-height: 100%;
+  height: 100%;
+  overflow: hidden;
   background: var(--color-bg);
 }


### PR DESCRIPTION
## 概要
- `html` / `body` / `#root` の縦スクロールを止め、スクロールを `.app-main` に閉じ込めました
- `.app-main` の上下端でネイティブのバウンドスクロールを抑制しました
- 本文スクロール領域に `overscroll-behavior-y: contain` を追加しました

## 確認
- `npm run build`
- プレビューを iPhone 相当幅で確認
- 本文上端の `touchmove` が `preventDefault: true` になることを確認
- `window.scrollY` が 0 のまま、ヘッダーの top / height が変わらないことを確認