### PR TITLE
fix: 色ベースカテゴリ・PTR修正・セーフエリア対応など8件

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,12 +3,11 @@
   overflow: hidden;
   display: flex;
   flex: 0 0 auto;
-  align-items: flex-end;
+  align-items: center;
   align-self: stretch;
   justify-content: center;
   box-sizing: border-box;
   width: 100%;
-  padding-bottom: 0;
   background: var(--color-bg);
   color: var(--color-primary);
   height: 0;
@@ -16,7 +15,6 @@
 
 .pull-indicator.refreshing {
   height: 60px;
-  padding-bottom: 10px;
   opacity: 1;
   transition: height 0.2s ease, opacity 0.2s ease;
 }
@@ -206,11 +204,23 @@
   min-width: 0;
   flex-direction: column;
   gap: 16px;
-  padding: 12px 16px calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
+  /* padding-top: 20px でoverflow-x: hiddenによるbox-shadow上端クリップを防ぐ */
+  padding: 20px 16px calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
+  scroll-behavior: auto;
+}
+
+@supports (padding-bottom: env(safe-area-inset-bottom)) {
+  .tab-panel {
+    padding-bottom: calc(var(--footer-height) + max(var(--footer-safe-padding), env(safe-area-inset-bottom)) + 16px);
+  }
+
+  .app-footer {
+    padding-bottom: max(var(--footer-safe-padding), env(safe-area-inset-bottom));
+  }
 }
 
 .modal-open .app-main {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,7 +57,7 @@ export default function App() {
     setShowWelcome(false)
   }, [])
 
-  const { habits, records, categories, setHabits, setRecords, setCategories } = useHabitsStorage()
+  const { habits, records, colorCategories, setHabits, setRecords, setColorCategories } = useHabitsStorage()
   const { themeId, handleThemeSelect } = useTheme()
 
   const [calendarDate, setCalendarDate] = useState(() => new Date())
@@ -321,32 +321,23 @@ export default function App() {
     setUndoAction(null)
   }, [undoAction])
 
-  const addHabit = useCallback(({ name, color, categoryId }) => {
+  const addHabit = useCallback(({ name, color }) => {
     const id = `h_${Date.now()}`
-    setHabits(prev => [...prev, { id, name, color, categoryId: categoryId ?? null, createdAt: today }])
+    setHabits(prev => [...prev, { id, name, color, createdAt: today }])
     setModal(null)
     dismissWelcome()
   }, [today, dismissWelcome])
 
-  const updateHabit = useCallback(({ name, color, categoryId }) => {
+  const updateHabit = useCallback(({ name, color }) => {
     setHabits(prev =>
-      prev.map(h => h.id === modal.habit.id ? { ...h, name, color, categoryId: categoryId ?? null } : h)
+      prev.map(h => h.id === modal.habit.id ? { ...h, name, color } : h)
     )
     setModal(null)
   }, [modal])
 
-  const addCategory = useCallback((cat) => {
-    setCategories(prev => [...prev, cat])
-  }, [])
-
-  const updateCategory = useCallback((id, name) => {
-    setCategories(prev => prev.map(c => c.id === id ? { ...c, name } : c))
-  }, [])
-
-  const deleteCategory = useCallback((id) => {
-    setCategories(prev => prev.filter(c => c.id !== id))
-    setHabits(prev => prev.map(h => h.categoryId === id ? { ...h, categoryId: null } : h))
-  }, [])
+  const handleColorCategoriesUpdate = useCallback((updated) => {
+    setColorCategories(updated)
+  }, [setColorCategories])
 
   const deleteHabit = useCallback((habitId) => {
     setHabits(prev => prev.filter(h => h.id !== habitId))
@@ -707,7 +698,7 @@ export default function App() {
                 <div className="section-header">
                   <h2 className="section-title">これからの続け方</h2>
                 </div>
-                <StatsView habits={habits} records={records} today={today} categories={categories} />
+                <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} />
               </section>
             </div>
           </div>
@@ -724,7 +715,7 @@ export default function App() {
       )}
 
       {modal?.type === 'add' && (
-        <AddHabitModal onSave={addHabit} onClose={closeModal} categories={categories} />
+        <AddHabitModal onSave={addHabit} onClose={closeModal} />
       )}
 
       {modal?.type === 'edit' && (
@@ -732,7 +723,6 @@ export default function App() {
           initialHabit={modal.habit}
           onSave={updateHabit}
           onClose={closeModal}
-          categories={categories}
         />
       )}
 
@@ -824,10 +814,8 @@ export default function App() {
 
       {modal?.type === 'categoryManage' && (
         <CategoryManageModal
-          categories={categories}
-          onAdd={addCategory}
-          onUpdate={updateCategory}
-          onDelete={deleteCategory}
+          colorCategories={colorCategories}
+          onUpdate={handleColorCategoriesUpdate}
           onClose={closeModal}
         />
       )}

--- a/src/components/AddHabitModal.jsx
+++ b/src/components/AddHabitModal.jsx
@@ -14,28 +14,16 @@ const COLOR_NAMES = {
   '#6C5CE7': 'パープル',
 }
 
-const COLOR_HINTS = {
-  '#FF6B6B': '生活・日課系',
-  '#FF9F43': '社交・コミュニティ系',
-  '#FECA57': '創作・趣味系',
-  '#48DBB4': '健康・運動系',
-  '#54A0FF': '学習・勉強系',
-  '#A29BFE': 'マインドフル・休息系',
-  '#FD79A8': 'セルフケア系',
-  '#6C5CE7': '集中・スキル系',
-}
-
-export default function AddHabitModal({ onSave, onClose, initialHabit = null, categories = [] }) {
+export default function AddHabitModal({ onSave, onClose, initialHabit = null }) {
   const isEdit = !!initialHabit
   const [name, setName] = useState(initialHabit?.name ?? '')
   const [color, setColor] = useState(initialHabit?.color ?? HABIT_COLORS[0])
-  const [categoryId, setCategoryId] = useState(initialHabit?.categoryId ?? null)
 
   const handleSubmit = (e) => {
     e.preventDefault()
     const trimmed = name.trim()
     if (!trimmed) return
-    onSave({ name: trimmed, color, categoryId })
+    onSave({ name: trimmed, color })
   }
 
   return (
@@ -69,35 +57,7 @@ export default function AddHabitModal({ onSave, onClose, initialHabit = null, ca
               />
             ))}
           </div>
-          {COLOR_HINTS[color] && (
-            <p className="color-hint">おすすめ：{COLOR_HINTS[color]}</p>
-          )}
         </div>
-
-        {categories.length > 0 && (
-          <div className="form-group">
-            <label className="form-label">カテゴリ</label>
-            <div className="category-chips">
-              <button
-                type="button"
-                className={`category-chip${categoryId === null ? ' selected' : ''}`}
-                onClick={() => setCategoryId(null)}
-              >
-                なし
-              </button>
-              {categories.map(cat => (
-                <button
-                  key={cat.id}
-                  type="button"
-                  className={`category-chip${categoryId === cat.id ? ' selected' : ''}`}
-                  onClick={() => setCategoryId(cat.id)}
-                >
-                  {cat.name}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
 
         <div className="preview-row">
           <div

--- a/src/components/CategoryManageModal.css
+++ b/src/components/CategoryManageModal.css
@@ -1,80 +1,35 @@
-.cat-empty {
+.cat-description {
+  font-size: 0.85rem;
   color: var(--color-text-secondary);
-  font-size: 0.88rem;
   line-height: 1.5;
-  padding: 8px 0 16px;
+  margin-bottom: 16px;
 }
 
-.cat-list {
+.cat-color-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin-bottom: 16px;
-  list-style: none;
+  gap: 10px;
+  margin-bottom: 20px;
 }
 
-.cat-item {
-  border-radius: var(--radius-sm);
-  background: var(--color-bg);
-  padding: 10px 12px;
-}
-
-.cat-row {
+.cat-color-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 10px;
 }
 
-.cat-name {
-  font-size: 0.92rem;
-  font-weight: 600;
-  color: var(--color-text);
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.cat-actions {
-  display: flex;
-  gap: 6px;
+.cat-color-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
   flex-shrink: 0;
 }
 
-.cat-edit-btn {
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: var(--color-primary);
-  padding: 3px 10px;
-  border-radius: 20px;
-  border: 1.5px solid var(--color-primary);
-  transition: opacity 0.15s;
-}
-
-.cat-edit-btn:active {
-  opacity: 0.6;
-}
-
-.cat-delete-btn {
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: var(--color-danger);
-  padding: 3px 10px;
-  border-radius: 20px;
-  border: 1.5px solid var(--color-danger);
-  transition: opacity 0.15s;
-}
-
-.cat-delete-btn:active {
-  opacity: 0.6;
-}
-
-.cat-edit-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+.cat-color-label {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  width: 56px;
+  flex-shrink: 0;
 }
 
 .cat-input {
@@ -83,8 +38,9 @@
   padding: 8px 10px;
   border-radius: var(--radius-sm);
   border: 1.5px solid var(--color-border);
-  background: var(--color-surface);
-  font-size: 0.88rem;
+  background: var(--color-bg);
+  /* iOSの自動ズーム防止: font-size >= 16px */
+  font-size: 16px;
   color: var(--color-text);
   outline: none;
   -webkit-user-select: text;
@@ -95,51 +51,17 @@
   border-color: var(--color-primary);
 }
 
-.cat-save-btn {
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: #fff;
-  background: var(--color-primary);
-  padding: 6px 12px;
-  border-radius: 20px;
-  flex-shrink: 0;
-  transition: opacity 0.15s;
-}
-
-.cat-save-btn:disabled {
-  opacity: 0.4;
-}
-
-.cat-cancel-btn {
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: var(--color-text-secondary);
-  padding: 6px 10px;
-  flex-shrink: 0;
-  transition: opacity 0.15s;
-}
-
-.cat-add-row {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.cat-add-btn {
-  font-size: 0.88rem;
-  font-weight: 600;
-  color: #fff;
-  background: var(--color-primary);
-  padding: 10px 16px;
+.cat-save-all-btn {
+  width: 100%;
+  padding: 13px;
   border-radius: var(--radius-sm);
-  flex-shrink: 0;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
   transition: opacity 0.15s;
 }
 
-.cat-add-btn:disabled {
-  opacity: 0.4;
-}
-
-.cat-add-btn:active {
-  opacity: 0.7;
+.cat-save-all-btn:active {
+  opacity: 0.8;
 }

--- a/src/components/CategoryManageModal.jsx
+++ b/src/components/CategoryManageModal.jsx
@@ -1,83 +1,56 @@
 import { useState } from 'react'
 import Modal from './Modal'
+import { HABIT_COLORS } from '../utils/date'
 import './CategoryManageModal.css'
 
-export default function CategoryManageModal({ categories, onAdd, onUpdate, onDelete, onClose }) {
-  const [newName, setNewName] = useState('')
-  const [editingId, setEditingId] = useState(null)
-  const [editingName, setEditingName] = useState('')
+const COLOR_NAMES = {
+  '#FF6B6B': 'レッド',
+  '#FF9F43': 'オレンジ',
+  '#FECA57': 'イエロー',
+  '#48DBB4': 'グリーン',
+  '#54A0FF': 'ブルー',
+  '#A29BFE': 'ラベンダー',
+  '#FD79A8': 'ピンク',
+  '#6C5CE7': 'パープル',
+}
 
-  const handleAdd = () => {
-    const name = newName.trim()
-    if (!name) return
-    onAdd({ id: `cat_${Date.now()}`, name })
-    setNewName('')
+export default function CategoryManageModal({ colorCategories, onUpdate, onClose }) {
+  const [draft, setDraft] = useState({ ...colorCategories })
+
+  const handleChange = (color, value) => {
+    setDraft(prev => ({ ...prev, [color]: value }))
   }
 
-  const handleUpdate = (id) => {
-    const name = editingName.trim()
-    if (!name) return
-    onUpdate(id, name)
-    setEditingId(null)
-  }
-
-  const startEdit = (cat) => {
-    setEditingId(cat.id)
-    setEditingName(cat.name)
+  const handleSave = () => {
+    const cleaned = Object.fromEntries(
+      Object.entries(draft).filter(([, v]) => v.trim() !== '')
+    )
+    onUpdate(cleaned)
+    onClose()
   }
 
   return (
     <Modal title="カテゴリ管理" onClose={onClose}>
-      {categories.length === 0 ? (
-        <p className="cat-empty">まだカテゴリがありません。下から追加してください。</p>
-      ) : (
-        <ul className="cat-list">
-          {categories.map(cat => (
-            <li key={cat.id} className="cat-item">
-              {editingId === cat.id ? (
-                <div className="cat-edit-row">
-                  <input
-                    className="cat-input"
-                    value={editingName}
-                    onChange={e => setEditingName(e.target.value)}
-                    onKeyDown={e => { if (e.key === 'Enter') handleUpdate(cat.id) }}
-                    autoFocus
-                    maxLength={20}
-                  />
-                  <button className="cat-save-btn" onClick={() => handleUpdate(cat.id)} disabled={!editingName.trim()}>
-                    保存
-                  </button>
-                  <button className="cat-cancel-btn" onClick={() => setEditingId(null)}>
-                    キャンセル
-                  </button>
-                </div>
-              ) : (
-                <div className="cat-row">
-                  <span className="cat-name">{cat.name}</span>
-                  <div className="cat-actions">
-                    <button className="cat-edit-btn" onClick={() => startEdit(cat)}>編集</button>
-                    <button className="cat-delete-btn" onClick={() => onDelete(cat.id)}>削除</button>
-                  </div>
-                </div>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
-
-      <div className="cat-add-row">
-        <input
-          className="cat-input"
-          value={newName}
-          onChange={e => setNewName(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter') handleAdd() }}
-          placeholder="新しいカテゴリ名"
-          maxLength={20}
-        />
-        <button className="cat-add-btn" onClick={handleAdd} disabled={!newName.trim()}>
-          追加
-        </button>
+      <p className="cat-description">色ごとにカテゴリ名を設定できます。名前をつけた色は分析画面でグループ表示されます。</p>
+      <div className="cat-color-list">
+        {HABIT_COLORS.map(color => (
+          <div key={color} className="cat-color-row">
+            <span className="cat-color-swatch" style={{ backgroundColor: color }} />
+            <span className="cat-color-label">{COLOR_NAMES[color]}</span>
+            <input
+              className="cat-input"
+              type="text"
+              value={draft[color] ?? ''}
+              onChange={e => handleChange(color, e.target.value)}
+              placeholder="カテゴリ名（任意）"
+              maxLength={20}
+            />
+          </div>
+        ))}
       </div>
+      <button className="cat-save-all-btn" onClick={handleSave}>
+        保存する
+      </button>
     </Modal>
   )
 }

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -84,7 +84,7 @@ export default function RecordView({
           <div className="phase-highlight-streak">{featured.streak > 0 ? `${featured.streak}日継続中` : '今日から始めよう'}</div>
           {featured.phase.daysToNext !== null && (
             <div className="phase-highlight-next">
-              {featured.phase.next}まであと{featured.phase.daysToNext}日
+              あと{featured.phase.daysToNext}日続けると「{featured.phase.next}」へ
             </div>
           )}
           {featured.streak > 0 && (
@@ -134,7 +134,7 @@ export default function RecordView({
                         <span className="phase-habit-name">{habit.name}</span>
                         {streak > 0 && <span className="phase-habit-streak">{streak}日継続中</span>}
                         {phase.daysToNext !== null && (
-                          <span className="phase-habit-next">{phase.next}まであと{phase.daysToNext}日</span>
+                          <span className="phase-habit-next">あと{phase.daysToNext}日で「{phase.next}」へ</span>
                         )}
                       </div>
                     </div>

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -1,4 +1,4 @@
-import { formatDate, parseLocalDate } from '../utils/date'
+import { formatDate, parseLocalDate, HABIT_COLORS } from '../utils/date'
 import './StatsView.css'
 
 const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
@@ -50,16 +50,17 @@ function calcWeekdayRates(habits, records, today, days = 30) {
   }))
 }
 
-function calcCategoryStats(habits, records, today, categories) {
+function calcColorStats(habits, records, today, colorCategories) {
   const activeHabits = habits.filter(h => !h.archivedAt)
-  return categories
-    .map(cat => {
-      const catHabits = activeHabits.filter(h => h.categoryId === cat.id)
+  return HABIT_COLORS
+    .filter(color => colorCategories[color]?.trim())
+    .map(color => {
+      const colorHabits = activeHabits.filter(h => h.color === color)
       return {
-        id: cat.id,
-        name: cat.name,
-        count: catHabits.length,
-        rate: calcRateForRange(catHabits, records, today, 30),
+        color,
+        name: colorCategories[color],
+        count: colorHabits.length,
+        rate: calcRateForRange(colorHabits, records, today, 30),
       }
     })
     .filter(c => c.count > 0)
@@ -79,13 +80,14 @@ function getAdvice(rate30) {
   return '少し負担が大きいかもしれません。習慣を小さくするのがおすすめです。'
 }
 
-export default function StatsView({ habits, records, today, categories = [] }) {
+export default function StatsView({ habits, records, today, colorCategories = {} }) {
   const activeHabits = habits.filter(habit => !habit.archivedAt)
   const rate7 = calcRateForRange(habits, records, today, 7)
   const rate30 = calcRateForRange(habits, records, today, 30)
   const weekdayRates = calcWeekdayRates(habits, records, today)
   const advice = getAdvice(rate7)
-  const categoryStats = calcCategoryStats(habits, records, today, categories)
+  const colorStats = calcColorStats(habits, records, today, colorCategories)
+  const hasNamedColors = Object.values(colorCategories).some(v => v?.trim())
 
   if (habits.length === 0) {
     return <p className="analysis-empty">習慣を追加すると、続け方のヒントが表示されます。</p>
@@ -111,19 +113,19 @@ export default function StatsView({ habits, records, today, categories = [] }) {
         </div>
       </div>
 
-      {categories.length > 0 && (
+      {hasNamedColors && (
         <div className="analysis-color">
           <div className="analysis-subhead">
             <span>カテゴリ別達成率</span>
             <small>直近30日</small>
           </div>
-          {categoryStats.length === 0 ? (
-            <p className="analysis-note">カテゴリが設定された習慣がありません。習慣の編集からカテゴリを設定できます。</p>
+          {colorStats.length === 0 ? (
+            <p className="analysis-note">カテゴリが設定された色の習慣がありません。</p>
           ) : (
             <div className="analysis-color-list">
-              {categoryStats.map(({ id, name, count, rate }) => (
-                <div className="analysis-color-row" key={id}>
-                  <span className="analysis-color-dot" style={{ backgroundColor: 'var(--color-primary)' }} />
+              {colorStats.map(({ color, name, count, rate }) => (
+                <div className="analysis-color-row" key={color}>
+                  <span className="analysis-color-dot" style={{ backgroundColor: color }} />
                   <span className="analysis-color-name">{name}</span>
                   <span className="analysis-color-count">{count}件</span>
                   <div className="analysis-weekday-bar">

--- a/src/hooks/useHabitsStorage.js
+++ b/src/hooks/useHabitsStorage.js
@@ -15,12 +15,16 @@ export function loadData() {
         return {
           habits: data.habits,
           records: data.records,
-          categories: Array.isArray(data.categories) ? data.categories : [],
+          colorCategories: (
+            data.colorCategories &&
+            typeof data.colorCategories === 'object' &&
+            !Array.isArray(data.colorCategories)
+          ) ? data.colorCategories : {},
         }
       }
     }
   } catch {}
-  return { habits: [], records: {}, categories: [] }
+  return { habits: [], records: {}, colorCategories: {} }
 }
 
 const _initial = loadData()
@@ -28,11 +32,11 @@ const _initial = loadData()
 export function useHabitsStorage() {
   const [habits, setHabits] = useState(_initial.habits)
   const [records, setRecords] = useState(_initial.records)
-  const [categories, setCategories] = useState(_initial.categories)
+  const [colorCategories, setColorCategories] = useState(_initial.colorCategories)
 
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ habits, records, categories }))
-  }, [habits, records, categories])
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ habits, records, colorCategories }))
+  }, [habits, records, colorCategories])
 
-  return { habits, records, categories, setHabits, setRecords, setCategories }
+  return { habits, records, colorCategories, setHabits, setRecords, setColorCategories }
 }


### PR DESCRIPTION
## 変更内容

- **色ヒント削除**: AddHabitModal から「おすすめ：健康・運動系」等のヒント表示を削除
- **色ベースカテゴリに刷新**: `categoryId`（習慣ごと）→ `colorCategories: { '#hex': 'name' }`（色ごと）
  - CategoryManageModal を8色スウォッチ＋テキスト入力の一覧に書き直し
  - StatsView は `habit.color` でグループ化し `colorCategories[color]` を使用
- **iOS自動ズーム防止**: `.cat-input` の `font-size` を 16px に
- **日本語修正**: 「〇〇まであと5日」→「あと5日続けると『〇〇』へ」
- **PWAフッター重なり修正**: `env(safe-area-inset-bottom)` を `@supports` ブロックで適用
- **カード頭切れ修正**: `.tab-panel` の `padding-top` を 12px → 20px に増加
- **PTRテキスト位置ズレ修正**: `align-items: flex-end → center`、`padding-bottom` を除去
- **習慣追加時のアニメーション修正**: `.tab-panel` に `scroll-behavior: auto` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)