### PR TITLE
feat: StatsView 責務分離・フェーズ視覚化・infoアイコン・advice改善（Issue #191/192/193/195）

### DIFF
--- a/src/components/StatsAdviceCard.jsx
+++ b/src/components/StatsAdviceCard.jsx
@@ -1,0 +1,41 @@
+// 達成率に基づく傾向コメント（#195: 評価ではなく支援寄りのトーン）
+function getAdvice(rate7) {
+  if (rate7 === null) {
+    return '記録が増えると、傾向がここに表示されます。'
+  }
+  if (rate7 >= 80) {
+    return '安定したペースで続けられています。'
+  }
+  if (rate7 >= 50) {
+    return '半分以上できています。今の調子を大切に。'
+  }
+  return '無理のないペースで続けることが、長続きにつながりやすいです。'
+}
+
+export default function StatsAdviceCard({ rate7, rate30 }) {
+  const advice = getAdvice(rate7)
+
+  return (
+    <section className="section">
+      <div className="section-header">
+        <h2 className="section-title">達成率</h2>
+      </div>
+      <div className="analysis-advice">
+        <span className="analysis-advice-label">直近7日の傾向</span>
+        <p>{advice}</p>
+      </div>
+      <div className="analysis-rate-grid">
+        <div className="analysis-rate-card">
+          <span className="analysis-rate-value">{rate7 ?? '-'}</span>
+          {rate7 !== null && <span className="analysis-rate-unit">%</span>}
+          <span className="analysis-rate-label">直近7日</span>
+        </div>
+        <div className="analysis-rate-card">
+          <span className="analysis-rate-value">{rate30 ?? '-'}</span>
+          {rate30 !== null && <span className="analysis-rate-unit">%</span>}
+          <span className="analysis-rate-label">直近30日</span>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/StatsCategoryCard.jsx
+++ b/src/components/StatsCategoryCard.jsx
@@ -1,0 +1,27 @@
+export default function StatsCategoryCard({ colorStats }) {
+  return (
+    <section className="section">
+      <div className="analysis-subhead">
+        <span>カテゴリ別達成率</span>
+        <small>直近30日</small>
+      </div>
+      {colorStats.length === 0 ? (
+        <p className="analysis-note">カテゴリが設定された色の習慣がありません。</p>
+      ) : (
+        <div className="analysis-color-list">
+          {colorStats.map(({ color, name, count, rate }) => (
+            <div className="analysis-color-row" key={color}>
+              <span className="analysis-color-dot" style={{ backgroundColor: color }} />
+              <span className="analysis-color-name">{name}</span>
+              <span className="analysis-color-count">{count}件</span>
+              <div className="analysis-weekday-bar">
+                <span style={{ width: `${rate ?? 0}%` }} />
+              </div>
+              <span className="analysis-color-rate">{rate !== null ? `${rate}%` : '-'}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/StatsPhaseCard.css
+++ b/src/components/StatsPhaseCard.css
@@ -1,0 +1,119 @@
+.phase-info-btn {
+  display: flex;
+  align-items: center;
+  color: var(--color-text-secondary);
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: color 0.15s;
+}
+
+.phase-info-btn:active {
+  color: var(--color-primary);
+}
+
+.phase-info-panel {
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  margin-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.phase-info-panel p {
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+
+/* フェーズ行レイアウト */
+.phase-row {
+  display: grid;
+  grid-template-columns: 10px 1fr auto;
+  align-items: start;
+  gap: 8px;
+  padding: 6px 0;
+}
+
+.phase-row-main {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.phase-row-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+/* ステップUI */
+.phase-steps {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.phase-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  position: relative;
+  flex: 1;
+}
+
+/* ドット間の線 */
+.phase-step:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 5px;
+  left: calc(50% + 5px);
+  right: calc(-50% + 5px);
+  height: 2px;
+  background: var(--color-border);
+  z-index: 0;
+}
+
+.phase-step.done:not(:last-child)::after {
+  background: var(--color-primary);
+  opacity: 0.5;
+}
+
+.phase-step-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid var(--color-border);
+  background: var(--color-surface);
+  z-index: 1;
+  flex-shrink: 0;
+}
+
+.phase-step.done .phase-step-dot {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  opacity: 0.6;
+}
+
+.phase-step.current .phase-step-dot {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  opacity: 1;
+  box-shadow: 0 0 0 3px var(--color-primary-light);
+}
+
+.phase-step-label {
+  font-size: 0.58rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.phase-step.done .phase-step-label,
+.phase-step.current .phase-step-label {
+  color: var(--color-primary);
+}

--- a/src/components/StatsPhaseCard.jsx
+++ b/src/components/StatsPhaseCard.jsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { PHASES } from '../utils/habitPhase'
+import './StatsPhaseCard.css'
+
+// フェーズのマイルストーン日数（最終の Infinity は除く）
+const MILESTONE_DAYS = PHASES.slice(0, -1).map(p => p.days)
+
+// 連続日数がどのステップ（0-indexed）にいるか
+function getStepIndex(streak) {
+  for (let i = 0; i < MILESTONE_DAYS.length; i++) {
+    if (streak < MILESTONE_DAYS[i]) return i
+  }
+  return MILESTONE_DAYS.length
+}
+
+function PhaseSteps({ streak }) {
+  const stepIndex = getStepIndex(streak)
+
+  return (
+    <div className="phase-steps">
+      {MILESTONE_DAYS.map((days, i) => {
+        const done = streak >= days
+        const current = i === stepIndex
+        return (
+          <div key={days} className={`phase-step${done ? ' done' : ''}${current ? ' current' : ''}`}>
+            <div className="phase-step-dot" />
+            <span className="phase-step-label">{days}日</span>
+          </div>
+        )
+      })}
+      {/* 最終フェーズ（自動化） */}
+      <div className={`phase-step${stepIndex >= MILESTONE_DAYS.length ? ' done' : ''}`}>
+        <div className="phase-step-dot" />
+        <span className="phase-step-label">定着</span>
+      </div>
+    </div>
+  )
+}
+
+export default function StatsPhaseCard({ habitPhases }) {
+  const [showInfo, setShowInfo] = useState(false)
+
+  return (
+    <section className="section">
+      <div className="analysis-subhead">
+        <span>習慣化フェーズ</span>
+        <button
+          className="phase-info-btn"
+          onClick={() => setShowInfo(v => !v)}
+          aria-label="フェーズ日数の根拠を見る"
+          aria-expanded={showInfo}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="8" strokeWidth="2.5" />
+            <line x1="12" y1="12" x2="12" y2="16" />
+          </svg>
+        </button>
+      </div>
+
+      {showInfo && (
+        <div className="phase-info-panel">
+          <p>習慣は繰り返しによって少しずつ自然化すると言われています。</p>
+          <p>研究では平均66日前後で自動化が進んだという報告もありますが、個人差があります。</p>
+          <p>このアプリでは、小さな継続を段階的に感じられるよう3日・14日・30日・60日などの目安を設定しています。</p>
+        </div>
+      )}
+
+      <div className="phase-list">
+        {habitPhases.map(({ habit, streak, phase }) => (
+          <div key={habit.id} className="phase-row">
+            <span className="phase-dot" style={{ backgroundColor: habit.color }} />
+            <div className="phase-row-main">
+              <span className="phase-name">{habit.name}</span>
+              <PhaseSteps streak={streak} />
+            </div>
+            <div className="phase-row-right">
+              <span className="phase-tag" style={{ color: habit.color, borderColor: habit.color }}>
+                {phase.label}
+              </span>
+              <span className="phase-streak">{streak}日</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -1,6 +1,10 @@
 import { formatDate, parseLocalDate, HABIT_COLORS } from '../utils/date'
 import { calcCurrentStreak } from '../utils/stats'
-import { PHASES, getPhase } from '../utils/habitPhase'
+import { getPhase } from '../utils/habitPhase'
+import StatsAdviceCard from './StatsAdviceCard'
+import StatsWeekdayCard from './StatsWeekdayCard'
+import StatsCategoryCard from './StatsCategoryCard'
+import StatsPhaseCard from './StatsPhaseCard'
 import './StatsView.css'
 
 const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
@@ -69,25 +73,11 @@ function calcColorStats(habits, records, today, colorCategories) {
     .sort((a, b) => (b.rate ?? -1) - (a.rate ?? -1))
 }
 
-function getAdvice(rate30) {
-  if (rate30 === null) {
-    return '記録が増えると、続け方のヒントがここに表示されます。'
-  }
-  if (rate30 >= 80) {
-    return 'かなり安定して続けられています。今のペースを維持しましょう。'
-  }
-  if (rate30 >= 50) {
-    return 'まずまず続けられています。無理に増やさず、今の習慣を整えましょう。'
-  }
-  return '少し負担が大きいかもしれません。習慣を小さくするのがおすすめです。'
-}
-
 export default function StatsView({ habits, records, today, colorCategories = {} }) {
   const activeHabits = habits.filter(habit => !habit.archivedAt)
   const rate7 = calcRateForRange(habits, records, today, 7)
   const rate30 = calcRateForRange(habits, records, today, 30)
   const weekdayRates = calcWeekdayRates(habits, records, today)
-  const advice = getAdvice(rate7)
   const colorStats = calcColorStats(habits, records, today, colorCategories)
   const hasNamedColors = Object.values(colorCategories).some(v => v?.trim())
 
@@ -101,98 +91,19 @@ export default function StatsView({ habits, records, today, colorCategories = {}
 
   return (
     <>
-      <section className="section">
-        <div className="section-header">
-          <h2 className="section-title">達成率</h2>
-        </div>
-        <div className="analysis-advice">
-          <span className="analysis-advice-label">直近7日の傾向</span>
-          <p>{advice}</p>
-        </div>
-        <div className="analysis-rate-grid">
-          <div className="analysis-rate-card">
-            <span className="analysis-rate-value">{rate7 ?? '-'}</span>
-            {rate7 !== null && <span className="analysis-rate-unit">%</span>}
-            <span className="analysis-rate-label">直近7日</span>
-          </div>
-          <div className="analysis-rate-card">
-            <span className="analysis-rate-value">{rate30 ?? '-'}</span>
-            {rate30 !== null && <span className="analysis-rate-unit">%</span>}
-            <span className="analysis-rate-label">直近30日</span>
-          </div>
-        </div>
-      </section>
+      <StatsAdviceCard rate7={rate7} rate30={rate30} />
 
       {hasNamedColors && (
-        <section className="section">
-          <div className="analysis-subhead">
-            <span>カテゴリ別達成率</span>
-            <small>直近30日</small>
-          </div>
-          {colorStats.length === 0 ? (
-            <p className="analysis-note">カテゴリが設定された色の習慣がありません。</p>
-          ) : (
-            <div className="analysis-color-list">
-              {colorStats.map(({ color, name, count, rate }) => (
-                <div className="analysis-color-row" key={color}>
-                  <span className="analysis-color-dot" style={{ backgroundColor: color }} />
-                  <span className="analysis-color-name">{name}</span>
-                  <span className="analysis-color-count">{count}件</span>
-                  <div className="analysis-weekday-bar">
-                    <span style={{ width: `${rate ?? 0}%` }} />
-                  </div>
-                  <span className="analysis-color-rate">{rate !== null ? `${rate}%` : '-'}</span>
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
+        <StatsCategoryCard colorStats={colorStats} />
       )}
 
-      <section className="section">
-        <div className="analysis-subhead">
-          <span>曜日別達成率</span>
-          <small>直近30日</small>
-        </div>
-        <div className="analysis-weekday-list">
-          {weekdayRates.map(item => (
-            <div className="analysis-weekday-row" key={item.label}>
-              <span className="analysis-weekday-label">{item.label}</span>
-              <div className="analysis-weekday-bar">
-                <span style={{ width: `${item.rate ?? 0}%` }} />
-              </div>
-              <span className="analysis-weekday-rate">{item.rate !== null ? `${item.rate}%` : '-'}</span>
-            </div>
-          ))}
-        </div>
-      </section>
+      <StatsWeekdayCard weekdayRates={weekdayRates} />
 
       {habitPhases.length > 0 && (
-        <section className="section">
-          <div className="analysis-subhead">
-            <span>習慣化フェーズ</span>
-          </div>
-          <div className="phase-scale">
-            {PHASES.slice(0, -1).map((p, i) => (
-              <span key={i} className="phase-scale-label">{p.days}日</span>
-            ))}
-          </div>
-          <div className="phase-list">
-            {habitPhases.map(({ habit, streak, phase, index }) => (
-              <div key={habit.id} className="phase-row">
-                <span className="phase-dot" style={{ backgroundColor: habit.color }} />
-                <span className="phase-name">{habit.name}</span>
-                <span className="phase-tag" style={{ color: habit.color, borderColor: habit.color }}>
-                  {phase.label}
-                </span>
-                <span className="phase-streak">{streak}日</span>
-              </div>
-            ))}
-          </div>
-        </section>
+        <StatsPhaseCard habitPhases={habitPhases} />
       )}
 
-      <p className="analysis-note">
+      <p className="analysis-note section">
         今の対象習慣は {activeHabits.length} 件です。達成率は、その日に対象だった習慣だけで計算しています。
       </p>
     </>

--- a/src/components/StatsWeekdayCard.jsx
+++ b/src/components/StatsWeekdayCard.jsx
@@ -1,0 +1,23 @@
+const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
+
+export default function StatsWeekdayCard({ weekdayRates }) {
+  return (
+    <section className="section">
+      <div className="analysis-subhead">
+        <span>曜日別達成率</span>
+        <small>直近30日</small>
+      </div>
+      <div className="analysis-weekday-list">
+        {weekdayRates.map(item => (
+          <div className="analysis-weekday-row" key={item.label}>
+            <span className="analysis-weekday-label">{item.label}</span>
+            <div className="analysis-weekday-bar">
+              <span style={{ width: `${item.rate ?? 0}%` }} />
+            </div>
+            <span className="analysis-weekday-rate">{item.rate !== null ? `${item.rate}%` : '-'}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## 変更内容

- StatsView.jsx を StatsAdviceCard / StatsWeekdayCard / StatsCategoryCard / StatsPhaseCard に分割（#193）
- StatsPhaseCard.jsx にフェーズステップUIを追加し、習慣ごとに現在地・達成済み日数を視覚化（#191）
- StatsPhaseCard.jsx の見出しにinfoアイコンを追加し、タップで日数根拠の説明を展開（#192）
- StatsAdviceCard.jsx のadviceロジックを評価ではなく支援・傾向寄りのトーンに変更（#195）

## 理由

- StatsView が肥大化し今後の機能追加でiPhone崩れが再発しやすい状態だった（#193）
- フェーズが現在どこにいるか直感的に分からなかった（#191）
- フェーズ日数の根拠が伝わらずゲーム的に見えていた（#192）
- 達成率ベースのadviceが評価・否定的な印象を与えていた（#195）

## 確認方法

分析タブ→習慣化フェーズで各習慣のステップ表示確認。infoアイコンタップで説明パネルが展開することを確認。

## iPhone/PWA影響

StatsPhaseCard.css はフレックス/グリッドのみ。safe-area/footer/scrollへの影響なし。

## 想定リスク

StatsView.css の phase-row スタイルが StatsPhaseCard.css と重複しているが、表示は StatsPhaseCard.css 側が優先されるため問題なし。