### PR TITLE
feat: 習慣カードに編集アイコンを追加 (#154)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -691,6 +691,7 @@ export default function App() {
                     streak={calcCurrentStreak(habit.id, records)}
                     onPress={(h) => toggleHabit(h.id, today)}
                     onLongPress={(h) => setModal({ type: 'longPress', habit: h })}
+                    onEdit={(h) => setModal({ type: 'edit', habit: h })}
                   />
                 ))}
                 <button className="add-habit-btn" onClick={() => setModal({ type: 'add' })}>

--- a/src/components/HabitButton.css
+++ b/src/components/HabitButton.css
@@ -85,3 +85,22 @@
   opacity: 0.7;
   line-height: 1;
 }
+
+.habit-edit-icon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 7px;
+  opacity: 0.35;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  cursor: pointer;
+}
+
+.habit-edit-icon:active {
+  opacity: 0.7;
+}

--- a/src/components/HabitButton.jsx
+++ b/src/components/HabitButton.jsx
@@ -3,7 +3,7 @@ import './HabitButton.css'
 
 const LONG_PRESS_DELAY = 500
 
-export default function HabitButton({ habit, completed, streak, onPress, onLongPress }) {
+export default function HabitButton({ habit, completed, streak, onPress, onLongPress, onEdit }) {
   const timerRef = useRef(null)
   const isLongPressRef = useRef(false)
   const startPosRef = useRef(null)
@@ -64,6 +64,20 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
       onPointerCancel={handlePointerCancel}
       onContextMenu={(e) => e.preventDefault()}
     >
+      {onEdit && (
+        <span
+          className="habit-edit-icon"
+          role="button"
+          aria-label={`${habit.name}を編集`}
+          onClick={(e) => { e.stopPropagation(); onEdit(habit) }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onPointerUp={(e) => e.stopPropagation()}
+        >
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
+          </svg>
+        </span>
+      )}
       <span
         className="habit-dot"
         style={{ backgroundColor: completed ? '#fff' : habit.color }}


### PR DESCRIPTION
## 変更内容

習慣カード（HabitButton）の左上に小さな鉛筆アイコンを追加。
タップすると対象習慣の編集モーダルを開く。

## 理由

- タップ（今日の達成）・長押し（昨日記録）の既存操作を維持しながら、編集への導線を追加したい
- 長押しを編集に割り当てると既存機能と競合するため、専用アイコンを採用

## 操作の整理

| 操作 | 動作 |
|---|---|
| カードをタップ | 今日の達成をトグル |
| カードを長押し | 昨日分など過去記録のモーダル |
| 鉛筆アイコンをタップ | 習慣名・色の編集モーダル |

## 実装詳細

- `HabitButton` に `onEdit` プロップ追加（未指定時はアイコン非表示）
- アイコンは `position: absolute; top: 0; left: 0` で左上配置
- `e.stopPropagation()` を onClick・onPointerDown・onPointerUp に付与し、達成タップ・長押しタイマーとの干渉を防止
- opacity: 0.35 で控えめな表示。active時に 0.7

## iPhone/PWA影響

- safe-area / footer / scroll に影響なし
- touch-action: manipulation 設定済み
- -webkit-tap-highlight-color: transparent 設定済み