### PR TITLE
refactor: Safe Area / footer / keyboard の恒久対応

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -73,9 +73,10 @@
 
 .app {
   --app-header-height: calc(56px + var(--app-safe-area-top));
-  --footer-height: 60px;
+  --footer-content-height: 60px;
   --footer-safe-padding: 10px;
-  --footer-browser-shift: 10px;
+  --footer-safe-bottom: max(var(--footer-safe-padding), var(--app-safe-area-bottom));
+  --footer-total-height: calc(var(--footer-content-height) + var(--footer-safe-bottom));
   height: var(--app-screen-height);
   display: flex;
   flex-direction: column;
@@ -104,7 +105,6 @@
 @supports (-webkit-touch-callout: none) {
   .app {
     --footer-safe-padding: 20px;
-    --footer-browser-shift: 8px;
   }
 }
 
@@ -205,7 +205,7 @@
   flex-direction: column;
   gap: 16px;
   /* padding-top: 20px でoverflow-x: hiddenによるbox-shadow上端クリップを防ぐ */
-  padding: 20px 16px calc(var(--footer-height) + var(--footer-safe-padding) + 16px);
+  padding: 20px 16px calc(var(--footer-total-height) + 16px);
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior-y: contain;
@@ -213,15 +213,6 @@
   scroll-behavior: auto;
 }
 
-@supports (padding-bottom: env(safe-area-inset-bottom)) {
-  .tab-panel {
-    padding-bottom: calc(var(--footer-height) + max(var(--footer-safe-padding), env(safe-area-inset-bottom)) + 16px);
-  }
-
-  .app-footer {
-    padding-bottom: max(var(--footer-safe-padding), env(safe-area-inset-bottom));
-  }
-}
 
 .modal-open .app-main {
   overflow: hidden;
@@ -397,29 +388,21 @@
   background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-  padding-bottom: var(--footer-safe-padding);
+  padding-bottom: var(--footer-safe-bottom);
   z-index: 20;
   touch-action: none;
-}
-
-.app.browser .app-footer {
-  transform: translateY(var(--footer-browser-shift));
-}
-
-.app.standalone .app-footer {
-  transform: none;
 }
 
 .app-footer-inner {
   display: flex;
   align-items: center;
   justify-content: space-around;
-  height: var(--footer-height);
+  height: var(--footer-content-height);
 }
 
 .undo-toast {
   position: fixed;
-  bottom: calc(var(--footer-height) + var(--footer-safe-padding) + 12px);
+  bottom: calc(var(--footer-total-height) + 12px);
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -174,16 +174,12 @@ export default function App() {
       const visualViewport = window.visualViewport
       const currentWidth = Math.round(visualViewport?.width || window.innerWidth)
       const currentHeight = visualViewport?.height || window.innerHeight
-      const activeElement = document.activeElement
-      const inputFocused = activeElement?.matches?.('input, textarea, [contenteditable="true"]')
 
       if (Math.abs(currentWidth - stableViewportRef.current.width) > 40) {
         stableViewportRef.current = { width: currentWidth, height: 0 }
       }
 
-      const height = inputFocused
-        ? currentHeight
-        : Math.max(stableViewportRef.current.height, currentHeight)
+      const height = Math.max(stableViewportRef.current.height, currentHeight)
 
       stableViewportRef.current = { width: currentWidth, height }
       document.documentElement.style.setProperty('--app-viewport-height', `${height}px`)

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -1,7 +1,6 @@
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  height: var(--app-screen-height);
   background: rgba(0, 0, 0, 0.45);
   z-index: 100;
   display: flex;

--- a/src/index.css
+++ b/src/index.css
@@ -15,7 +15,7 @@ input, textarea, [contenteditable] {
   --app-safe-area-top: env(safe-area-inset-top, 0px);
   --app-safe-area-bottom: env(safe-area-inset-bottom, 0px);
   --app-viewport-height: 100svh;
-  --app-screen-height: calc(var(--app-viewport-height) + var(--app-safe-area-bottom));
+  --app-screen-height: var(--app-viewport-height);
   --color-bg: #F0F2F5;
   --color-surface: #FFFFFF;
   --color-primary: #6366F1;


### PR DESCRIPTION
## 概要

#165 の暫定対応で残っていた「safe-area-bottom の二重加算」「footer transform 補正」「キーボード時の app shell 縮小」を根本から整理します。

## 変更内容

### --app-screen-height の修正（index.css）
- viewport-height + safe-area-bottom から viewport-height のみに変更
- アプリ全体の高さを viewport と一致させる

### footer 高さ変数の整理（App.css）
- --footer-content-height: 60px（コンテンツ部の高さ）
- --footer-safe-bottom: max(--footer-safe-padding, --app-safe-area-bottom)（下余白）
- --footer-total-height: --footer-content-height + --footer-safe-bottom（footer 実高さ）
- safe-area の責務を footer 内部余白に集約し、二重加算を解消

### .tab-panel padding-bottom の簡略化（App.css）
- --footer-total-height + 16px のみに統一
- @supports による safe-area 二重加算ブロックを削除

### browser モード footer transform 廃止（App.css）
- .app.browser .app-footer の transform: translateY(...) を削除
- padding / bottom の計算で統一

### modal backdrop の高さ修正（Modal.css）
- height: --app-screen-height を削除
- position: fixed; inset: 0 で viewport を自然に覆う

### キーボード表示時の app shell 縮小を防止（App.jsx）
- inputFocused による分岐を除去
- 常に stable max height を使用し、キーボード表示時に app shell が縮まないようにする

## 関連
- #165 の暫定対応に続く恒久対応