### PR TITLE
fix: manifest の purpose を any と maskable に分割（close #159）

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -19,13 +19,19 @@
       "src": "/habit-tracker/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "/habit-tracker/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/habit-tracker/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }


### PR DESCRIPTION
## 変更内容

`manifest.webmanifest` の `icons[].purpose` フィールドを修正。

**変更前:** icon-192 / icon-512 ともに `"purpose": "any maskable"`
**変更後:** icon-192 を `"purpose": "any"`、icon-512 を `"purpose": "any"` と `"purpose": "maskable"` の別エントリに分割

## 背景

`"purpose": "any maskable"` の複合指定は W3C 仕様では非推奨で、Lighthouse が警告を出す対象。
`any` と `maskable` は別エントリに分割するのが正しい構成。

- `any` → ブラウザ・PWA の汎用アイコン
- `maskable` → Android アダプティブアイコン用（safe zone 付きの 512px を使用）

## 確認事項
- [ ] PWA インストール時にアイコンが正常表示される
- [ ] Lighthouse PWA 監査でアイコン関連の警告が消えている

## iPhone Safari キャッシュについて

manifest の変更は iPhone Safari のキャッシュに残る場合があります。
動作確認時は以下の手順を踏んでください：

1. ホーム画面のアプリアイコンを長押し → 削除
2. Safari でキャッシュクリア後に再読み込み
3. ホーム画面に再追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
