### PR TITLE
fix: App.cssコンフリクトマーカー除去・下余白変数の整理

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -77,6 +77,7 @@
   --footer-safe-padding: 10px;
   --footer-safe-bottom: max(var(--footer-safe-padding), var(--app-safe-area-bottom));
   --footer-total-height: calc(var(--footer-content-height) + var(--footer-safe-bottom));
+  --content-bottom-breathing: 24px;
   height: var(--app-screen-height);
   display: flex;
   flex-direction: column;
@@ -106,6 +107,10 @@
   .app {
     --footer-safe-padding: 20px;
   }
+}
+
+.app.standalone {
+  --content-bottom-breathing: 32px;
 }
 
 .app-header {
@@ -205,7 +210,7 @@
   flex-direction: column;
   gap: 16px;
   /* padding-top: 20px でoverflow-x: hiddenによるbox-shadow上端クリップを防ぐ */
-  padding: 20px 16px calc(var(--footer-total-height) + 16px);
+  padding: 20px 16px calc(var(--footer-total-height) + var(--content-bottom-breathing));
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior-y: contain;
@@ -388,11 +393,7 @@
   background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-<<<<<<< HEAD
   padding-bottom: var(--footer-safe-bottom);
-=======
-  padding-bottom: max(var(--footer-safe-padding), var(--app-safe-area-bottom));
->>>>>>> origin/main
   z-index: 20;
   touch-action: none;
 }


### PR DESCRIPTION
## 概要

#166 マージ後に残ったコンフリクトマーカーの除去と下余白変数の整理。

## 変更内容

### コンフリクトマーカー除去（App.css）
- .app-footer の padding-bottom にマーカーが文字列として残っていたため除去
- padding-bottom: var(--footer-safe-bottom) に統一

### --content-bottom-breathing の導入（App.css）
- browser モード: 24px
- standalone（PWA）モード: 32px
- safe-area の二重加算をせず、見た目の余白を別変数で管理

### .tab-panel padding-bottom の更新（App.css）
- calc(--footer-total-height + --content-bottom-breathing) に変更

## 関連
- #166 の後続修正