### PR TITLE
fix/feat: バックアップUX改善・PWAアイコン整理・フェーズヒント追加 (#142 #159 #176)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
     <meta name="apple-mobile-web-app-title" content="習慣" />
     <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%icon.svg" />
-    <link rel="apple-touch-icon" href="%BASE_URL%apple-touch-icon.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="%BASE_URL%apple-touch-icon.png" />
     <title>習慣トラッカー</title>
   </head>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -423,7 +423,7 @@ export default function App() {
     a.download = filename
     a.click()
     URL.revokeObjectURL(url)
-    setToast(`${filename} のダウンロードを開始しました。保存されたかどうかはブラウザで確認してください${skippedText}`)
+    setToast(`${filename} をダウンロードしました。「ファイルに保存」を選択して保存してください${skippedText}`)
   }, [habits, records, today])
 
   const handleImportClick = () => fileInputRef.current?.click()
@@ -754,8 +754,10 @@ export default function App() {
       {modal?.type === 'exportConfirm' && (
         <ConfirmModal
           title="バックアップ保存"
-          message={`バックアップファイルを保存します。\n\n対応しているブラウザでは、選んだ場所に「${BACKUP_DIR_NAME}」フォルダを作って保存します。`}
-          confirmLabel="ダウンロード"
+          message={'showDirectoryPicker' in window
+            ? `バックアップファイルを保存します。\n\n保存先フォルダを選択すると「${BACKUP_DIR_NAME}」フォルダを作って自動保存します。\nキャンセルした場合はバックアップされません。`
+            : 'バックアップファイルをダウンロードします。\n\nダウンロード後、「ファイルに保存」を選択してください。\nキャンセルした場合はバックアップされません。'}
+          confirmLabel="保存する"
           danger={false}
           onConfirm={() => { handleExport(); closeModal() }}
           onClose={closeModal}

--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -29,6 +29,13 @@
   margin-top: 2px;
 }
 
+.phase-highlight-tip {
+  font-size: 0.8rem;
+  opacity: 0.75;
+  margin-top: 4px;
+  font-style: italic;
+}
+
 .phase-highlight-habit {
   display: flex;
   align-items: center;

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -87,6 +87,7 @@ export default function RecordView({
               あと{featured.phase.daysToNext}日続けると「{featured.phase.next}」へ
             </div>
           )}
+          <div className="phase-highlight-tip">{featured.phase.tip}</div>
           {featured.streak > 0 && (
             <div className="phase-highlight-habit">
               <span className="phase-highlight-dot" style={{ backgroundColor: featured.habit.color }} />

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -51,10 +51,10 @@ export function calcStats(habitId, records) {
 }
 
 export function getHabitPhase(currentStreak) {
-  if (currentStreak >= 90) return { label: '生活の一部', next: null, daysToNext: null }
-  if (currentStreak >= 30) return { label: '日常に馴染んできた', next: '生活の一部', daysToNext: 90 - currentStreak }
-  if (currentStreak >= 14) return { label: 'リズムができてきた', next: '日常に馴染んできた', daysToNext: 30 - currentStreak }
-  return { label: 'まず2週間続けてみよう', next: 'リズムができてきた', daysToNext: 14 - currentStreak }
+  if (currentStreak >= 90) return { label: '生活の一部', next: null, daysToNext: null, tip: 'もう自然と続いています。この調子で。' }
+  if (currentStreak >= 30) return { label: '日常に馴染んできた', next: '生活の一部', daysToNext: 90 - currentStreak, tip: '1日抜けても大丈夫。戻ってくることが大切です。' }
+  if (currentStreak >= 14) return { label: 'リズムができてきた', next: '日常に馴染んできた', daysToNext: 30 - currentStreak, tip: '同じ時間・場所でやると定着しやすくなります。' }
+  return { label: 'まず2週間続けてみよう', next: 'リズムができてきた', daysToNext: 14 - currentStreak, tip: '今日1回できればOK。完璧より継続を。' }
 }
 
 export function calcPeriodStats(habitId, records, today, createdAt, archivedAt) {


### PR DESCRIPTION
## 概要

3つのissueをまとめて対応します。

### #142 — バックアップUX改善
- 保存確認モーダルのメッセージをブラウザ対応状況で分岐
  - 対応ブラウザ（Chrome等）: フォルダ選択→自動保存・キャンセル時は保存されない旨を明示
  - 非対応ブラウザ（iOS Safari等）: 「ファイルに保存」選択を促す案内に変更
- ボタンラベルを「ダウンロード」→「保存する」に変更（意図を明確化）
- フォールバックToastを「ダウンロードを開始しました」から「ファイルに保存を選択してください」に改善

### #159 — PWA/アイコン構成整理
- index.html の apple-touch-icon タグ重複を削除（sizes=180x180 のみ残す）
- 現状の icon 構成（SVG + 192px + 512px + apple-touch-icon）は最小・正常を確認

### #176 — 習慣化フェーズにヒント表示追加（#153・#157 も実装済みを確認）
- getHabitPhase に tip フィールドを追加（フェーズごとの一言ヒント）
- フェーズハイライト部分に italic でヒントを表示
- 「1日抜けても大丈夫。戻ってくることが大切です。」など、pm方針に沿った控えめな文言
- なお #153・#157 はすでに RecordView に実装済みのため合わせてクローズ対象

## 確認観点
- 設定 > バックアップを保存 でモーダルメッセージが変わっている
- キャンセルした場合は「保存されません」と明示されている
- 実績画面のフェーズハイライトにヒントが表示される
- npm run build 成功

Generated with Claude Code