### PR TITLE
fix: .tab-panel に height:100%/min-height:0 を追加しスクロールを成立させる

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -205,7 +205,9 @@
 .tab-panel {
   display: flex;
   flex: 0 0 calc(100% / 3);
+  height: 100%;
   min-width: 0;
+  min-height: 0;
   flex-direction: column;
   gap: 16px;
   /* padding-top: 20px でoverflow-x: hiddenによるbox-shadow上端クリップを防ぐ */


### PR DESCRIPTION
## 概要

分析画面の縦スクロールが成立しない根本原因を修正。

## 原因

`.tab-panel` は flex アイテム（`.tab-track` の子）だが、
`min-height` のデフォルトが `auto` のためコンテンツの高さに合わせて縦に伸びてしまっていた。
結果として `scrollHeight === clientHeight` となり、`overflow-y: auto` によるスクロールが機能しない状態だった。

## 修正内容

`.tab-panel` に以下を追加：

```css
height: 100%;    /* 親（.tab-track）の高さに拘束 */
min-height: 0;   /* flex アイテムの収縮を許可 */
```

## 効果確認（プレビュー）

修正前：stats パネル `scrollHeight: 920 === clientHeight: 920`（スクロール不可）
修正後：stats パネル `scrollHeight: 1057 > clientHeight: 920`（スクロール可能）

## 関連
- #169 / #170 の後続修正