### PR TITLE
fix: PWA下端の紫背景露出を防ぐ

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -51,7 +51,19 @@ html, body {
 html.pwa-standalone,
 html.pwa-standalone body,
 html.pwa-standalone #root {
+  background: var(--color-bg);
+}
+
+html.pwa-standalone body::after {
+  content: "";
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: var(--app-safe-area-top);
   background: var(--color-primary);
+  pointer-events: none;
+  z-index: 28;
 }
 
 html.pwa-standalone.modal-open body::before {


### PR DESCRIPTION
## 変更内容

- PWA standalone時の `html` / `body` / `#root` 背景を `--color-primary` から `--color-bg` に戻しました。
- ヘッダー上部のsafe-areaだけは `body::after` で紫を維持します。

## 理由

#233 のマージ後も、新しくホーム画面に追加したPWAでフッター下の白いsafe-area余白のさらに下に紫背景が露出していました。

原因候補として、standalone時にページ全体の背景を紫にしていたため、app shell下端より外側が見えた時に紫が出ていました。下端に露出する背景はアプリ背景色にし、上端safe-areaだけ紫を維持する形に分けます。

## 確認方法

- `npm run build` 成功

## iPhone/PWA影響

- PWA standalone時の背景色に関わる変更です。
- フッター直下の白いsafe-area余白は許容し、そのさらに下に紫が出ないことを確認してください。
- ヘッダー上部safe-areaは紫のまま自然に見える想定です。

## 想定リスク

- 実機PWA固有の表示差分はローカルでは完全再現できないため、ホーム画面に新規追加したPWAで確認してください。

Refs #231