### PR TITLE
fix: フェーズハイライトカードの上側角丸を復元

### DIFF
--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -1,8 +1,6 @@
 
 /* フェーズハイライト（実績画面最上部） */
 .section.record-phase-highlight-section {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
   background: var(--color-primary);
   color: #fff;
   display: flex;


### PR DESCRIPTION
## 変更内容

`RecordView.css` に `border-top-left-radius: 0; border-top-right-radius: 0;` が残っていたため、フェーズハイライトカード（「日常に馴染んできた」等）の上側2角が直角になっていた。

以前は全幅バナーとして上端をヘッダーに接続するデザインだったが、パネル独立スクロール化後はカードが浮いた状態になるため、4隅すべて `border-radius: var(--radius)` で統一する。

## 修正
- `border-top-left-radius: 0` を削除
- `border-top-right-radius: 0` を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)