### PR TITLE
feat: 実績画面に習慣の進捗ステータス（路線図）を追加 (#229)

### DIFF
--- a/src/components/HabitProgressLine.css
+++ b/src/components/HabitProgressLine.css
@@ -1,0 +1,96 @@
+.hpl-row {
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.hpl-row:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.hpl-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.hpl-habit-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.hpl-habit-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #fff;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hpl-next {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.75);
+  flex-shrink: 0;
+}
+
+.hpl-track {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.hpl-stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  position: relative;
+}
+
+/* Connecting line from previous stage to this stage */
+.hpl-stage:not(:first-child)::before {
+  content: '';
+  position: absolute;
+  top: 5px;
+  left: calc(-50% + 6px);
+  right: calc(50% + 6px);
+  height: 2px;
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.hpl-stage--reached:not(:first-child)::before {
+  background: #fff;
+}
+
+.hpl-node {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  background: transparent;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+}
+
+.hpl-stage--reached .hpl-node {
+  background: #fff;
+  border-color: #fff;
+}
+
+.hpl-stage-label {
+  font-size: 0.6rem;
+  color: rgba(255, 255, 255, 0.6);
+  text-align: center;
+  line-height: 1.3;
+}
+
+.hpl-stage--reached .hpl-stage-label {
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 600;
+}

--- a/src/components/HabitProgressLine.jsx
+++ b/src/components/HabitProgressLine.jsx
@@ -1,0 +1,38 @@
+import './HabitProgressLine.css'
+
+const STAGES = [
+  { label: '脱3日坊主', minDays: 4 },
+  { label: '1週間継続', minDays: 8 },
+  { label: '定着期', minDays: 22 },
+  { label: '安定期', minDays: 67 },
+]
+
+export default function HabitProgressLine({ habit, streak }) {
+  const nextStage = STAGES.find(s => streak < s.minDays)
+
+  return (
+    <div className="hpl-row">
+      <div className="hpl-header">
+        <span className="hpl-habit-dot" style={{ backgroundColor: habit.color }} />
+        <span className="hpl-habit-name">{habit.name}</span>
+        {nextStage && (
+          <span className="hpl-next">NEXT：{nextStage.label}まであと{nextStage.minDays - streak}日</span>
+        )}
+      </div>
+      <div className="hpl-track">
+        {STAGES.map((stage, i) => {
+          const reached = streak >= stage.minDays
+          return (
+            <div
+              key={stage.label}
+              className={`hpl-stage${reached ? ' hpl-stage--reached' : ''}`}
+            >
+              <div className="hpl-node" />
+              <span className="hpl-stage-label">{stage.label}</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -4,8 +4,13 @@
   color: #fff;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0;
   padding: 16px 20px;
+}
+
+.progress-line-list {
+  display: flex;
+  flex-direction: column;
 }
 
 .phase-highlight-heading {

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -1,4 +1,5 @@
 import Calendar from './Calendar'
+import HabitProgressLine from './HabitProgressLine'
 import { calcCurrentStreak, getHabitPhase } from '../utils/stats'
 import './RecordView.css'
 
@@ -53,31 +54,18 @@ export default function RecordView({
     }
   }
 
-  // 継続中習慣（streak > 0）を降順で最大5件
-  const streakingHabits = [...habitPhaseList]
-    .filter(item => item.streak > 0)
-    .sort((a, b) => b.streak - a.streak)
-    .slice(0, 5)
+  const sortedHabits = [...habitPhaseList].sort((a, b) => b.streak - a.streak)
 
   return (
     <>
-      {streakingHabits.length > 0 && (
+      {activeHabits.length > 0 && (
         <section className="section record-phase-highlight-section">
-          <div className="phase-highlight-heading">続いている習慣</div>
-          <div className="streak-habit-list">
-            {streakingHabits.map(({ habit, streak, phase }, i) => (
-              <div key={habit.id} className={`streak-habit-row${i === 0 ? ' streak-habit-row--top' : ''}`}>
-                <span className="streak-habit-dot" style={{ backgroundColor: habit.color }} />
-                <span className="streak-habit-name">{habit.name}</span>
-                <span className="streak-habit-count">{streak}日</span>
-              </div>
+          <div className="phase-highlight-heading">習慣の進捗</div>
+          <div className="progress-line-list">
+            {sortedHabits.map(({ habit, streak }) => (
+              <HabitProgressLine key={habit.id} habit={habit} streak={streak} />
             ))}
           </div>
-          {streakingHabits[0]?.phase.daysToNext !== null && (
-            <div className="phase-highlight-next">
-              次の目標：「{streakingHabits[0].phase.next}」まであと{streakingHabits[0].phase.daysToNext}日
-            </div>
-          )}
         </section>
       )}
 


### PR DESCRIPTION
## 概要
- 実績画面の「続いている習慣」セクションを「習慣の進捗」路線図セクションに置き換え
- `HabitProgressLine` コンポーネントを新規作成
  - 4ステージ（脱3日坊主/1週間継続/定着期/安定期）の路線図表示
  - 到達済みステージは白塗りドット・白ライン、未到達は半透明
  - NEXT：次ステージまでの残り日数を右端に表示
- 全アクティブ習慣をストリーク降順で一覧表示

## テスト
- [ ] 実績タブを開き、「習慣の進捗」カードが表示されることを確認
- [ ] 継続日数に応じてドットが正しく塗りつぶされることを確認
- [ ] NEXT テキストが正しい残日数を表示することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)