### PR TITLE
fix: ヘッダー下余白・Safe Areaテーマ反映・追加ボタンアニメーション改善 (#147 #144 #158)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -213,10 +213,10 @@
   min-height: 0;
   flex-direction: column;
   gap: 16px;
-  /* padding-top: 20px でoverflow-x: hiddenによるbox-shadow上端クリップを防ぐ */
+  /* padding-top: 12px でoverflow-x: hiddenによるbox-shadow上端クリップを防ぐ（shadow blur: 12px） */
   /* padding-bottom は iOS Safari の flex コンテナ scroll 高さバグを避けるため
      ::after flex item に移動（padding-bottom は scrollHeight に含まれないケースがある） */
-  padding: 20px 16px 0;
+  padding: 12px 16px 0;
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior-y: contain;
@@ -296,13 +296,12 @@
   color: var(--color-text-secondary);
   font-size: 0.85rem;
   font-weight: 500;
-  transition: transform 0.15s ease-out, border-color 0.15s, color 0.15s, opacity 0.15s;
-  will-change: transform;
+  transition: transform 0.18s ease-out, opacity 0.18s ease-out;
 }
 
 .add-habit-btn:active {
-  transform: scale(0.96);
-  opacity: 0.8;
+  transform: scale(0.97);
+  opacity: 0.7;
 }
 
 .add-icon {

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -25,7 +25,19 @@ export default function Modal({ onClose, children, title }) {
 
   useEffect(() => {
     document.documentElement.classList.add('modal-open')
-    return () => document.documentElement.classList.remove('modal-open')
+    const meta = document.querySelector('meta[name="theme-color"]')
+    const prevColor = meta?.getAttribute('content') ?? null
+    // iOS PWA: status bar をモーダルの暗幕に合わせて暗くする
+    meta?.setAttribute('content', '#000000')
+    return () => {
+      document.documentElement.classList.remove('modal-open')
+      if (meta) {
+        // テーマが変更されていた場合は変更後の primary を使う
+        const current = getComputedStyle(document.documentElement)
+          .getPropertyValue('--color-primary').trim()
+        meta.setAttribute('content', current || prevColor)
+      }
+    }
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## 概要

バグ3件をまとめて修正します。

### #147 — ヘッダー下グレー空白
- `.tab-panel` の `padding-top` を `20px -> 12px` に縮小
- カードの box-shadow blur 12px を維持するのに必要な最小値に設定

### #144 — Safe Area にテーマカラーが反映されない
- `Modal.jsx` の `useEffect` で modal open 時に `meta[name=theme-color]` を `#000000` に更新
- iOS PWA のステータスバー領域がモーダルの暗幕に追従するよう修正
- close 時は `getComputedStyle` で現在の `--color-primary` を取得して復元

### #158 — 習慣追加ボタンのアニメーションが荒ぶる
- `.add-habit-btn` から `will-change: transform` を削除
- transition を `transform + opacity` のみに簡略化
- scale(0.96 -> 0.97) / 0.15s -> 0.18s でより落ち着いた押し込み感に調整

## 確認観点
- ヘッダー下のグレー空白が視覚的に目立たない
- 習慣追加モーダルが自然に開く
- 設定モーダル open 時にヘッダー上部も暗幕になる（iPhone PWA）
- テーマカラー変更後にモーダルを閉じると Safe Area が新しい色になる（iPhone PWA）
- npm run build 成功

Generated with Claude Code