### PR TITLE
fix: verticalGestureRef が pull-to-refresh を止める問題を修正

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -479,8 +479,12 @@ export default function App() {
   }, [handleTabSwipeStart, handleTouchStart])
 
   const handleAppTouchMove = useCallback((e) => {
-    // 縦スクロール確定後はブラウザのネイティブスクロールに完全に委ねる
-    if (verticalGestureRef.current) return
+    if (verticalGestureRef.current) {
+      // 縦スクロール確定後も、上端での下スワイプは pull-to-refresh へ渡す
+      const atTop = !scrollRef.current || scrollRef.current.scrollTop <= 0
+      if (atTop) handleTouchMove(e)
+      return
+    }
     const swipingTabs = handleTabSwipeMove(e)
     if (!swipingTabs) handleTouchMove(e)
   }, [handleTabSwipeMove, handleTouchMove])


### PR DESCRIPTION
## 概要

#169 で導入した `verticalGestureRef` が pull-to-refresh まで止めていた問題を修正。

## 原因

`verticalGestureRef.current = true` になると `handleAppTouchMove` が早期 return するため、
上端での下スワイプ（pull-to-refresh）も `handleTouchMove` に渡らなくなっていた。

## 修正内容

`verticalGestureRef.current = true` の状態でも、
上端（scrollTop <= 0）での touchmove は `handleTouchMove` へ渡す例外を追加。

```js
if (verticalGestureRef.current) {
  const atTop = !scrollRef.current || scrollRef.current.scrollTop <= 0
  if (atTop) handleTouchMove(e)  // pull-to-refresh のみ通す
  return
}
```

`handleTouchMove` 内部で dy の方向チェック（dy > 0 = 下スワイプ）を行うため、
上端でも上スワイプ時は即キャンセルされる。

## 期待する挙動
- 上スワイプ → 縦スクロール（ネイティブ）
- 上端で下スワイプ → pull-to-refresh
- 横スワイプ → タブ移動

## 関連
- #169 の後続修正