### PR TITLE
fix: 路線図の目標地点を均等配置にする

### DIFF
--- a/src/components/StatsView.css
+++ b/src/components/StatsView.css
@@ -236,36 +236,70 @@
   overflow: hidden;
 }
 
-.phase-milestones {
+.phase-route {
+  position: relative;
+  min-width: 0;
+  padding: 6px 0 14px;
+}
+
+.phase-route-line {
+  position: absolute;
+  top: 10px;
+  right: 0;
+  left: 0;
+  overflow: hidden;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--color-border);
+}
+
+.phase-route-line span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--color-primary);
+  opacity: 0.55;
+}
+
+.phase-route-milestones {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: start;
+}
+
+.phase-route-milestone {
   display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
 }
 
-.phase-milestone {
-  font-size: 0.62rem;
-  font-weight: 600;
-  padding: 1px 6px;
-  border-radius: 20px;
-  white-space: nowrap;
+.phase-route-dot {
+  width: 9px;
+  height: 9px;
+  border: 2px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-surface);
 }
 
-.phase-milestone.achieved {
+.phase-route-milestone.achieved .phase-route-dot {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  opacity: 0.55;
+}
+
+.phase-route-label {
+  overflow: hidden;
+  max-width: 100%;
   color: var(--color-text-secondary);
-  background: var(--color-bg);
-  opacity: 0.5;
-}
-
-.phase-milestone.current {
-  color: var(--color-primary);
-  background: var(--color-primary-light);
+  font-size: 0.58rem;
   font-weight: 700;
-}
-
-.phase-milestone.upcoming {
-  color: var(--color-text-secondary);
-  background: var(--color-bg);
-  opacity: 0.35;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .phase-next-hint {

--- a/src/components/StatsView.css
+++ b/src/components/StatsView.css
@@ -265,7 +265,6 @@
   position: relative;
   z-index: 1;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
   align-items: start;
 }
 

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -6,6 +6,62 @@ import StatsCategoryCard from './StatsCategoryCard'
 import './StatsView.css'
 
 const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
+const ROUTE_MILESTONES = PHASES
+  .filter(phase => Number.isFinite(phase.days))
+  .map(phase => ({ days: phase.days, label: `${phase.days}日` }))
+
+function calcRouteProgress(streak) {
+  if (ROUTE_MILESTONES.length === 0) return 0
+
+  let previousDays = 0
+  let previousPosition = 0
+  const segmentWidth = 100 / ROUTE_MILESTONES.length
+
+  for (let i = 0; i < ROUTE_MILESTONES.length; i++) {
+    const milestone = ROUTE_MILESTONES[i]
+    const nextPosition = segmentWidth * (i + 1)
+
+    if (streak <= milestone.days) {
+      const daysInSegment = milestone.days - previousDays
+      const segmentProgress = daysInSegment > 0
+        ? (streak - previousDays) / daysInSegment
+        : 1
+      return Math.max(0, Math.min(100, previousPosition + segmentProgress * segmentWidth))
+    }
+
+    previousDays = milestone.days
+    previousPosition = nextPosition
+  }
+
+  return 100
+}
+
+function PhaseRoute({ streak }) {
+  const progress = calcRouteProgress(streak)
+
+  return (
+    <div
+      className="phase-route"
+      aria-label={`習慣化の進捗 ${Math.round(progress)}%`}
+    >
+      <div className="phase-route-line" aria-hidden="true">
+        <span style={{ width: `${progress}%` }} />
+      </div>
+      <div className="phase-route-milestones">
+        {ROUTE_MILESTONES.map(milestone => (
+          <span
+            key={milestone.days}
+            className={`phase-route-milestone${streak >= milestone.days ? ' achieved' : ''}`}
+            aria-label={`${milestone.label}${streak >= milestone.days ? ' 到達済み' : ' 未到達'}`}
+          >
+            <span className="phase-route-dot" />
+            <span className="phase-route-label">{milestone.label}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
 
 function isHabitActiveOn(habit, dateStr) {
   if (habit.createdAt && dateStr < habit.createdAt) return false
@@ -106,25 +162,12 @@ export default function StatsView({ habits, records, today, colorCategories = {}
             <span>習慣化フェーズ</span>
           </div>
           <div className="phase-list">
-            {habitPhases.map(({ habit, streak, phaseInfo, index }) => (
+            {habitPhases.map(({ habit, streak, phaseInfo }) => (
               <div key={habit.id} className="phase-row">
                 <span className="phase-dot" style={{ backgroundColor: habit.color }} />
                 <div className="phase-row-info">
                   <span className="phase-name">{habit.name}</span>
-                  <div className="phase-milestones">
-                    {PHASES.map((p, i) => {
-                      const achieved = i < index
-                      const current = i === index
-                      return (
-                        <span
-                          key={i}
-                          className={`phase-milestone${achieved ? ' achieved' : current ? ' current' : ' upcoming'}`}
-                        >
-                          {p.label}
-                        </span>
-                      )
-                    })}
-                  </div>
+                  <PhaseRoute streak={streak} />
                   {phaseInfo.daysToNext !== null && (
                     <span className="phase-next-hint">あと{phaseInfo.daysToNext}日で「{phaseInfo.next}」へ</span>
                   )}

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -6,9 +6,12 @@ import StatsCategoryCard from './StatsCategoryCard'
 import './StatsView.css'
 
 const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
-const ROUTE_MILESTONES = PHASES
-  .filter(phase => Number.isFinite(phase.days))
-  .map(phase => ({ days: phase.days, label: `${phase.days}日` }))
+const ROUTE_MILESTONES = [
+  { days: 3, label: '3日', name: '脱3日坊主' },
+  ...PHASES
+    .filter(phase => Number.isFinite(phase.days))
+    .map(phase => ({ days: phase.days, label: `${phase.days}日`, name: phase.label })),
+]
 
 function calcRouteProgress(streak) {
   if (ROUTE_MILESTONES.length === 0) return 0
@@ -47,12 +50,16 @@ function PhaseRoute({ streak }) {
       <div className="phase-route-line" aria-hidden="true">
         <span style={{ width: `${progress}%` }} />
       </div>
-      <div className="phase-route-milestones">
+      <div
+        className="phase-route-milestones"
+        style={{ gridTemplateColumns: `repeat(${ROUTE_MILESTONES.length}, minmax(0, 1fr))` }}
+      >
         {ROUTE_MILESTONES.map(milestone => (
           <span
             key={milestone.days}
             className={`phase-route-milestone${streak >= milestone.days ? ' achieved' : ''}`}
-            aria-label={`${milestone.label}${streak >= milestone.days ? ' 到達済み' : ' 未到達'}`}
+            aria-label={`${milestone.name}（${milestone.label}）${streak >= milestone.days ? ' 到達済み' : ' 未到達'}`}
+            title={milestone.name}
           >
             <span className="phase-route-dot" />
             <span className="phase-route-label">{milestone.label}</span>


### PR DESCRIPTION
## 変更内容

- 分析画面の習慣化フェーズ表示を、ラベルチップの並びから路線図型の表示に変更しました。
- 目標地点の丸は `14日` / `30日` / `90日` を均等間隔で配置します。
- 実際の日数差は、丸の位置ではなく進捗線の幅に反映します。
- 現在地の丸は作らず、進捗の主体を線にしました。
- 到達済みの目標丸は控えめに色を付け、未到達の道筋も細線で残します。

## 理由

実日数差で丸を配置すると、次の目標が遠すぎる印象になりやすく、モバイル幅でも見た目が不安定になります。目標地点を均等配置し、進捗量だけを線で表すことで、静かなUIトーンを保ちながら道筋を見やすくしました。

## 確認方法

- `npm run build` 成功
- UI方針レビューで、丸=目標地点、線=進捗主体の方針を確認

## iPhone/PWA影響

- safe-area / footer / scroll の変更はありません。
- 分析画面内の表示変更のみです。

## 想定リスク

- Chrome headlessのデータ投入確認は、この環境ではデバッグポートがすぐ終了したため実施できませんでした。
- 実機では分析タブで、習慣名・日数・路線図が横幅内に収まるか確認してください。

Closes #232