### PR TITLE
fix: バックアップ保存キャンセル時の誤表示を修正 (close #142)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -423,7 +423,7 @@ export default function App() {
     a.download = filename
     a.click()
     URL.revokeObjectURL(url)
-    setToast(`${filename} をダウンロードしました。「ファイルに保存」を選択して保存してください${skippedText}`)
+    setToast(`ダウンロードを開始しました。保存ダイアログが表示されたら保存先を選んでください${skippedText}`)
   }, [habits, records, today])
 
   const handleImportClick = () => fileInputRef.current?.click()


### PR DESCRIPTION
## 変更内容

フォールバックダウンロード（a.click()）完了後のToast文言を修正。

変更前: `{filename} をダウンロードしました。「ファイルに保存」を選択して保存してください`
変更後: `ダウンロードを開始しました。保存ダイアログが表示されたら保存先を選んでください`

## 背景

a.click() によるダウンロードはブラウザの制約でキャンセル検知ができない。
そのためユーザーが保存をキャンセルしても「保存しました」のような断言が出ていた。
文言を状況説明に変えることで誤解を防ぐ。

showDirectoryPicker 対応環境（デスクトップChrome等）のキャンセル時は既存の AbortError 処理で対応済み。

## 確認事項
- [ ] 設定 → バックアップを保存 → 保存する → Toastが「ダウンロードを開始しました〜」と表示される
- [ ] showDirectoryPicker 環境でのキャンセル時は従来通り「バックアップ保存をキャンセルしました」が表示される

Generated with Claude Code