### PR TITLE
refactor: 設定画面のセクション構造を整理（#217）

### DIFF
--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -4,11 +4,13 @@
   color: var(--color-text-secondary);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  margin: 16px 0 10px;
+  margin: 0 0 10px;
 }
 
-.settings-section-title:first-child {
-  margin-top: 0;
+.settings-divider {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: 20px 0;
 }
 
 .theme-grid {

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -26,7 +26,7 @@ export function applyTheme(theme) {
 export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate }) {
   return (
     <Modal title="設定" onClose={onClose}>
-      <p className="settings-section-title">テーマカラー</p>
+      <p className="settings-section-title">見た目</p>
       <div className="theme-grid">
         {THEMES.map(theme => (
           <button
@@ -52,7 +52,9 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
         ))}
       </div>
 
-      <p className="settings-section-title">カテゴリ</p>
+      <hr className="settings-divider" />
+
+      <p className="settings-section-title">習慣</p>
       <div className="data-mgmt-list">
         <button className="data-mgmt-btn" onClick={onManageCategories}>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
@@ -62,7 +64,9 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
         </button>
       </div>
 
-      <p className="settings-section-title">データ管理</p>
+      <hr className="settings-divider" />
+
+      <p className="settings-section-title">データ</p>
       <div className="data-mgmt-list">
         <button className="data-mgmt-btn" onClick={onExport}>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">


### PR DESCRIPTION
設定画面のセクションを「見た目 / 習慣 / データ」に整理し、divider で視覚的に区切った。

closes #217

- テーマカラー → 見た目
- カテゴリ → 習慣
- データ管理 → データ
- セクション間に divider 追加（border-top）
- セクションタイトルの上マージンを divider に委譲して統一

Generated with Claude Code