### PR TITLE
UI改善・カテゴリ機能・スクロール修正

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,7 +9,7 @@
   box-sizing: border-box;
   width: 100%;
   padding-bottom: 0;
-  background: var(--color-surface);
+  background: var(--color-bg);
   color: var(--color-primary);
   height: 0;
 }
@@ -179,24 +179,19 @@
 .app-main {
   flex: 1 1 auto;
   min-height: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
-  overscroll-behavior-y: contain;
-  -webkit-overflow-scrolling: touch;
-  padding: 0 0 calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
-  padding-bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
+  overflow: hidden;
   background: var(--color-bg);
 }
 
 .tab-viewport {
   overflow: hidden;
-  min-height: 100%;
+  height: 100%;
   background: var(--color-bg);
 }
 
 .tab-track {
   display: flex;
-  align-items: flex-start;
+  height: 100%;
   will-change: transform;
   touch-action: pan-y;
 }
@@ -211,7 +206,11 @@
   min-width: 0;
   flex-direction: column;
   gap: 16px;
-  padding: 12px 16px 0;
+  padding: 12px 16px calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior-y: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .modal-open .app-main {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
 import {
   DndContext,
   closestCenter,
@@ -27,6 +27,7 @@ import AddToHomePrompt from './components/AddToHomePrompt'
 import MonthPickerModal from './components/MonthPickerModal'
 import RecordView from './components/RecordView'
 import StatsView from './components/StatsView'
+import CategoryManageModal from './components/CategoryManageModal'
 import { useHabitsStorage, loadData } from './hooks/useHabitsStorage'
 import { useTheme } from './hooks/useTheme'
 import { usePullToRefresh, PULL_THRESHOLD } from './hooks/usePullToRefresh'
@@ -56,7 +57,7 @@ export default function App() {
     setShowWelcome(false)
   }, [])
 
-  const { habits, records, setHabits, setRecords } = useHabitsStorage()
+  const { habits, records, categories, setHabits, setRecords, setCategories } = useHabitsStorage()
   const { themeId, handleThemeSelect } = useTheme()
 
   const [calendarDate, setCalendarDate] = useState(() => new Date())
@@ -73,6 +74,10 @@ export default function App() {
   const [undoAction, setUndoAction] = useState(null)
   const undoTimerRef = useRef(null)
   const mainRef = useRef(null)
+  const recordPanelRef = useRef(null)
+  const habitPanelRef = useRef(null)
+  const statsPanelRef = useRef(null)
+  const scrollRef = useRef(null)
   const headerRef = useRef(null)
   const footerRef = useRef(null)
   const fileInputRef = useRef(null)
@@ -96,7 +101,7 @@ export default function App() {
   const {
     pullY, pullReturning, refreshing, refreshComplete, scrolled,
     handleTouchStart, handleTouchMove, handleTouchEnd,
-  } = usePullToRefresh({ mainRef, onRefresh })
+  } = usePullToRefresh({ mainRef: scrollRef, scrollKey: activeTab, onRefresh })
   const tabsLocked = refreshing && !refreshComplete
 
   const sensors = useSensors(
@@ -124,8 +129,15 @@ export default function App() {
     }
   }, [])
 
+  const panelRefMap = { record: recordPanelRef, habit: habitPanelRef, stats: statsPanelRef }
+
+  useLayoutEffect(() => {
+    scrollRef.current = panelRefMap[activeTab]?.current ?? null
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab])
+
   useEffect(() => {
-    const scrollEl = mainRef.current
+    const scrollEl = scrollRef.current
     if (!scrollEl) return undefined
 
     let touchStartY = 0
@@ -155,7 +167,7 @@ export default function App() {
       scrollEl.removeEventListener('touchstart', handleMainTouchStart)
       scrollEl.removeEventListener('touchmove', handleMainTouchMove)
     }
-  }, [])
+  }, [activeTab])
 
   useEffect(() => {
     const setViewportHeight = () => {
@@ -309,19 +321,32 @@ export default function App() {
     setUndoAction(null)
   }, [undoAction])
 
-  const addHabit = useCallback(({ name, color }) => {
+  const addHabit = useCallback(({ name, color, categoryId }) => {
     const id = `h_${Date.now()}`
-    setHabits(prev => [...prev, { id, name, color, createdAt: today }])
+    setHabits(prev => [...prev, { id, name, color, categoryId: categoryId ?? null, createdAt: today }])
     setModal(null)
     dismissWelcome()
   }, [today, dismissWelcome])
 
-  const updateHabit = useCallback(({ name, color }) => {
+  const updateHabit = useCallback(({ name, color, categoryId }) => {
     setHabits(prev =>
-      prev.map(h => h.id === modal.habit.id ? { ...h, name, color } : h)
+      prev.map(h => h.id === modal.habit.id ? { ...h, name, color, categoryId: categoryId ?? null } : h)
     )
     setModal(null)
   }, [modal])
+
+  const addCategory = useCallback((cat) => {
+    setCategories(prev => [...prev, cat])
+  }, [])
+
+  const updateCategory = useCallback((id, name) => {
+    setCategories(prev => prev.map(c => c.id === id ? { ...c, name } : c))
+  }, [])
+
+  const deleteCategory = useCallback((id) => {
+    setCategories(prev => prev.filter(c => c.id !== id))
+    setHabits(prev => prev.map(h => h.categoryId === id ? { ...h, categoryId: null } : h))
+  }, [])
 
   const deleteHabit = useCallback((habitId) => {
     setHabits(prev => prev.filter(h => h.id !== habitId))
@@ -564,7 +589,7 @@ export default function App() {
             style={tabTrackStyle}
             onTransitionEnd={() => setTabSettling(false)}
           >
-            <div className="tab-panel" aria-hidden={activeTab !== 'record'}>
+            <div className="tab-panel" ref={recordPanelRef} aria-hidden={activeTab !== 'record'}>
               <RecordView
                 calendarDate={calendarDate}
                 onCalendarDateChange={setCalendarDate}
@@ -576,7 +601,7 @@ export default function App() {
               />
             </div>
 
-            <div className="tab-panel" aria-hidden={activeTab !== 'habit'}>
+            <div className="tab-panel" ref={habitPanelRef} aria-hidden={activeTab !== 'habit'}>
               <section className="section">
             <div className="section-header">
               <h2 className="section-title">今日の習慣</h2>
@@ -666,7 +691,6 @@ export default function App() {
                     streak={calcCurrentStreak(habit.id, records)}
                     onPress={(h) => toggleHabit(h.id, today)}
                     onLongPress={(h) => setModal({ type: 'longPress', habit: h })}
-                    onEdit={(h) => setModal({ type: 'edit', habit: h })}
                   />
                 ))}
                 <button className="add-habit-btn" onClick={() => setModal({ type: 'add' })}>
@@ -678,12 +702,12 @@ export default function App() {
           </section>
             </div>
 
-            <div className="tab-panel" aria-hidden={activeTab !== 'stats'}>
+            <div className="tab-panel" ref={statsPanelRef} aria-hidden={activeTab !== 'stats'}>
               <section className="section">
                 <div className="section-header">
                   <h2 className="section-title">これからの続け方</h2>
                 </div>
-                <StatsView habits={habits} records={records} today={today} />
+                <StatsView habits={habits} records={records} today={today} categories={categories} />
               </section>
             </div>
           </div>
@@ -700,7 +724,7 @@ export default function App() {
       )}
 
       {modal?.type === 'add' && (
-        <AddHabitModal onSave={addHabit} onClose={closeModal} />
+        <AddHabitModal onSave={addHabit} onClose={closeModal} categories={categories} />
       )}
 
       {modal?.type === 'edit' && (
@@ -708,6 +732,7 @@ export default function App() {
           initialHabit={modal.habit}
           onSave={updateHabit}
           onClose={closeModal}
+          categories={categories}
         />
       )}
 
@@ -719,6 +744,7 @@ export default function App() {
           isCompletedToday={todayRecords.includes(modal.habit.id)}
           isCompletedYesterday={(records[yesterday] || []).includes(modal.habit.id)}
           onSelect={(dateStr) => { toggleHabit(modal.habit.id, dateStr); closeModal() }}
+          onEdit={(h) => setModal({ type: 'edit', habit: h })}
           onClose={closeModal}
         />
       )}
@@ -790,8 +816,19 @@ export default function App() {
           onSelectTheme={(theme) => { handleThemeSelect(theme) }}
           onExport={() => { closeModal(); setTimeout(() => setModal({ type: 'exportConfirm' }), 50) }}
           onImport={() => { closeModal(); setTimeout(() => setModal({ type: 'importConfirm' }), 50) }}
+          onManageCategories={() => { closeModal(); setTimeout(() => setModal({ type: 'categoryManage' }), 50) }}
           onClose={closeModal}
           lastBackupDate={lastBackupDate}
+        />
+      )}
+
+      {modal?.type === 'categoryManage' && (
+        <CategoryManageModal
+          categories={categories}
+          onAdd={addCategory}
+          onUpdate={updateCategory}
+          onDelete={deleteCategory}
+          onClose={closeModal}
         />
       )}
 

--- a/src/components/AddHabitModal.css
+++ b/src/components/AddHabitModal.css
@@ -111,3 +111,30 @@
   color: var(--color-text-secondary);
   margin-top: 4px;
 }
+
+.category-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.category-chip {
+  padding: 5px 14px;
+  border-radius: 20px;
+  border: 1.5px solid var(--color-border);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  background: var(--color-surface);
+  transition: all 0.15s;
+}
+
+.category-chip.selected {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+.category-chip:active {
+  opacity: 0.7;
+}

--- a/src/components/AddHabitModal.jsx
+++ b/src/components/AddHabitModal.jsx
@@ -25,16 +25,17 @@ const COLOR_HINTS = {
   '#6C5CE7': '集中・スキル系',
 }
 
-export default function AddHabitModal({ onSave, onClose, initialHabit = null }) {
+export default function AddHabitModal({ onSave, onClose, initialHabit = null, categories = [] }) {
   const isEdit = !!initialHabit
   const [name, setName] = useState(initialHabit?.name ?? '')
   const [color, setColor] = useState(initialHabit?.color ?? HABIT_COLORS[0])
+  const [categoryId, setCategoryId] = useState(initialHabit?.categoryId ?? null)
 
   const handleSubmit = (e) => {
     e.preventDefault()
     const trimmed = name.trim()
     if (!trimmed) return
-    onSave({ name: trimmed, color })
+    onSave({ name: trimmed, color, categoryId })
   }
 
   return (
@@ -72,6 +73,31 @@ export default function AddHabitModal({ onSave, onClose, initialHabit = null }) 
             <p className="color-hint">おすすめ：{COLOR_HINTS[color]}</p>
           )}
         </div>
+
+        {categories.length > 0 && (
+          <div className="form-group">
+            <label className="form-label">カテゴリ</label>
+            <div className="category-chips">
+              <button
+                type="button"
+                className={`category-chip${categoryId === null ? ' selected' : ''}`}
+                onClick={() => setCategoryId(null)}
+              >
+                なし
+              </button>
+              {categories.map(cat => (
+                <button
+                  key={cat.id}
+                  type="button"
+                  className={`category-chip${categoryId === cat.id ? ' selected' : ''}`}
+                  onClick={() => setCategoryId(cat.id)}
+                >
+                  {cat.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="preview-row">
           <div

--- a/src/components/CategoryManageModal.css
+++ b/src/components/CategoryManageModal.css
@@ -1,0 +1,145 @@
+.cat-empty {
+  color: var(--color-text-secondary);
+  font-size: 0.88rem;
+  line-height: 1.5;
+  padding: 8px 0 16px;
+}
+
+.cat-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+  list-style: none;
+}
+
+.cat-item {
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  padding: 10px 12px;
+}
+
+.cat-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.cat-name {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--color-text);
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cat-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.cat-edit-btn {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  padding: 3px 10px;
+  border-radius: 20px;
+  border: 1.5px solid var(--color-primary);
+  transition: opacity 0.15s;
+}
+
+.cat-edit-btn:active {
+  opacity: 0.6;
+}
+
+.cat-delete-btn {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-danger);
+  padding: 3px 10px;
+  border-radius: 20px;
+  border: 1.5px solid var(--color-danger);
+  transition: opacity 0.15s;
+}
+
+.cat-delete-btn:active {
+  opacity: 0.6;
+}
+
+.cat-edit-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.cat-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+  font-size: 0.88rem;
+  color: var(--color-text);
+  outline: none;
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.cat-input:focus {
+  border-color: var(--color-primary);
+}
+
+.cat-save-btn {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--color-primary);
+  padding: 6px 12px;
+  border-radius: 20px;
+  flex-shrink: 0;
+  transition: opacity 0.15s;
+}
+
+.cat-save-btn:disabled {
+  opacity: 0.4;
+}
+
+.cat-cancel-btn {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  padding: 6px 10px;
+  flex-shrink: 0;
+  transition: opacity 0.15s;
+}
+
+.cat-add-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.cat-add-btn {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--color-primary);
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  transition: opacity 0.15s;
+}
+
+.cat-add-btn:disabled {
+  opacity: 0.4;
+}
+
+.cat-add-btn:active {
+  opacity: 0.7;
+}

--- a/src/components/CategoryManageModal.jsx
+++ b/src/components/CategoryManageModal.jsx
@@ -1,0 +1,83 @@
+import { useState } from 'react'
+import Modal from './Modal'
+import './CategoryManageModal.css'
+
+export default function CategoryManageModal({ categories, onAdd, onUpdate, onDelete, onClose }) {
+  const [newName, setNewName] = useState('')
+  const [editingId, setEditingId] = useState(null)
+  const [editingName, setEditingName] = useState('')
+
+  const handleAdd = () => {
+    const name = newName.trim()
+    if (!name) return
+    onAdd({ id: `cat_${Date.now()}`, name })
+    setNewName('')
+  }
+
+  const handleUpdate = (id) => {
+    const name = editingName.trim()
+    if (!name) return
+    onUpdate(id, name)
+    setEditingId(null)
+  }
+
+  const startEdit = (cat) => {
+    setEditingId(cat.id)
+    setEditingName(cat.name)
+  }
+
+  return (
+    <Modal title="カテゴリ管理" onClose={onClose}>
+      {categories.length === 0 ? (
+        <p className="cat-empty">まだカテゴリがありません。下から追加してください。</p>
+      ) : (
+        <ul className="cat-list">
+          {categories.map(cat => (
+            <li key={cat.id} className="cat-item">
+              {editingId === cat.id ? (
+                <div className="cat-edit-row">
+                  <input
+                    className="cat-input"
+                    value={editingName}
+                    onChange={e => setEditingName(e.target.value)}
+                    onKeyDown={e => { if (e.key === 'Enter') handleUpdate(cat.id) }}
+                    autoFocus
+                    maxLength={20}
+                  />
+                  <button className="cat-save-btn" onClick={() => handleUpdate(cat.id)} disabled={!editingName.trim()}>
+                    保存
+                  </button>
+                  <button className="cat-cancel-btn" onClick={() => setEditingId(null)}>
+                    キャンセル
+                  </button>
+                </div>
+              ) : (
+                <div className="cat-row">
+                  <span className="cat-name">{cat.name}</span>
+                  <div className="cat-actions">
+                    <button className="cat-edit-btn" onClick={() => startEdit(cat)}>編集</button>
+                    <button className="cat-delete-btn" onClick={() => onDelete(cat.id)}>削除</button>
+                  </div>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="cat-add-row">
+        <input
+          className="cat-input"
+          value={newName}
+          onChange={e => setNewName(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') handleAdd() }}
+          placeholder="新しいカテゴリ名"
+          maxLength={20}
+        />
+        <button className="cat-add-btn" onClick={handleAdd} disabled={!newName.trim()}>
+          追加
+        </button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/HabitButton.css
+++ b/src/components/HabitButton.css
@@ -1,9 +1,3 @@
-.habit-btn-wrapper {
-  position: relative;
-  display: block;
-  width: 100%;
-}
-
 .habit-btn {
   display: flex;
   flex-direction: column;
@@ -27,25 +21,6 @@
   width: 100%;
 }
 
-.habit-edit-btn {
-  position: absolute;
-  top: 5px;
-  left: 6px;
-  width: 22px;
-  height: 22px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-text-secondary);
-  opacity: 0.5;
-  border-radius: 4px;
-  z-index: 1;
-  transition: opacity 0.15s;
-}
-
-.habit-edit-btn:active {
-  opacity: 1;
-}
 
 .habit-btn.completed {
   background: var(--color);

--- a/src/components/HabitButton.jsx
+++ b/src/components/HabitButton.jsx
@@ -3,7 +3,7 @@ import './HabitButton.css'
 
 const LONG_PRESS_DELAY = 500
 
-export default function HabitButton({ habit, completed, streak, onPress, onLongPress, onEdit }) {
+export default function HabitButton({ habit, completed, streak, onPress, onLongPress }) {
   const timerRef = useRef(null)
   const isLongPressRef = useRef(false)
   const startPosRef = useRef(null)
@@ -52,40 +52,25 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
   }, [habit, onPress, completed])
 
   return (
-    <div className="habit-btn-wrapper">
-      <button
-        className={`habit-btn${completed ? ' completed' : ''}${popping ? ' pop' : ''}`}
-        style={{ '--color': habit.color }}
-        aria-label={`${habit.name}${completed ? '（達成済み）' : ''}`}
-        aria-pressed={completed}
-        onClick={handleClick}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerCancel}
-        onContextMenu={(e) => e.preventDefault()}
-      >
-        <span
-          className="habit-dot"
-          style={{ backgroundColor: completed ? '#fff' : habit.color }}
-        />
-        <span className="habit-name">{habit.name}</span>
-        {streak > 1 && <span className="habit-streak">{streak}日継続</span>}
-        {completed && <span className="habit-check">✓</span>}
-      </button>
-      {onEdit && (
-        <button
-          className="habit-edit-btn"
-          onClick={() => onEdit(habit)}
-          onPointerDown={(e) => e.stopPropagation()}
-          aria-label={`${habit.name}を編集`}
-        >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-          </svg>
-        </button>
-      )}
-    </div>
+    <button
+      className={`habit-btn${completed ? ' completed' : ''}${popping ? ' pop' : ''}`}
+      style={{ '--color': habit.color }}
+      aria-label={`${habit.name}${completed ? '（達成済み）' : ''}`}
+      aria-pressed={completed}
+      onClick={handleClick}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <span
+        className="habit-dot"
+        style={{ backgroundColor: completed ? '#fff' : habit.color }}
+      />
+      <span className="habit-name">{habit.name}</span>
+      {streak > 1 && <span className="habit-streak">{streak}日継続</span>}
+      {completed && <span className="habit-check">✓</span>}
+    </button>
   )
 }

--- a/src/components/LongPressModal.css
+++ b/src/components/LongPressModal.css
@@ -70,6 +70,27 @@
   cursor: default;
 }
 
+.lp-edit-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 13px;
+  border-radius: var(--radius-sm);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.95rem;
+  font-weight: 600;
+  transition: opacity 0.15s;
+}
+
+.lp-edit-btn:active {
+  opacity: 0.6;
+}
+
 .lp-cancel-btn {
   width: 100%;
   padding: 13px;

--- a/src/components/LongPressModal.jsx
+++ b/src/components/LongPressModal.jsx
@@ -8,6 +8,7 @@ export default function LongPressModal({
   isCompletedToday,
   isCompletedYesterday,
   onSelect,
+  onEdit,
   onClose,
 }) {
   const days = [
@@ -41,6 +42,15 @@ export default function LongPressModal({
           )
         })}
       </div>
+      {onEdit && (
+        <button className="lp-edit-btn" onClick={() => onEdit(habit)}>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+          </svg>
+          習慣を編集
+        </button>
+      )}
       <button className="lp-cancel-btn" onClick={onClose}>
         キャンセル
       </button>

--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -1,6 +1,6 @@
 
 /* フェーズハイライト（実績画面最上部） */
-.record-phase-highlight-section {
+.section.record-phase-highlight-section {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   background: var(--color-primary);

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -23,7 +23,7 @@ export function applyTheme(theme) {
   }
 }
 
-export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onClose, lastBackupDate }) {
+export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate }) {
   return (
     <Modal title="設定" onClose={onClose}>
       <p className="settings-section-title">テーマカラー</p>
@@ -50,6 +50,16 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
             )}
           </button>
         ))}
+      </div>
+
+      <p className="settings-section-title">カテゴリ</p>
+      <div className="data-mgmt-list">
+        <button className="data-mgmt-btn" onClick={onManageCategories}>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" /><line x1="7" y1="7" x2="7.01" y2="7" />
+          </svg>
+          <span>カテゴリを管理</span>
+        </button>
       </div>
 
       <p className="settings-section-title">データ管理</p>

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -3,17 +3,6 @@ import './StatsView.css'
 
 const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
 
-const COLOR_CATEGORY_NAMES = {
-  '#FF6B6B': '生活・日課',
-  '#FF9F43': '社交',
-  '#FECA57': '創作',
-  '#48DBB4': '健康',
-  '#54A0FF': '学習',
-  '#A29BFE': 'ケア',
-  '#FD79A8': 'セルフケア',
-  '#6C5CE7': '集中',
-}
-
 function isHabitActiveOn(habit, dateStr) {
   if (habit.createdAt && dateStr < habit.createdAt) return false
   if (habit.archivedAt && dateStr >= habit.archivedAt) return false
@@ -61,22 +50,19 @@ function calcWeekdayRates(habits, records, today, days = 30) {
   }))
 }
 
-function calcColorStats(habits, records, today) {
+function calcCategoryStats(habits, records, today, categories) {
   const activeHabits = habits.filter(h => !h.archivedAt)
-  const colorGroups = {}
-
-  for (const habit of activeHabits) {
-    if (!colorGroups[habit.color]) colorGroups[habit.color] = []
-    colorGroups[habit.color].push(habit)
-  }
-
-  return Object.entries(colorGroups)
-    .map(([color, groupHabits]) => ({
-      color,
-      name: COLOR_CATEGORY_NAMES[color] || color,
-      count: groupHabits.length,
-      rate: calcRateForRange(groupHabits, records, today, 30),
-    }))
+  return categories
+    .map(cat => {
+      const catHabits = activeHabits.filter(h => h.categoryId === cat.id)
+      return {
+        id: cat.id,
+        name: cat.name,
+        count: catHabits.length,
+        rate: calcRateForRange(catHabits, records, today, 30),
+      }
+    })
+    .filter(c => c.count > 0)
     .sort((a, b) => (b.rate ?? -1) - (a.rate ?? -1))
 }
 
@@ -93,13 +79,13 @@ function getAdvice(rate30) {
   return '少し負担が大きいかもしれません。習慣を小さくするのがおすすめです。'
 }
 
-export default function StatsView({ habits, records, today }) {
+export default function StatsView({ habits, records, today, categories = [] }) {
   const activeHabits = habits.filter(habit => !habit.archivedAt)
   const rate7 = calcRateForRange(habits, records, today, 7)
   const rate30 = calcRateForRange(habits, records, today, 30)
   const weekdayRates = calcWeekdayRates(habits, records, today)
-  const advice = getAdvice(rate30)
-  const colorStats = calcColorStats(habits, records, today)
+  const advice = getAdvice(rate7)
+  const categoryStats = calcCategoryStats(habits, records, today, categories)
 
   if (habits.length === 0) {
     return <p className="analysis-empty">習慣を追加すると、続け方のヒントが表示されます。</p>
@@ -125,25 +111,29 @@ export default function StatsView({ habits, records, today }) {
         </div>
       </div>
 
-      {colorStats.length > 1 && (
+      {categories.length > 0 && (
         <div className="analysis-color">
           <div className="analysis-subhead">
             <span>カテゴリ別達成率</span>
             <small>直近30日</small>
           </div>
-          <div className="analysis-color-list">
-            {colorStats.map(({ color, name, count, rate }) => (
-              <div className="analysis-color-row" key={color}>
-                <span className="analysis-color-dot" style={{ backgroundColor: color }} />
-                <span className="analysis-color-name">{name}</span>
-                <span className="analysis-color-count">{count}件</span>
-                <div className="analysis-weekday-bar">
-                  <span style={{ width: `${rate ?? 0}%`, backgroundColor: color }} />
+          {categoryStats.length === 0 ? (
+            <p className="analysis-note">カテゴリが設定された習慣がありません。習慣の編集からカテゴリを設定できます。</p>
+          ) : (
+            <div className="analysis-color-list">
+              {categoryStats.map(({ id, name, count, rate }) => (
+                <div className="analysis-color-row" key={id}>
+                  <span className="analysis-color-dot" style={{ backgroundColor: 'var(--color-primary)' }} />
+                  <span className="analysis-color-name">{name}</span>
+                  <span className="analysis-color-count">{count}件</span>
+                  <div className="analysis-weekday-bar">
+                    <span style={{ width: `${rate ?? 0}%` }} />
+                  </div>
+                  <span className="analysis-color-rate">{rate !== null ? `${rate}%` : '-'}</span>
                 </div>
-                <span className="analysis-color-rate">{rate !== null ? `${rate}%` : '-'}</span>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/src/hooks/useHabitsStorage.js
+++ b/src/hooks/useHabitsStorage.js
@@ -12,11 +12,15 @@ export function loadData() {
         Array.isArray(data.habits) &&
         data.records && typeof data.records === 'object' && !Array.isArray(data.records)
       ) {
-        return data
+        return {
+          habits: data.habits,
+          records: data.records,
+          categories: Array.isArray(data.categories) ? data.categories : [],
+        }
       }
     }
   } catch {}
-  return { habits: [], records: {} }
+  return { habits: [], records: {}, categories: [] }
 }
 
 const _initial = loadData()
@@ -24,10 +28,11 @@ const _initial = loadData()
 export function useHabitsStorage() {
   const [habits, setHabits] = useState(_initial.habits)
   const [records, setRecords] = useState(_initial.records)
+  const [categories, setCategories] = useState(_initial.categories)
 
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ habits, records }))
-  }, [habits, records])
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ habits, records, categories }))
+  }, [habits, records, categories])
 
-  return { habits, records, setHabits, setRecords }
+  return { habits, records, categories, setHabits, setRecords, setCategories }
 }

--- a/src/hooks/usePullToRefresh.js
+++ b/src/hooks/usePullToRefresh.js
@@ -2,7 +2,7 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 
 export const PULL_THRESHOLD = 80
 
-export function usePullToRefresh({ mainRef, onRefresh }) {
+export function usePullToRefresh({ mainRef, scrollKey, onRefresh }) {
   const [pullY, setPullY] = useState(0)
   const [pullReturning, setPullReturning] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
@@ -32,7 +32,8 @@ export function usePullToRefresh({ mainRef, onRefresh }) {
     scrollEl.addEventListener('scroll', onScroll, { passive: true })
     onScroll()
     return () => scrollEl.removeEventListener('scroll', onScroll)
-  }, [mainRef])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mainRef, scrollKey])
 
   const handleTouchStart = useCallback((e) => {
     // ヘッダー上のタッチはpull-to-refreshを起動しない


### PR DESCRIPTION
## 対応内容

### バグ修正
- **更新中の背景色** pull-indicator の背景を `--color-bg`（グレー）に変更し、アプリ背景と統一
- **実績画面の白カード** `.section.record-phase-highlight-section` の CSS 特異度を上げて白表示を解消
- **スクロール領域** タブパネルごとの独立スクロールを実装。習慣画面の過剰スクロールと達成履歴の表示切れを修正
- **「次の続け方」判定** 直近30日→直近7日の達成率をもとに判定するよう変更（使い始め期間の誤判定を解消）

### UX 改善
- **編集ボタン位置** 習慣カードから編集アイコンを削除し、長押しモーダル内に「習慣を編集」ボタンとして配置

### 新機能
- **ユーザー定義カテゴリ** 設定 → カテゴリ管理 から自由に作成・編集・削除できるカテゴリ機能を追加
  - 習慣の追加・編集時にカテゴリを選択可能
  - 分析画面のカテゴリ別達成率をユーザー定義カテゴリに変更（色ベースの自動割り当てを廃止）

## テスト観点
- [ ] 引っ張り更新後の背景がグレーになっていること
- [ ] 実績タブのフェーズハイライトがインディゴ色で表示されること（白くない）
- [ ] 習慣タブ・実績タブ・分析タブがそれぞれ独立してスクロールすること
- [ ] 達成履歴が最後の行まで見えること
- [ ] 習慣を長押し → 「習慣を編集」ボタンが表示されること
- [ ] 設定 → カテゴリを管理 → カテゴリの追加・編集・削除ができること
- [ ] 習慣追加・編集モーダルでカテゴリが選択できること
- [ ] 分析タブのカテゴリ別達成率がユーザー定義カテゴリで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)