### PR TITLE
fix: PWAフッター下余白の再発を抑制

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -75,11 +75,13 @@
   --app-header-height: calc(56px + var(--app-safe-area-top));
   --footer-content-height: 60px;
   --footer-safe-padding: 10px;
-  --footer-safe-bottom: max(var(--footer-safe-padding), var(--app-safe-area-bottom));
+  --footer-safe-bottom-max: 34px;
+  --footer-safe-bottom: clamp(var(--footer-safe-padding), var(--app-safe-area-bottom), var(--footer-safe-bottom-max));
   --footer-total-height: calc(var(--footer-content-height) + var(--footer-safe-bottom));
   --content-bottom-breathing: 24px;
   height: var(--app-screen-height);
   display: flex;
+  position: relative;
   flex-direction: column;
   width: 100%;
   max-width: 480px;
@@ -411,6 +413,10 @@
   touch-action: none;
 }
 
+.app.standalone .app-footer {
+  position: absolute;
+}
+
 .app-footer-inner {
   display: flex;
   align-items: center;
@@ -435,6 +441,10 @@
   z-index: 30;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
   animation: toast-in 0.2s ease;
+}
+
+.app.standalone .undo-toast {
+  position: absolute;
 }
 
 @keyframes toast-in {
@@ -558,6 +568,16 @@
   background: #00e676;
 }
 
+.viewport-debug-safe-probe {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  width: 0;
+  height: var(--app-safe-area-bottom);
+  pointer-events: none;
+  visibility: hidden;
+}
+
 .viewport-debug-panel {
   position: fixed;
   right: 8px;
@@ -570,5 +590,6 @@
   color: #fff;
   font-size: 10px;
   line-height: 1.2;
+  white-space: pre;
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,6 +81,7 @@ export default function App() {
   const scrollRef = useRef(null)
   const headerRef = useRef(null)
   const footerRef = useRef(null)
+  const safeAreaProbeRef = useRef(null)
   const fileInputRef = useRef(null)
   const stableViewportRef = useRef({ width: window.innerWidth, height: 0 })
   const tabSwipeRef = useRef(null)
@@ -183,7 +184,8 @@ export default function App() {
     const setViewportHeight = () => {
       const visualViewport = window.visualViewport
       const currentWidth = Math.round(visualViewport?.width || window.innerWidth)
-      const currentHeight = visualViewport?.height || window.innerHeight
+      const visualHeight = visualViewport?.height || window.innerHeight
+      const currentHeight = Math.max(visualHeight, window.innerHeight)
 
       if (Math.abs(currentWidth - stableViewportRef.current.width) > 40) {
         stableViewportRef.current = { width: currentWidth, height: 0 }
@@ -194,11 +196,29 @@ export default function App() {
       stableViewportRef.current = { width: currentWidth, height }
       document.documentElement.style.setProperty('--app-viewport-height', `${height}px`)
       if (viewportDebug) {
-        const appHeight = document.querySelector('.app')?.getBoundingClientRect().height
+        const appEl = document.querySelector('.app')
+        const appRect = appEl?.getBoundingClientRect()
+        const footerRect = footerRef.current?.getBoundingClientRect()
         const styles = getComputedStyle(document.documentElement)
+        const appStyles = appEl ? getComputedStyle(appEl) : styles
+        const footerStyles = footerRef.current ? getComputedStyle(footerRef.current) : null
+        const afterStyles = scrollRef.current ? getComputedStyle(scrollRef.current, '::after') : null
         const screenHeight = styles.getPropertyValue('--app-screen-height').trim()
+        const displayStandalone = window.matchMedia('(display-mode: standalone)').matches
+        const footerGap = footerRect ? window.innerHeight - footerRect.bottom : 0
+        const safeBottom = safeAreaProbeRef.current?.getBoundingClientRect().height || 0
         setViewportDebugInfo(
-          `vv:${Math.round(currentHeight)} stable:${Math.round(height)} ih:${window.innerHeight} app:${Math.round(appHeight || 0)} shell:${screenHeight}`
+          [
+            `mode:${displayStandalone ? 'standalone' : 'browser'}/${window.navigator.standalone === true ? 'ios-standalone' : 'nav'}`,
+            `vv:${Math.round(visualHeight)} ih:${window.innerHeight} stable:${Math.round(height)}`,
+            `app:${Math.round(appRect?.height || 0)} viewport:${styles.getPropertyValue('--app-viewport-height').trim()} shell:${screenHeight}`,
+            `safe:${Math.round(safeBottom)}px raw:${styles.getPropertyValue('--app-safe-area-bottom').trim()}`,
+            `footerSafe:${footerStyles?.paddingBottom || appStyles.getPropertyValue('--footer-safe-bottom').trim()}`,
+            `footerTotal:${appStyles.getPropertyValue('--footer-total-height').trim()}`,
+            `breath:${appStyles.getPropertyValue('--content-bottom-breathing').trim()}`,
+            `after:${afterStyles?.flexBasis || 'n/a'}`,
+            `gap:${Math.round(footerGap)}`,
+          ].join('\n')
         )
       }
     }
@@ -917,6 +937,7 @@ export default function App() {
 
       {viewportDebug && (
         <>
+          <div ref={safeAreaProbeRef} className="viewport-debug-safe-probe" />
           <div className="viewport-debug-shell-bar" />
           <div className="viewport-debug-fixed-bar" />
           <div className="viewport-debug-panel">{viewportDebugInfo}</div>


### PR DESCRIPTION
## 変更内容

- `visualViewport.height` が `window.innerHeight` より小さく返る環境でも、app shell の高さが小さくならないように調整しました。
- standalone PWA ではフッターとUndoトーストを app shell 内の絶対配置にし、visual viewport の下端差分に引きずられにくくしました。
- `--footer-safe-bottom` に上限を設け、新規ホーム追加PWAで safe-area-bottom が過大に扱われた場合でもフッター下余白へ直結しないようにしました。
- `?debugViewport` の表示を拡張し、新旧PWAで `display-mode`、`navigator.standalone`、viewport、safe-area、footer計算、疑似要素余白を比較しやすくしました。

## 理由

新しくホーム画面に追加したPWAだけでフッター下余白が出るため、CSSの単純な崩れではなく、iOS PWAのホーム追加タイミングやsafe-area/visualViewport再評価の差分が関係している可能性があります。
footer側とcontent側のsafe-area計算を壊さず、standalone時の固定位置だけをapp shell基準に寄せることで、既存PWA・新規PWAの差を吸収しやすくしました。

## 確認方法

- `npm run build` 成功
- Chrome headless 375x812 で `?debugViewport` 表示を確認

## iPhone/PWA影響

- standalone PWA時のフッター配置を調整しています。
- safe-area対応は削除せず、過大値だけを抑制しています。
- 実機では `?debugViewport` を付けて新旧PWAの値を比較してください。

## 想定リスク

- iOS実機の新旧PWA差分はローカルheadless環境では完全再現できません。
- Safariブラウザ表示では既存のfixed footerを維持しています。

Closes #231