### PR TITLE
fix: バックアップ復元時にcolorCategoriesを保持（#222）

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -386,7 +386,7 @@ export default function App() {
   // --- Export / Import ---
   const handleExport = useCallback(async () => {
     const sanitized = sanitizeImportData({ habits, records })
-    const json = JSON.stringify(sanitized.data, null, 2)
+    const json = JSON.stringify({ ...sanitized.data, colorCategories }, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const filename = `habit-tracker-${today}.json`
     const skippedText = sanitized.skippedUnknownRecords > 0
@@ -467,6 +467,7 @@ export default function App() {
     const dayCount = Object.keys(modal.data.records).length
     setHabits(modal.data.habits)
     setRecords(modal.data.records)
+    if (modal.data.colorCategories) setColorCategories(modal.data.colorCategories)
     setModal(null)
     setToast(`データを復元しました（習慣 ${habitCount}件・記録 ${dayCount}日分）`)
   }, [modal])

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -61,6 +61,9 @@ export function sanitizeImportData(data) {
     data: {
       habits: data.habits,
       records,
+      ...(data.colorCategories && typeof data.colorCategories === 'object' && !Array.isArray(data.colorCategories)
+        ? { colorCategories: data.colorCategories }
+        : {}),
     },
     skippedUnknownRecords,
   }


### PR DESCRIPTION
バックアップのexport/importにcolorCategoriesを含めるようにした。

closes #222

変更点:
- handleExport: JSON出力に colorCategories を追加
- handleImportConfirm: 復元時に colorCategories をセット
- sanitizeImportData: colorCategories を pass-through（型チェック付き）

Generated with Claude Code