### PR TITLE
refactor: モーダル状態をhookへ分離

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,7 @@ import { useHabitsStorage, loadData } from './hooks/useHabitsStorage'
 import { useTheme } from './hooks/useTheme'
 import { usePullToRefresh, PULL_THRESHOLD } from './hooks/usePullToRefresh'
 import { useTabSwipe } from './hooks/useTabSwipe'
+import { useModalState } from './hooks/useModalState'
 import { getToday, getYesterday } from './utils/date'
 import { calcCurrentStreak } from './utils/stats'
 import { sanitizeImportData, validateImportData } from './utils/validation'
@@ -62,7 +63,7 @@ export default function App() {
 
   const [calendarDate, setCalendarDate] = useState(() => new Date())
   const [editMode, setEditMode] = useState(false)
-  const [modal, setModal] = useState(null)
+  const { modal, setModal, closeModal } = useModalState()
   const [toast, setToast] = useState(null)
   const [lastBackupDate, setLastBackupDate] = useState(() => {
     try { return localStorage.getItem(LAST_BACKUP_KEY) || null } catch { return null }
@@ -212,8 +213,6 @@ export default function App() {
       window.removeEventListener('resize', setViewportHeight)
     }
   }, [viewportDebug])
-
-  const closeModal = useCallback(() => setModal(null), [])
 
   const handleTabSelect = useCallback((tab) => {
     if (tabsLocked || tab === activeTab) return

--- a/src/hooks/useModalState.js
+++ b/src/hooks/useModalState.js
@@ -1,0 +1,8 @@
+import { useCallback, useState } from 'react'
+
+export function useModalState(initialModal = null) {
+  const [modal, setModal] = useState(initialModal)
+  const closeModal = useCallback(() => setModal(null), [])
+
+  return { modal, setModal, closeModal }
+}


### PR DESCRIPTION
## 変更内容

- `useModalState` を追加しました。
- `App.jsx` の `modal` / `setModal` / `closeModal` をhook経由にしました。
- 既存のモーダル種別・開閉呼び出しは維持しています。

## 理由

#221 の段階的責務分離の第二段階です。先にマージ済みのタブスワイプ分離に続き、挙動差が出にくいモーダル状態だけを小さく切り出しました。

## 確認方法

- `npm run build` 成功

## iPhone/PWA影響

- UI / safe-area / footer / scroll の変更はありません。
- モーダル状態管理の置き場所だけを変更しています。

## 想定リスク

- 実機では、各モーダルの開閉が従来通り動くことを確認してください。
- #221 の全hook分離ではなく、段階的対応の一部です。

Refs #221