### PR TITLE
feat: HabitTip独立カード化・継続習慣一覧表示・達成履歴削除（#208/#209/#211 再適用）

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -683,27 +683,29 @@ export default function App() {
                 )}
               </>
             ) : (
-              <>
-                <div className="habits-grid">
-                  {activeHabits.map(habit => (
-                    <HabitButton
-                      key={habit.id}
-                      habit={habit}
-                      completed={todayRecords.includes(habit.id)}
-                      streak={calcCurrentStreak(habit.id, records)}
-                      onPress={(h) => toggleHabit(h.id, today)}
-                      onLongPress={(h) => setModal({ type: 'longPress', habit: h })}
-                    />
-                  ))}
-                  <button className="add-habit-btn" onClick={() => setModal({ type: 'add' })}>
-                    <span className="add-icon">＋</span>
-                    <span>追加</span>
-                  </button>
-                </div>
-                <HabitTip today={today} />
-              </>
+              <div className="habits-grid">
+                {activeHabits.map(habit => (
+                  <HabitButton
+                    key={habit.id}
+                    habit={habit}
+                    completed={todayRecords.includes(habit.id)}
+                    streak={calcCurrentStreak(habit.id, records)}
+                    onPress={(h) => toggleHabit(h.id, today)}
+                    onLongPress={(h) => setModal({ type: 'longPress', habit: h })}
+                  />
+                ))}
+                <button className="add-habit-btn" onClick={() => setModal({ type: 'add' })}>
+                  <span className="add-icon">＋</span>
+                  <span>追加</span>
+                </button>
+              </div>
             )}
           </section>
+          {!editMode && habits.length > 0 && (
+            <section className="section habit-tip-section">
+              <HabitTip today={today} />
+            </section>
+          )}
             </div>
 
             <div className="tab-panel" ref={statsPanelRef} aria-hidden={activeTab !== 'stats'}>

--- a/src/components/HabitTip.css
+++ b/src/components/HabitTip.css
@@ -1,5 +1,4 @@
 ﻿.habit-tip-card {
-  margin: 8px 16px 4px;
   padding: 10px 14px;
   border-radius: var(--radius-sm, 8px);
   background: var(--color-surface, #f5f5f5);

--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -1,4 +1,3 @@
-
 /* フェーズハイライト（実績画面最上部） */
 .section.record-phase-highlight-section {
   background: var(--color-primary);
@@ -9,47 +8,73 @@
   padding: 16px 20px;
 }
 
-.phase-highlight-label {
-  font-size: 0.78rem;
+.phase-highlight-heading {
+  font-size: 0.72rem;
   font-weight: 700;
-  opacity: 0.8;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.phase-highlight-streak {
-  font-size: 1.3rem;
-  font-weight: 800;
-  line-height: 1.2;
+  opacity: 0.75;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
 }
 
 .phase-highlight-next {
   font-size: 0.82rem;
   opacity: 0.85;
-  margin-top: 2px;
-}
-
-.phase-highlight-tip {
-  font-size: 0.8rem;
-  opacity: 0.75;
   margin-top: 4px;
-  font-style: italic;
 }
 
-.phase-highlight-habit {
+/* 継続中習慣リスト */
+.streak-habit-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.streak-habit-row {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-top: 6px;
-  font-size: 0.8rem;
-  opacity: 0.9;
+  gap: 8px;
+  opacity: 0.85;
 }
 
-.phase-highlight-dot {
+.streak-habit-row--top {
+  opacity: 1;
+}
+
+.streak-habit-dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
+}
+
+.streak-habit-row--top .streak-habit-dot {
+  width: 10px;
+  height: 10px;
+}
+
+.streak-habit-name {
+  flex: 1;
+  font-size: 0.88rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.streak-habit-row--top .streak-habit-name {
+  font-size: 1.0rem;
+  font-weight: 800;
+}
+
+.streak-habit-count {
+  font-size: 0.8rem;
+  font-weight: 700;
+  opacity: 0.9;
+  white-space: nowrap;
+}
+
+.streak-habit-row--top .streak-habit-count {
+  font-size: 0.88rem;
 }
 
 /* 積み上がりセクション */
@@ -126,91 +151,16 @@
   color: var(--color-text-secondary);
 }
 
-/* 達成履歴 */
-.record-history-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.record-history-item {
-  display: grid;
-  grid-template-columns: 48px 1fr auto;
-  align-items: center;
-  gap: 10px;
-  width: 100%;
-  padding: 10px 12px;
-  border-radius: var(--radius-sm);
-  background: var(--color-bg);
-  color: var(--color-text);
-  text-align: left;
-}
-
-.record-history-date {
-  font-size: 0.85rem;
-  font-weight: 800;
-  color: var(--color-primary);
-}
-
-.record-history-dots {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-}
-
-.record-history-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-}
-
-.record-history-count {
-  color: var(--color-text-secondary);
-  font-size: 0.78rem;
-  font-weight: 700;
-}
-
 .record-empty {
   color: var(--color-text-secondary);
   font-size: 0.85rem;
   line-height: 1.5;
 }
 
-/* フェーズハイライト - 追加クラス（Issue #198） */
 .phase-highlight-heading {
   font-size: 0.72rem;
   font-weight: 700;
   opacity: 0.75;
   letter-spacing: 0.04em;
   margin-bottom: 6px;
-}
-
-.phase-highlight-habit-row {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  margin-bottom: 2px;
-}
-
-.phase-highlight-habit-name {
-  font-size: 1.05rem;
-  font-weight: 800;
-  line-height: 1.2;
-}
-
-.phase-highlight-current {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 4px;
-}
-
-.phase-highlight-current-label {
-  font-size: 0.65rem;
-  font-weight: 700;
-  opacity: 0.65;
-  background: rgba(255, 255, 255, 0.2);
-  padding: 1px 6px;
-  border-radius: 20px;
-  white-space: nowrap;
 }

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -21,23 +21,6 @@ function countTotalRecords(records) {
   return Object.values(records).reduce((total, ids) => total + new Set(ids).size, 0)
 }
 
-function getRecentHistory(records, habits, limit = 5) {
-  const habitMap = new Map(habits.map(habit => [habit.id, habit]))
-  return Object.entries(records)
-    .map(([date, ids]) => ({
-      date,
-      habits: [...new Set(ids)].map(id => habitMap.get(id)).filter(Boolean),
-    }))
-    .filter(item => item.habits.length > 0)
-    .sort((a, b) => b.date.localeCompare(a.date))
-    .slice(0, limit)
-}
-
-function formatShortDate(dateStr) {
-  const [, month, day] = dateStr.split('-')
-  return `${Number(month)}/${Number(day)}`
-}
-
 export default function RecordView({
   calendarDate,
   onCalendarDateChange,
@@ -50,11 +33,9 @@ export default function RecordView({
   const monthKey = formatMonthKey(calendarDate)
   const monthCount = countRecordsInMonth(records, monthKey)
   const totalCount = countTotalRecords(records)
-  const recentHistory = getRecentHistory(records, habits)
 
   const activeHabits = habits.filter(h => !h.archivedAt)
 
-  // フェーズごとに習慣を分類
   const habitPhaseList = activeHabits.map(habit => {
     const streak = calcCurrentStreak(habit.id, records)
     return { habit, streak, phase: getHabitPhase(streak) }
@@ -66,35 +47,35 @@ export default function RecordView({
     if (!groupedByPhase[label]) groupedByPhase[label] = []
     groupedByPhase[label].push(item)
   }
-  // 各フェーズ内を連続日数降順にソート
   for (const label of PHASE_ORDER) {
     if (groupedByPhase[label]) {
       groupedByPhase[label].sort((a, b) => b.streak - a.streak)
     }
   }
 
-  // フェーズハイライト：連続日数が最も長い習慣
-  const featured = [...habitPhaseList].sort((a, b) => b.streak - a.streak)[0] ?? null
+  // 継続中習慣（streak > 0）を降順で最大5件
+  const streakingHabits = [...habitPhaseList]
+    .filter(item => item.streak > 0)
+    .sort((a, b) => b.streak - a.streak)
+    .slice(0, 5)
 
   return (
     <>
-      {featured && (
+      {streakingHabits.length > 0 && (
         <section className="section record-phase-highlight-section">
-          <div className="phase-highlight-heading">いま一番続いている習慣</div>
-          <div className="phase-highlight-habit-row">
-            {featured.streak > 0 && (
-              <span className="phase-highlight-dot" style={{ backgroundColor: featured.habit.color }} />
-            )}
-            <div className="phase-highlight-habit-name">{featured.habit.name}</div>
+          <div className="phase-highlight-heading">続いている習慣</div>
+          <div className="streak-habit-list">
+            {streakingHabits.map(({ habit, streak, phase }, i) => (
+              <div key={habit.id} className={`streak-habit-row${i === 0 ? ' streak-habit-row--top' : ''}`}>
+                <span className="streak-habit-dot" style={{ backgroundColor: habit.color }} />
+                <span className="streak-habit-name">{habit.name}</span>
+                <span className="streak-habit-count">{streak}日</span>
+              </div>
+            ))}
           </div>
-          <div className="phase-highlight-streak">{featured.streak > 0 ? `${featured.streak}日継続中` : '今日から始めよう'}</div>
-          <div className="phase-highlight-current">
-            <span className="phase-highlight-current-label">現在地</span>
-            <span className="phase-highlight-label">{featured.phase.label}</span>
-          </div>
-          {featured.phase.daysToNext !== null && (
+          {streakingHabits[0]?.phase.daysToNext !== null && (
             <div className="phase-highlight-next">
-              次の目標：「{featured.phase.next}」まであと{featured.phase.daysToNext}日
+              次の目標：「{streakingHabits[0].phase.next}」まであと{streakingHabits[0].phase.daysToNext}日
             </div>
           )}
         </section>
@@ -147,37 +128,6 @@ export default function RecordView({
               )
             })}
           </div>
-        )}
-      </section>
-
-      <section className="section record-history-section">
-        <div className="section-header">
-          <h2 className="section-title">達成履歴</h2>
-        </div>
-        {recentHistory.length > 0 ? (
-          <div className="record-history-list">
-            {recentHistory.map(item => (
-              <button
-                className="record-history-item"
-                key={item.date}
-                onClick={() => onDayClick(item.date)}
-              >
-                <span className="record-history-date">{formatShortDate(item.date)}</span>
-                <span className="record-history-dots">
-                  {item.habits.slice(0, 8).map(habit => (
-                    <span
-                      className="record-history-dot"
-                      style={{ backgroundColor: habit.color }}
-                      key={habit.id}
-                    />
-                  ))}
-                </span>
-                <span className="record-history-count">{item.habits.length}件</span>
-              </button>
-            ))}
-          </div>
-        ) : (
-          <p className="record-empty">記録が増えると、最近の達成がここに並びます。</p>
         )}
       </section>
     </>


### PR DESCRIPTION
## 概要

PR #213 が誤って issue/206-207-210-phase ブランチをベースにマージされたため、main に変更が届いていなかった。本PRはそのコミット（be6464f）を main に cherry-pick して再適用するもの。

closes #208
closes #209
closes #211

## 変更内容

- HabitTip を習慣一覧とは独立したカードとして表示
- 「一番続いている習慣」を一覧表示に変更
- 実績画面から達成履歴セクションを削除

Generated with Claude Code