### PR TITLE
補助情報の意味づけ整理と継続ヒントカード化（Issue #197/#198/#199）

### DIFF
--- a/src/components/HabitTip.css
+++ b/src/components/HabitTip.css
@@ -1,8 +1,21 @@
-.habit-tip {
-  margin: 12px 16px 4px;
-  padding: 10px 12px;
+﻿.habit-tip-card {
+  margin: 8px 16px 4px;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm, 8px);
+  background: var(--color-surface, #f5f5f5);
   border-left: 3px solid var(--color-primary, #6366f1);
-  background: transparent;
+}
+
+.habit-tip-title {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--color-primary, #6366f1);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.habit-tip-body {
   color: var(--color-text-muted, #888);
   font-size: 0.78rem;
   line-height: 1.5;

--- a/src/components/HabitTip.jsx
+++ b/src/components/HabitTip.jsx
@@ -4,8 +4,9 @@ import './HabitTip.css'
 export default function HabitTip({ today }) {
   const tip = getDailyTip(today)
   return (
-    <p className="habit-tip" aria-label="継続のヒント">
-      {tip}
-    </p>
+    <div className="habit-tip-card" aria-label="習慣化のヒント">
+      <span className="habit-tip-title">習慣化のヒント</span>
+      <p className="habit-tip-body">{tip}</p>
+    </div>
   )
 }

--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -175,3 +175,25 @@
   font-size: 0.85rem;
   line-height: 1.5;
 }
+
+/* フェーズハイライト - 追加クラス（Issue #198） */
+.phase-highlight-heading {
+  font-size: 0.72rem;
+  font-weight: 700;
+  opacity: 0.75;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+}
+
+.phase-highlight-habit-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 2px;
+}
+
+.phase-highlight-habit-name {
+  font-size: 1.05rem;
+  font-weight: 800;
+  line-height: 1.2;
+}

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -80,18 +80,18 @@ export default function RecordView({
     <>
       {featured && (
         <section className="section record-phase-highlight-section">
-          <div className="phase-highlight-label">{featured.phase.label}</div>
+          <div className="phase-highlight-heading">いま一番続いている習慣</div>
+          <div className="phase-highlight-habit-row">
+            {featured.streak > 0 && (
+              <span className="phase-highlight-dot" style={{ backgroundColor: featured.habit.color }} />
+            )}
+            <div className="phase-highlight-habit-name">{featured.habit.name}</div>
+          </div>
           <div className="phase-highlight-streak">{featured.streak > 0 ? `${featured.streak}日継続中` : '今日から始めよう'}</div>
+          <div className="phase-highlight-label">{featured.phase.label}</div>
           {featured.phase.daysToNext !== null && (
             <div className="phase-highlight-next">
               あと{featured.phase.daysToNext}日続けると「{featured.phase.next}」へ
-            </div>
-          )}
-          <div className="phase-highlight-tip">{featured.phase.tip}</div>
-          {featured.streak > 0 && (
-            <div className="phase-highlight-habit">
-              <span className="phase-highlight-dot" style={{ backgroundColor: featured.habit.color }} />
-              <span>{featured.habit.name}</span>
             </div>
           )}
         </section>

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -96,17 +96,17 @@ export default function StatsView({ habits, records, today, colorCategories = {}
     .sort((a, b) => b.streak - a.streak)
 
   if (habits.length === 0) {
-    return <p className="analysis-empty">習慣を追加すると、続け方のヒントが表示されます。</p>
+    return <p className="analysis-empty">習慣を追加すると、達成率が表示されます。</p>
   }
 
   return (
     <>
       <section className="section">
         <div className="section-header">
-          <h2 className="section-title">これからの続け方</h2>
+          <h2 className="section-title">達成率</h2>
         </div>
         <div className="analysis-advice">
-          <span className="analysis-advice-label">次の続け方</span>
+          <span className="analysis-advice-label">直近7日の傾向</span>
           <p>{advice}</p>
         </div>
         <div className="analysis-rate-grid">
@@ -189,12 +189,6 @@ export default function StatsView({ habits, records, today, colorCategories = {}
               </div>
             ))}
           </div>
-          <p className="analysis-note phase-note">
-            {(() => {
-              const best = habitPhases[0]
-              return best ? best.phase.desc : ''
-            })()}
-          </p>
         </section>
       )}
 


### PR DESCRIPTION
## 対応Issue

- Closes #197 継続ヒントを独立カード化し、分かりやすいタイトルを付けたい
- Closes #198 実績画面最上部のカードの意味を分かりやすくしたい
- Closes #199 実績画面・分析画面の補助文言を整理したい

## 変更内容

### Issue #197: HabitTip カード化

- `<p>` タグから `<div>` カードに変更
- 「習慣化のヒント」タイトルをカード上部に追加
- border-left スタイルを維持し、静かな見た目を保つ
- 背景色をsurfaceカラーに変更してカードとして区別

### Issue #198: 実績画面フェーズハイライト改善

- 「いま一番続いている習慣」見出しを追加（カードの役割を明示）
- 習慣名を目立つ位置に移動（何の習慣かが先に分かる構成に変更）
- フェーズtipの重複表示を削除してシンプル化

### Issue #199: 分析画面 文言整理

- セクションタイトル「これからの続け方」→「達成率」に変更（押し付け感を除去）
- advice ラベル「次の続け方」→「直近7日の傾向」に変更（根拠を明示）
- phase-note（フェーズ説明の追加文）を削除してUIの喋りすぎ感を低減

## 確認事項

- [x] npm run build 成功
- [x] iPhone幅に影響する固定レイアウト変更なし
- [x] safe-area / footer / scroll 影響なし
- [x] App.jsx 変更なし（コンフリクトリスクなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)