### PR TITLE
fix: touch-action:pan-yでiOSスクロールブロックを根本解消

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -190,6 +190,9 @@
   overflow: hidden;
   height: 100%;
   background: var(--color-bg);
+  /* CSSで横パンをブロックしJSのpreventDefaultを不要にすることで
+     iOS Safariが縦スクロールを即開始できるようにする */
+  touch-action: pan-y;
 }
 
 .tab-track {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -260,7 +260,6 @@ export default function App() {
     }
 
     if (swipe.horizontal) {
-      e.preventDefault()
       const atFirst = swipe.activeIndex === 0 && dx > 0
       const atLast = swipe.activeIndex === TAB_ORDER.length - 1 && dx < 0
       setTabSettling(false)
@@ -494,7 +493,7 @@ export default function App() {
     const end = (e) => stableHandlersRef.current.tabSwipeEnd(e)
 
     el.addEventListener('touchstart', start, { passive: true })
-    el.addEventListener('touchmove', move, { passive: false })
+    el.addEventListener('touchmove', move, { passive: true })
     el.addEventListener('touchend', end, { passive: true })
     el.addEventListener('touchcancel', end, { passive: true })
 


### PR DESCRIPTION
## 原因

`handleTabSwipeMove` が `{ passive: false }` で `.tab-viewport` にバインドされており、スワイプに少しでも横方向の成分があると `swipe.horizontal = true` → `e.preventDefault()` が呼ばれ、縦スクロールをブロックしていた。

**更新中だけスクロールできた理由**: `tabsLocked = true` のとき `handleTabSwipeStart` が `tabSwipeRef.current = null` にするため、`handleTabSwipeMove` が即リターンし `e.preventDefault()` を一切呼ばなかった。

## 修正

`.tab-viewport` に `touch-action: pan-y` を CSS で設定する。ブラウザが横パンを自前でブロックするため、JS 側の `e.preventDefault()` が不要になる。

```
Before: .tab-viewport { passive: false touchmove }
         → handleTabSwipeMove が横成分を検知すると e.preventDefault()
         → iOS Safari が縦スクロールをブロック

After:  .tab-viewport { touch-action: pan-y }
         → ブラウザが横パンをネイティブにブロック
         → touchmove を passive: true にできる
         → iOS Safari が即座に縦スクロールを開始できる
```

## 変更ファイル

- `App.css`: `.tab-viewport` に `touch-action: pan-y` を追加
- `App.jsx`: `.tab-viewport` の touchmove リスナーを `passive: false` → `passive: true` に変更
- `App.jsx`: `handleTabSwipeMove` の `e.preventDefault()` を削除（`touch-action` で代替）

## 影響範囲

- 分析画面の縦スクロール: 修正済み
- 横スワイプによるタブ切り替え: 維持（JS の CSS transform で実装）
- 下スワイプ更新 (pull-to-refresh): 維持（`.tab-panel` の `{ passive: false }` リスナーで制御）

🤖 Generated with [Claude Code](https://claude.com/claude-code)