### PR TITLE
fix: バックアップキャンセル時のトースト修正・apple-touch-icon重複削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
     <meta name="apple-mobile-web-app-title" content="習慣" />
     <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%icon.svg" />
-    <link rel="apple-touch-icon" href="%BASE_URL%apple-touch-icon.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="%BASE_URL%apple-touch-icon.png" />
     <title>習慣トラッカー</title>
   </head>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -423,7 +423,7 @@ export default function App() {
     a.download = filename
     a.click()
     URL.revokeObjectURL(url)
-    setToast(`${filename} のダウンロードを開始しました。保存されたかどうかはブラウザで確認してください${skippedText}`)
+    setToast(`${filename} のダウンロードを開始しました。\nキャンセルした場合はバックアップされていません。${skippedText}`)
   }, [habits, records, today])
 
   const handleImportClick = () => fileInputRef.current?.click()


### PR DESCRIPTION
## 変更内容

### #142 バックアップキャンセル時メッセージの修正
legacy download（`a.click()`）パスのトーストメッセージを変更。

**変更前：**
`habit-tracker-2026-05-09.json のダウンロードを開始しました。保存されたかどうかはブラウザで確認してください`

**変更後：**
`habit-tracker-2026-05-09.json のダウンロードを開始しました。\nキャンセルした場合はバックアップされていません。`

### #159 apple-touch-icon 重複タグの削除
`index.html` に `sizes` 属性なし・180x180 の2つのタグが重複していたため、サイズ指定のある `sizes=180x180` を残して削除。

## 理由

- #142: ブラウザAPIの制約上キャンセル検知は不可能だが、「キャンセルした場合はバックアップされていません」と明示することでユーザーの誤解を防ぐ。File System Access API（`showDirectoryPicker`）のキャンセルはAbortErrorで検知済みで変更なし。
- #159: 重複タグは不要で、`sizes=180x180` の指定がある方が正確。

## iPhone/PWA影響

- #142: エクスポートのトーストのみ。safe-area/footer/scroll に影響なし。
- #159: `<link>` タグの整理のみ。iPhoneホーム画面アイコンは `apple-touch-icon.png` を引き続き使用。変更なし。

## 確認方法

1. 設定 → バックアップを保存 → ダウンロードをタップ
2. ブラウザのダウンロードをキャンセル
3. 「キャンセルした場合はバックアップされていません。」トーストが表示されることを確認