### PR TITLE
fix: 下端判定による縦スクロール抑止を解消

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -150,12 +150,11 @@ export default function App() {
     const handleMainTouchMove = (e) => {
       if (e.touches.length !== 1) return
 
+      // 上端で引き下げ（pull-to-refresh）のみ防ぐ。
+      // 下端は overscroll-behavior-y: contain に任せる（atBottom 判定は浮動小数点ズレで誤検知しやすい）
       const deltaY = e.touches[0].clientY - touchStartY
       const atTop = scrollEl.scrollTop <= 0
-      const atBottom =
-        scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - 1
-
-      if ((atTop && deltaY > 0) || (atBottom && deltaY < 0)) {
+      if (atTop && deltaY > 0) {
         e.preventDefault()
       }
     }


### PR DESCRIPTION
## 概要

分析画面（分析タブ）で縦スクロールができない問題を修正。

## 原因

`handleMainTouchMove` 内の `atBottom` 判定が早すぎることで、上スワイプ（下方向スクロール）が `preventDefault()` でブロックされていた。

- `scrollHeight - clientHeight` が浮動小数点の差で 1px 未満になると `atBottom = true` と誤判定
- 結果として、スクロール可能なはずの状態で上スワイプが無効化された

## 修正内容

- `atBottom && deltaY < 0` での `preventDefault()` を削除
- 底端のオーバースクロール防止は `overscroll-behavior-y: contain` に委譲
- 上端の `preventDefault`（pull-to-refresh 用）は維持

## 関連
- #167 の後続修正