### PR TITLE
feat: 分析タブに習慣化フェーズ表示を追加（#176）

### DIFF
--- a/src/components/StatsView.css
+++ b/src/components/StatsView.css
@@ -166,3 +166,64 @@
   font-size: 0.78rem;
   line-height: 1.5;
 }
+
+.phase-scale {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 2px;
+  margin-bottom: 10px;
+}
+
+.phase-scale-label {
+  color: var(--color-text-secondary);
+  font-size: 0.66rem;
+}
+
+.phase-list {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.phase-row {
+  display: grid;
+  grid-template-columns: 10px 1fr auto 32px;
+  align-items: center;
+  gap: 8px;
+}
+
+.phase-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.phase-name {
+  font-size: 0.82rem;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.phase-tag {
+  font-size: 0.68rem;
+  font-weight: 700;
+  border: 1.5px solid;
+  border-radius: 20px;
+  padding: 1px 7px;
+  white-space: nowrap;
+}
+
+.phase-streak {
+  text-align: right;
+  font-size: 0.72rem;
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+.phase-note {
+  margin-top: 12px;
+  font-style: italic;
+}

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -1,4 +1,6 @@
 import { formatDate, parseLocalDate, HABIT_COLORS } from '../utils/date'
+import { calcCurrentStreak } from '../utils/stats'
+import { PHASES, getPhase } from '../utils/habitPhase'
 import './StatsView.css'
 
 const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
@@ -89,6 +91,10 @@ export default function StatsView({ habits, records, today, colorCategories = {}
   const colorStats = calcColorStats(habits, records, today, colorCategories)
   const hasNamedColors = Object.values(colorCategories).some(v => v?.trim())
 
+  const habitPhases = activeHabits
+    .map(h => ({ habit: h, streak: calcCurrentStreak(h.id, records), ...getPhase(calcCurrentStreak(h.id, records)) }))
+    .sort((a, b) => b.streak - a.streak)
+
   if (habits.length === 0) {
     return <p className="analysis-empty">習慣を追加すると、続け方のヒントが表示されます。</p>
   }
@@ -160,6 +166,37 @@ export default function StatsView({ habits, records, today, colorCategories = {}
           ))}
         </div>
       </section>
+
+      {habitPhases.length > 0 && (
+        <section className="section">
+          <div className="analysis-subhead">
+            <span>習慣化フェーズ</span>
+          </div>
+          <div className="phase-scale">
+            {PHASES.slice(0, -1).map((p, i) => (
+              <span key={i} className="phase-scale-label">{p.days}日</span>
+            ))}
+          </div>
+          <div className="phase-list">
+            {habitPhases.map(({ habit, streak, phase, index }) => (
+              <div key={habit.id} className="phase-row">
+                <span className="phase-dot" style={{ backgroundColor: habit.color }} />
+                <span className="phase-name">{habit.name}</span>
+                <span className="phase-tag" style={{ color: habit.color, borderColor: habit.color }}>
+                  {phase.label}
+                </span>
+                <span className="phase-streak">{streak}日</span>
+              </div>
+            ))}
+          </div>
+          <p className="analysis-note phase-note">
+            {(() => {
+              const best = habitPhases[0]
+              return best ? best.phase.desc : ''
+            })()}
+          </p>
+        </section>
+      )}
 
       <p className="analysis-note">
         今の対象習慣は {activeHabits.length} 件です。達成率は、その日に対象だった習慣だけで計算しています。

--- a/src/utils/habitPhase.js
+++ b/src/utils/habitPhase.js
@@ -1,0 +1,14 @@
+export const PHASES = [
+  { label: '脱・三日坊主', days: 3, desc: '最初の数日は心理的ハードルが最も高い時期。完璧より「やる感覚」を作ることが大切です。' },
+  { label: '継続チャレンジ', days: 14, desc: '同じ行動を繰り返すことで、少しずつ生活リズムに組み込みやすくなる時期です。' },
+  { label: 'リズム形成', days: 30, desc: '行動が生活の一部になり始める時期。同じ時間・場所で行うとさらに定着しやすくなります。' },
+  { label: '習慣定着', days: 60, desc: '約2か月前後で自然に続けやすくなる傾向があります。ここまで来たら自信を持って。' },
+  { label: '自動化', days: Infinity, desc: '行動が「当たり前」になった状態。次の習慣に挑戦するいいタイミングかもしれません。' },
+]
+
+export function getPhase(streak) {
+  for (let i = 0; i < PHASES.length; i++) {
+    if (streak < PHASES[i].days) return { phase: PHASES[i], index: i }
+  }
+  return { phase: PHASES[PHASES.length - 1], index: PHASES.length - 1 }
+}


### PR DESCRIPTION
## 変更内容
- src/utils/habitPhase.js: 5段階フェーズ定義（脱・三日坊主→継続チャレンジ→リズム形成→習慣定着→自動化）
- StatsView: 各習慣の連続日数から現在フェーズを計算・表示するセクションを追加
- フェーズタグ（色付きボーダー）＋説明文（最も進んだ習慣を基準）

## 理由
Issue #176。「頑張らせる」より「自然に続けられる」UXへ。連続日数に習慣科学的な意味を付与することで、数字の意味が分かりやすくなる。

## 確認方法
分析タブを開き、習慣一覧が「習慣化フェーズ」セクションに表示されること。

## iPhone/PWA影響
なし（分析タブ追記のみ）

## 想定リスク
なし（計算はcalcCurrentStreakの既存ロジックを流用）

Closes #176