### PR TITLE
refactor: touch/scroll責務整理・モーダル共通設計コメント追加（Issue #194/196）

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -9,6 +9,23 @@ export function useModalClose() {
   return useContext(ModalCloseContext)
 }
 
+/**
+ * 共通モーダルベースコンポーネント。
+ *
+ * 全モーダル（AddHabitModal / HelpModal / SettingsModal / ConfirmModal 等）はこのコンポーネントを使う。
+ *
+ * 共通で処理していること:
+ * - safe-area: .modal-sheet の padding-bottom に env(safe-area-inset-bottom) を適用
+ * - scroll: overscroll-behavior: contain でスクロール連鎖を防止
+ * - animation: slideUp / slideDown + backdrop fade
+ * - drag-to-close: 下スワイプで閉じる（scrollTop === 0 のときのみ）
+ * - focus: アニメーション完了後に sheetRef へ focus（キーボード対応）
+ * - iOS PWA: modal-open クラスで背後のスクロールをロック、テーマカラーを暗くする
+ * - reduced-motion: prefers-reduced-motion 時はアニメーションをスキップ
+ *
+ * 新モーダルを追加するときはこのコンポーネントをラップするだけでよい。
+ * safe-area / scroll / keyboard 対応は自動的に適用される。
+ */
 export default function Modal({ onClose, children, title }) {
   const [closing, setClosing] = useState(false)
   const sheetRef = useRef(null)
@@ -24,6 +41,7 @@ export default function Modal({ onClose, children, title }) {
   }, [])
 
   useEffect(() => {
+    // iOS PWA: .modal-open でバックグラウンドのスクロールを防ぐ
     document.documentElement.classList.add('modal-open')
     const meta = document.querySelector('meta[name="theme-color"]')
     const prevColor = meta?.getAttribute('content') ?? null
@@ -54,6 +72,7 @@ export default function Modal({ onClose, children, title }) {
     closeTimerRef.current = setTimeout(onClose, CLOSE_DURATION)
   }, [closing, onClose])
 
+  // drag-to-close: scrollTop が 0 のときのみ下スワイプで閉じる
   const handleTouchStart = (e) => {
     if (closing) return
     if (sheetRef.current.scrollTop > 0) return
@@ -63,6 +82,7 @@ export default function Modal({ onClose, children, title }) {
   }
 
   const handleTouchMove = (e) => {
+    // モーダル内の touchmove が外側（タブスワイプ等）に伝播しないよう stopPropagation
     e.stopPropagation()
     if (closing) return
     if (!draggingRef.current) return
@@ -96,6 +116,7 @@ export default function Modal({ onClose, children, title }) {
       className={`modal-backdrop${closing ? ' closing' : ''}`}
       onClick={requestClose}
       onTouchMove={(e) => {
+        // backdrop の touchmove はデフォルト動作（iOS overscroll）を防ぐ
         e.preventDefault()
         e.stopPropagation()
       }}

--- a/src/hooks/useTabSwipe.js
+++ b/src/hooks/useTabSwipe.js
@@ -1,0 +1,94 @@
+import { useState, useCallback, useRef } from 'react'
+
+const SWIPE_THRESHOLD_X = 72
+const SWIPE_MAX_Y = 60
+
+/**
+ * 水平タブスワイプを管理するフック。
+ *
+ * 責務:
+ * - タッチ開始時に水平スワイプか垂直スクロールかを判定
+ * - 水平スワイプ中は tabDragX でリアルタイム追従
+ * - タッチ終了時に SWIPE_THRESHOLD_X 超えでタブ切り替え
+ * - モーダル/編集モード/ロック時はスワイプ無効
+ *
+ * NOTE: iPhone Safari では vertical scroll と水平スワイプが競合しやすいため、
+ * touchmove のリスナーは passive: true で登録する。
+ * （passive: false にすると縦スクロールがカクつく）
+ */
+export function useTabSwipe({ tabOrder, activeTab, onTabChange, disabled }) {
+  const [tabDragX, setTabDragX] = useState(0)
+  const [tabSettling, setTabSettling] = useState(false)
+  const swipeRef = useRef(null)
+
+  const handleStart = useCallback((e) => {
+    if (
+      disabled ||
+      e.touches.length !== 1 ||
+      e.target.closest('button, a, input, textarea, select, [contenteditable], [role="button"], .app-header, .app-footer, .modal-backdrop')
+    ) {
+      swipeRef.current = null
+      return
+    }
+
+    const touch = e.touches[0]
+    swipeRef.current = {
+      x: touch.clientX,
+      y: touch.clientY,
+      horizontal: false,
+      activeIndex: tabOrder.indexOf(activeTab),
+    }
+  }, [disabled, tabOrder, activeTab])
+
+  const handleMove = useCallback((e) => {
+    const swipe = swipeRef.current
+    if (!swipe || e.touches.length !== 1) return
+
+    const touch = e.touches[0]
+    const dx = touch.clientX - swipe.x
+    const dy = touch.clientY - swipe.y
+
+    // 最初の動き方向を確定（水平スワイプか縦スクロールか）
+    if (!swipe.horizontal) {
+      if (Math.abs(dx) > 18 && Math.abs(dx) > Math.abs(dy) * 1.4) {
+        swipe.horizontal = true
+      } else if (Math.abs(dy) > 18 && Math.abs(dy) > Math.abs(dx)) {
+        // 縦方向が先に確定 → スワイプをキャンセル
+        swipeRef.current = null
+        return
+      }
+    }
+
+    if (swipe.horizontal) {
+      const atFirst = swipe.activeIndex === 0 && dx > 0
+      const atLast = swipe.activeIndex === tabOrder.length - 1 && dx < 0
+      setTabSettling(false)
+      // 端に達したときはゴムのように抵抗をかける
+      setTabDragX((atFirst || atLast) ? dx * 0.28 : dx)
+    }
+  }, [tabOrder.length])
+
+  const handleEnd = useCallback((e) => {
+    const swipe = swipeRef.current
+    swipeRef.current = null
+
+    if (!swipe?.horizontal || disabled) {
+      setTabDragX(0)
+      return
+    }
+
+    const touch = e.changedTouches[0]
+    const dx = touch.clientX - swipe.x
+    const dy = touch.clientY - swipe.y
+    setTabSettling(true)
+    setTabDragX(0)
+
+    if (Math.abs(dx) < SWIPE_THRESHOLD_X || Math.abs(dy) > SWIPE_MAX_Y) return
+
+    const nextIndex = dx < 0 ? swipe.activeIndex + 1 : swipe.activeIndex - 1
+    const nextTab = tabOrder[nextIndex]
+    if (nextTab) onTabChange(nextTab)
+  }, [disabled, tabOrder, onTabChange])
+
+  return { tabDragX, tabSettling, setTabSettling, handleStart, handleMove, handleEnd }
+}


### PR DESCRIPTION
## 変更内容

### useTabSwipe.js（新規）
- タブ水平スワイプの責務を App.jsx から分離したカスタムフック
- 水平/縦スクロール判定ロジック、端でのゴム引き抵抗を整理
- passive: true で登録する理由のコメント付き
- 将来 App.jsx に組み込むことでタブスワイプ関連のデバッグが局所化できる

### Modal.jsx（コメント追加）
- 全モーダルの共通処理（safe-area / scroll / focus / iOS PWA / reduced-motion）を JSDoc コメントで明文化
- 新モーダル追加時の設計ガイドとして機能する

## 理由

- touch/scroll制御が複雑化し、再発時のデバッグが困難な状態だった（#194）
- モーダル追加時に共通処理が暗黙的で、各モーダルが独自対応を追加しやすい状態だった（#196）

## 確認方法

動作は変更なし。ビルドが通ることを確認。

## iPhone/PWA影響

Modal.jsx はコメント追加のみ（動作変更なし）。useTabSwipe.js は新規ファイルで App.jsx からは未接続。

## 想定リスク

なし（useTabSwipe は未接続のため、App.jsx の動作は変わらない）

## 補足

useTabSwipe フックの App.jsx への組み込みは、issue/189-remove-edit-icon の App.jsx 変更とのコンフリクトを避けるため、#189 マージ後に別PRで対応する。