### PR TITLE
fix: iPhoneでフッターとコンテンツが被る問題を修正

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -205,22 +205,19 @@
   flex-direction: column;
   gap: 16px;
   /* padding-top: 20px でoverflow-x: hiddenによるbox-shadow上端クリップを防ぐ */
-  padding: 20px 16px calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
+  /* --app-screen-height が viewport+env(safe-area-inset-bottom) 分高いため、
+     tab-panelもその分余分にスクロールできる。padding-bottomにenv分を2回加算して補正する */
+  padding: 20px 16px calc(
+    var(--footer-height) +
+    max(var(--footer-safe-padding), var(--app-safe-area-bottom)) +
+    var(--app-safe-area-bottom) +
+    16px
+  );
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   scroll-behavior: auto;
-}
-
-@supports (padding-bottom: env(safe-area-inset-bottom)) {
-  .tab-panel {
-    padding-bottom: calc(var(--footer-height) + max(var(--footer-safe-padding), env(safe-area-inset-bottom)) + 16px);
-  }
-
-  .app-footer {
-    padding-bottom: max(var(--footer-safe-padding), env(safe-area-inset-bottom));
-  }
 }
 
 .modal-open .app-main {
@@ -397,7 +394,7 @@
   background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-  padding-bottom: var(--footer-safe-padding);
+  padding-bottom: max(var(--footer-safe-padding), var(--app-safe-area-bottom));
   z-index: 20;
   touch-action: none;
 }


### PR DESCRIPTION
## 原因

`--app-screen-height: calc(100svh + env(safe-area-inset-bottom))` によりアプリ全体がビューポートより `env(safe-area-inset-bottom)`（iPhone X以降で約34px）分だけ背高になっている。そのため tab-panel のスクロール底辺もビューポート外に出てしまい、最下部コンテンツがフッターの裏に潜り込んでいた。

## 修正

`padding-bottom` に `env(safe-area-inset-bottom)` を2回分加算して補正。

```
before: footer_h + max(safe_padding, env) + 16px  →  110px (iPhone X)
after:  footer_h + max(safe_padding, env) + env + 16px  →  144px (iPhone X)
```

- `.tab-panel` padding-bottom を上記式に更新（`--app-safe-area-bottom` を使用）
- `.app-footer` padding-bottom を `max(--footer-safe-padding, --app-safe-area-bottom)` に更新
- 不要になった `@supports env(safe-area-inset-bottom)` ブロックを削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)