### PR TITLE
fix: 分析画面を複数section構造に変更してiOSスクロールを修正

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -704,12 +704,7 @@ export default function App() {
             </div>
 
             <div className="tab-panel" ref={statsPanelRef} aria-hidden={activeTab !== 'stats'}>
-              <section className="section">
-                <div className="section-header">
-                  <h2 className="section-title">これからの続け方</h2>
-                </div>
-                <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} />
-              </section>
+              <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} />
             </div>
           </div>
         </div>

--- a/src/components/StatsView.css
+++ b/src/components/StatsView.css
@@ -6,12 +6,6 @@
   text-align: center;
 }
 
-.analysis-content {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
 .analysis-advice {
   padding: 14px;
   border-radius: var(--radius-sm);
@@ -37,6 +31,7 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
+  margin-top: 14px;
 }
 
 .analysis-rate-card {
@@ -68,12 +63,6 @@
   color: var(--color-text-secondary);
   font-size: 0.78rem;
   font-weight: 700;
-}
-
-.analysis-weekday {
-  padding: 14px;
-  border-radius: var(--radius-sm);
-  background: var(--color-bg);
 }
 
 .analysis-subhead {
@@ -121,7 +110,7 @@
   overflow: hidden;
   height: 8px;
   border-radius: 999px;
-  background: var(--color-surface);
+  background: var(--color-bg);
 }
 
 .analysis-weekday-bar span {
@@ -131,17 +120,10 @@
   background: var(--color-primary);
 }
 
-.analysis-color {
-  padding: 14px;
-  border-radius: var(--radius-sm);
-  background: var(--color-bg);
-}
-
 .analysis-color-list {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin-top: 12px;
 }
 
 .analysis-color-row {

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -94,27 +94,31 @@ export default function StatsView({ habits, records, today, colorCategories = {}
   }
 
   return (
-    <div className="analysis-content">
-      <div className="analysis-advice">
-        <span className="analysis-advice-label">次の続け方</span>
-        <p>{advice}</p>
-      </div>
-
-      <div className="analysis-rate-grid">
-        <div className="analysis-rate-card">
-          <span className="analysis-rate-value">{rate7 ?? '-'}</span>
-          {rate7 !== null && <span className="analysis-rate-unit">%</span>}
-          <span className="analysis-rate-label">直近7日</span>
+    <>
+      <section className="section">
+        <div className="section-header">
+          <h2 className="section-title">これからの続け方</h2>
         </div>
-        <div className="analysis-rate-card">
-          <span className="analysis-rate-value">{rate30 ?? '-'}</span>
-          {rate30 !== null && <span className="analysis-rate-unit">%</span>}
-          <span className="analysis-rate-label">直近30日</span>
+        <div className="analysis-advice">
+          <span className="analysis-advice-label">次の続け方</span>
+          <p>{advice}</p>
         </div>
-      </div>
+        <div className="analysis-rate-grid">
+          <div className="analysis-rate-card">
+            <span className="analysis-rate-value">{rate7 ?? '-'}</span>
+            {rate7 !== null && <span className="analysis-rate-unit">%</span>}
+            <span className="analysis-rate-label">直近7日</span>
+          </div>
+          <div className="analysis-rate-card">
+            <span className="analysis-rate-value">{rate30 ?? '-'}</span>
+            {rate30 !== null && <span className="analysis-rate-unit">%</span>}
+            <span className="analysis-rate-label">直近30日</span>
+          </div>
+        </div>
+      </section>
 
       {hasNamedColors && (
-        <div className="analysis-color">
+        <section className="section">
           <div className="analysis-subhead">
             <span>カテゴリ別達成率</span>
             <small>直近30日</small>
@@ -136,10 +140,10 @@ export default function StatsView({ habits, records, today, colorCategories = {}
               ))}
             </div>
           )}
-        </div>
+        </section>
       )}
 
-      <div className="analysis-weekday">
+      <section className="section">
         <div className="analysis-subhead">
           <span>曜日別達成率</span>
           <small>直近30日</small>
@@ -155,11 +159,11 @@ export default function StatsView({ habits, records, today, colorCategories = {}
             </div>
           ))}
         </div>
-      </div>
+      </section>
 
-      <div className="analysis-note">
+      <p className="analysis-note">
         今の対象習慣は {activeHabits.length} 件です。達成率は、その日に対象だった習慣だけで計算しています。
-      </div>
-    </div>
+      </p>
+    </>
   )
 }


### PR DESCRIPTION
## 問題

分析画面だけ上スワイプで下の内容が見られない。実績画面は正常にスクロールできる。

## 原因

構造の差異が原因。

| タブ | 構造 |
|------|------|
| 実績 | `.tab-panel` → `RecordView` (複数の `section.section` をフラグメントで返す) |
| 分析 | `.tab-panel` → `section.section` (単一) → `.analysis-content` → 各ブロック |

iOS Safariは単一の大きなflex itemでネストが深い場合、scroll高さ計算が崩れることがある。

## 修正

`StatsView` を `RecordView` と同じ構造（フラグメント + 複数 `section.section`）に統一。

```
変更前: .tab-panel > section.section(1つ) > .analysis-content > 各ブロック
変更後: .tab-panel > section.section × 3 + p
```

- `App.jsx`: stats パネルの外側 `section.section` ラッパーを除去
- `StatsView.jsx`: Fragment で複数 section を返す構造に変更
  - section 1: これからの続け方 + 達成率カード (7日・30日)
  - section 2: カテゴリ別達成率 (conditional)
  - section 3: 曜日別達成率
- `StatsView.css`: `.analysis-content` / `.analysis-color` / `.analysis-weekday` のカード用スタイルを整理（`.section` に統合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)