### PR TITLE
fix: ::afterでiOS Safari flexスクロールバグを回避

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -214,13 +214,22 @@
   flex-direction: column;
   gap: 16px;
   /* padding-top: 20px でoverflow-x: hiddenによるbox-shadow上端クリップを防ぐ */
-  padding: 20px 16px calc(var(--footer-total-height) + var(--content-bottom-breathing));
+  /* padding-bottom は iOS Safari の flex コンテナ scroll 高さバグを避けるため
+     ::after flex item に移動（padding-bottom は scrollHeight に含まれないケースがある） */
+  padding: 20px 16px 0;
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   scroll-behavior: auto;
   touch-action: pan-y;
+}
+
+/* iOS Safari では flex コンテナの padding-bottom が scrollHeight に反映されないバグがある。
+   flex item として末尾に挿入することで確実にスクロール余地を確保する */
+.tab-panel::after {
+  content: "";
+  flex: 0 0 calc(var(--footer-total-height) + var(--content-bottom-breathing));
 }
 
 


### PR DESCRIPTION
## 原因

iOS Safari の既知バグ: display:flex + overflow-y:auto のコンテナでは padding-bottom が scrollHeight に含まれないケースがある。

このため .tab-panel の scrollHeight <= clientHeight になり、ブラウザが「スクロール不要」と判断していた。

更新中だけスクロールできた理由: pull-indicator(60px)が表示されると clientHeight が縮み、コンテンツが相対的にオーバーフローして初めて scrollHeight > clientHeight になっていた。

## 修正

.tab-panel の padding-bottom を除去し、::after 擬似要素（flex item）として同サイズのスペーサーに置き換え。flex item は scrollHeight に確実に反映される。

## 確認結果（プレビュー）

| パネル | scrollHeight | clientHeight | canScroll |
|--------|-------------|--------------|-----------|
| 実績   | 1541px      | 756px        | OK |
| 習慣   | 756px       | 756px        | (コンテンツが少ない場合は不要) |
| 分析   | 812px       | 756px        | OK (修正前は 920 = 920) |

::after flex-basis: 94px、padding-bottom: 0px を確認済み。

Generated with Claude Code