### PR TITLE
fix: 色選択時の「おすすめ」表記を削除（Issue #188）

### DIFF
--- a/src/components/AddHabitModal.css
+++ b/src/components/AddHabitModal.css
@@ -106,12 +106,6 @@
   opacity: 0.8;
 }
 
-.color-hint {
-  font-size: 0.78rem;
-  color: var(--color-text-secondary);
-  margin-top: 4px;
-}
-
 .category-chips {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/AddHabitModal.jsx
+++ b/src/components/AddHabitModal.jsx
@@ -14,17 +14,6 @@ const COLOR_NAMES = {
   '#6C5CE7': 'パープル',
 }
 
-const COLOR_HINTS = {
-  '#FF6B6B': '生活・食事・体調管理',
-  '#FF9F43': '食事・料理・朝のルーティン',
-  '#FECA57': '気分・趣味・創作',
-  '#48DBB4': '健康・運動・ストレッチ',
-  '#54A0FF': '勉強・読書・学習',
-  '#A29BFE': '睡眠・リラックス・瞑想',
-  '#FD79A8': '美容・ケア・セルフケア',
-  '#6C5CE7': '集中・思考・仕事',
-}
-
 export default function AddHabitModal({ onSave, onClose, initialHabit = null }) {
   const isEdit = !!initialHabit
   const [name, setName] = useState(initialHabit?.name ?? '')
@@ -67,9 +56,6 @@ export default function AddHabitModal({ onSave, onClose, initialHabit = null }) 
               />
             ))}
           </div>
-          {COLOR_HINTS[color] && (
-            <p className="color-hint">おすすめ：{COLOR_HINTS[color]}</p>
-          )}
         </div>
 
         <div className="preview-row">


### PR DESCRIPTION
## 変更内容

- AddHabitModal.jsx から COLOR_HINTS 定数と「おすすめ：{ヒント}」表示を削除
- AddHabitModal.css から未使用の .color-hint スタイルを削除

## 理由

色選択時に「おすすめ：健康・運動・ストレッチ」のような表示が出ていたが、アプリの設計方針として「色の意味はユーザー自身がカテゴリ設定で決める」ため、アプリ側が色に意味を与えるこの表記は不整合だった。

## 確認方法

習慣追加モーダルを開き、色を選択しても「おすすめ：」の文言が表示されないことを確認。

## iPhone/PWA影響

なし（表示要素の削除のみ）

## 想定リスク

なし