### PR TITLE
fix: 分析画面の縦スクロール不能を修正（touch-action + verticalGestureRef）

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -196,7 +196,6 @@
   display: flex;
   height: 100%;
   will-change: transform;
-  touch-action: pan-y;
 }
 
 .tab-track.settling {
@@ -216,6 +215,7 @@
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   scroll-behavior: auto;
+  touch-action: pan-y;
 }
 
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,6 +83,7 @@ export default function App() {
   const fileInputRef = useRef(null)
   const stableViewportRef = useRef({ width: window.innerWidth, height: 0 })
   const tabSwipeRef = useRef(null)
+  const verticalGestureRef = useRef(false)
 
   const today = getToday()
   const yesterday = getYesterday()
@@ -260,6 +261,7 @@ export default function App() {
 
     if (Math.abs(dy) > 18 && Math.abs(dy) > Math.abs(dx)) {
       tabSwipeRef.current = null
+      verticalGestureRef.current = true
     }
 
     return false
@@ -471,11 +473,14 @@ export default function App() {
   }, [])
 
   const handleAppTouchStart = useCallback((e) => {
+    verticalGestureRef.current = false
     handleTabSwipeStart(e)
     handleTouchStart(e)
   }, [handleTabSwipeStart, handleTouchStart])
 
   const handleAppTouchMove = useCallback((e) => {
+    // 縦スクロール確定後はブラウザのネイティブスクロールに完全に委ねる
+    if (verticalGestureRef.current) return
     const swipingTabs = handleTabSwipeMove(e)
     if (!swipingTabs) handleTouchMove(e)
   }, [handleTabSwipeMove, handleTouchMove])


### PR DESCRIPTION
## 概要

iPhone Safari（PWA・通常ブラウザ両方）で分析画面の縦スクロールができない問題を修正。

## 原因

2点の干渉が重なっていた。

### 1. `touch-action: pan-y` の位置が不適切（App.css）
`.tab-track`（スクロールしない親コンテナ）に `touch-action: pan-y` を設定していたため、
iOS Safari が `.tab-panel` のネイティブスクロールを正しく認識できなかった可能性がある。

### 2. 縦スクロール確定後も親の onTouchMove が走り続けていた（App.jsx）
縦方向の動きが確定した後も `handleAppTouchMove` 内で
`handleTabSwipeMove` + `handleTouchMove`（pull-to-refresh）が呼ばれ続けており、
iOS Safari のネイティブスクロールの判断を阻害していた可能性がある。

## 修正内容

**App.css**
- `touch-action: pan-y` を `.tab-track` から削除し `.tab-panel` へ移動
  → スクロールコンテナ自身に縦スクロール意図を明示

**App.jsx**
- `verticalGestureRef` を追加
- 縦方向の動きが確定（dy > 18 かつ dy > dx）した時点でフラグを立て、
  以降の `handleAppTouchMove` では処理を完全スキップ
  → pull-to-refresh・横スワイプ判定がネイティブ縦スクロールを阻害しない

## 確認ポイント
- 分析画面で上スワイプして下部までスクロールできること
- 習慣・実績画面の縦スクロールが壊れていないこと
- 横スワイプでのタブ移動が動くこと
- pull-to-refresh が上端で動くこと

## 関連
- #168 の後続修正