### PR TITLE
feat: 編集導線の初回ヒントを追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -459,6 +459,35 @@
   margin: 4px 0 8px;
 }
 
+.edit-hint {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin: -2px 0 12px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--color-primary-light);
+  color: var(--color-text-secondary);
+  font-size: 0.76rem;
+  font-weight: 600;
+}
+
+.edit-hint span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.edit-hint button {
+  flex: 0 0 auto;
+  color: var(--color-primary);
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 2px 4px;
+}
+
 .footer-btn {
   display: flex;
   flex-direction: column;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,7 @@ import './App.css'
 
 const LAST_BACKUP_KEY = 'habit-tracker-last-backup'
 const ONBOARDING_KEY = 'habit-tracker-onboarding-done'
+const EDIT_HINT_KEY = 'habit-tracker-edit-hint-seen'
 const TAB_ORDER = ['record', 'habit', 'stats']
 const SWIPE_THRESHOLD_X = 72
 const SWIPE_MAX_Y = 60
@@ -53,9 +54,16 @@ export default function App() {
   const [showWelcome, setShowWelcome] = useState(() => {
     try { return !localStorage.getItem(ONBOARDING_KEY) } catch { return false }
   })
+  const [showEditHint, setShowEditHint] = useState(() => {
+    try { return !localStorage.getItem(EDIT_HINT_KEY) } catch { return false }
+  })
   const dismissWelcome = useCallback(() => {
     try { localStorage.setItem(ONBOARDING_KEY, '1') } catch {}
     setShowWelcome(false)
+  }, [])
+  const dismissEditHint = useCallback(() => {
+    try { localStorage.setItem(EDIT_HINT_KEY, '1') } catch {}
+    setShowEditHint(false)
   }, [])
 
   const { habits, records, colorCategories, setHabits, setRecords, setColorCategories } = useHabitsStorage()
@@ -617,6 +625,13 @@ export default function App() {
               )}
             </div>
 
+            {activeHabits.length > 0 && !editMode && showEditHint && (
+              <div className="edit-hint">
+                <span>習慣は長押しで編集できます。</span>
+                <button type="button" onClick={dismissEditHint}>閉じる</button>
+              </div>
+            )}
+
             {habits.length === 0 ? (
               <div className="empty-state">
                 {showWelcome ? (
@@ -692,7 +707,7 @@ export default function App() {
                     completed={todayRecords.includes(habit.id)}
                     streak={calcCurrentStreak(habit.id, records)}
                     onPress={(h) => toggleHabit(h.id, today)}
-                    onLongPress={(h) => setModal({ type: 'longPress', habit: h })}
+                    onLongPress={(h) => { dismissEditHint(); setModal({ type: 'longPress', habit: h }) }}
                   />
                 ))}
                 <button className="add-habit-btn" onClick={() => setModal({ type: 'add' })}>

--- a/src/components/LongPressModal.css
+++ b/src/components/LongPressModal.css
@@ -79,11 +79,11 @@
   margin-bottom: 8px;
   padding: 13px;
   border-radius: var(--radius-sm);
-  border: 1.5px solid var(--color-border);
-  background: var(--color-surface);
-  color: var(--color-text);
+  border: 1.5px solid var(--color-primary);
+  background: var(--color-primary-light);
+  color: var(--color-primary);
   font-size: 0.95rem;
-  font-weight: 600;
+  font-weight: 700;
   transition: opacity 0.15s;
 }
 


### PR DESCRIPTION
## 変更内容

- 習慣がある通常表示時に、初回のみ「習慣は長押しで編集できます。」というヒントを表示します。
- ヒントの表示済み状態を `localStorage` に保存します。
- ヒントは閉じる、または実際に長押しした時点で非表示にします。
- 長押しモーダル内の「習慣を編集」ボタンを、薄い背景色とprimary色で少しだけ見つけやすくしました。

## 理由

習慣の編集方法に気づきにくいため、記録の流れを止めない範囲で初回だけ導線を出します。文言と見た目は控えめにし、自己啓発感や過剰な演出を避けています。

## 確認方法

- `npm run build` 成功
- UI/UX方針レビューで文言と強調度を確認

## iPhone/PWA影響

- フッター / safe-area / scroll の変更はありません。
- 長押し導線に関わるため、実機では長押し時にモーダルが開き、ヒントが再表示されないことを確認してください。

## 想定リスク

- ヒント表示済みフラグは `localStorage` のため、既存ユーザーには初回として1度表示されます。

Closes #219