### PR TITLE
fix: 習慣カードの編集アイコンを削除し、編集導線を長押しに統一（Issue #189）

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -693,7 +693,6 @@ export default function App() {
                       streak={calcCurrentStreak(habit.id, records)}
                       onPress={(h) => toggleHabit(h.id, today)}
                       onLongPress={(h) => setModal({ type: 'longPress', habit: h })}
-                      onEdit={(h) => setModal({ type: 'edit', habit: h })}
                     />
                   ))}
                   <button className="add-habit-btn" onClick={() => setModal({ type: 'add' })}>

--- a/src/components/HabitButton.css
+++ b/src/components/HabitButton.css
@@ -85,22 +85,3 @@
   opacity: 0.7;
   line-height: 1;
 }
-
-.habit-edit-icon {
-  position: absolute;
-  top: 0;
-  left: 0;
-  padding: 7px;
-  opacity: 0.35;
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  touch-action: manipulation;
-  -webkit-tap-highlight-color: transparent;
-  cursor: pointer;
-}
-
-.habit-edit-icon:active {
-  opacity: 0.7;
-}

--- a/src/components/HabitButton.jsx
+++ b/src/components/HabitButton.jsx
@@ -3,7 +3,7 @@ import './HabitButton.css'
 
 const LONG_PRESS_DELAY = 500
 
-export default function HabitButton({ habit, completed, streak, onPress, onLongPress, onEdit }) {
+export default function HabitButton({ habit, completed, streak, onPress, onLongPress }) {
   const timerRef = useRef(null)
   const isLongPressRef = useRef(false)
   const startPosRef = useRef(null)
@@ -64,20 +64,6 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
       onPointerCancel={handlePointerCancel}
       onContextMenu={(e) => e.preventDefault()}
     >
-      {onEdit && (
-        <span
-          className="habit-edit-icon"
-          role="button"
-          aria-label={`${habit.name}を編集`}
-          onClick={(e) => { e.stopPropagation(); onEdit(habit) }}
-          onPointerDown={(e) => e.stopPropagation()}
-          onPointerUp={(e) => e.stopPropagation()}
-        >
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
-          </svg>
-        </span>
-      )}
       <span
         className="habit-dot"
         style={{ backgroundColor: completed ? '#fff' : habit.color }}


### PR DESCRIPTION
## 変更内容

- HabitButton.jsx から onEdit prop と編集アイコン表示を削除
- HabitButton.css から .habit-edit-icon スタイルを削除
- App.jsx の HabitButton への onEdit prop 渡しを削除

## 理由

習慣カード左上の鉛筆アイコンは日々の記録操作中に誤タップしやすく、UIが騒がしかった。過去のUX方針「タップ→達成、長押し→詳細操作」に沿って、編集導線をLongPressModalに統一した。

## 確認方法

習慣カードをタップ→達成のみ。長押し→モーダル表示で編集できることを確認。

## iPhone/PWA影響

なし（編集操作はLongPressModalで引き続き可能）

## 想定リスク

編集アイコンに慣れているユーザーは長押しで編集できることに気づかない可能性があるが、LongPressModal内に編集ボタンが表示されるため問題ない。