### PR TITLE
fix: AddHabitModalのautoFocus削除でiOSキーボード誤起動を修正 (#158補足)

### DIFF
--- a/src/components/AddHabitModal.jsx
+++ b/src/components/AddHabitModal.jsx
@@ -37,7 +37,6 @@ export default function AddHabitModal({ onSave, onClose, initialHabit = null }) 
             placeholder="例：ランニング、読書..."
             value={name}
             onChange={(e) => setName(e.target.value)}
-            autoFocus
             maxLength={20}
           />
         </div>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -19,7 +19,7 @@ export default function Modal({ onClose, children, title }) {
 
   // アニメーション完了後にフォーカスを移動（重複effectを解消）
   useEffect(() => {
-    const timer = setTimeout(() => sheetRef.current?.focus(), 220)
+    const timer = setTimeout(() => sheetRef.current?.focus({ preventScroll: true }), 220)
     return () => clearTimeout(timer)
   }, [])
 


### PR DESCRIPTION
## 概要

PR #178 マージ後に判明した #158 の追加修正です。

## 問題

習慣追加ボタン押下時、iPhone でキーボードが一瞬立ち上がり画面全体が上に移動する。

## 原因

- AddHabitModal.jsx の input に autoFocus が残っていた
- モーダル表示と同時に iOS がフォーカスを拾いキーボードを表示・viewport を押し上げていた
- Modal.jsx の sheetRef.current?.focus() に preventScroll オプションがなかった

## 変更内容

- AddHabitModal.jsx: input から autoFocus を削除（主因）
- Modal.jsx: focus({ preventScroll: true }) に変更（スクロール位置変動を防止）

## 確認観点

- 習慣追加ボタン押下時にキーボードが一瞬表示されない
- 画面全体が上に移動しない
- モーダルだけが自然にスライドイン
- iPhone Safari / PWA の両方で確認
- npm run build 成功

Generated with Claude Code