### PR TITLE
fix: PWAフッターを下端固定に戻す

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -413,10 +413,6 @@
   touch-action: none;
 }
 
-.app.standalone .app-footer {
-  position: absolute;
-}
-
 .app-footer-inner {
   display: flex;
   align-items: center;
@@ -441,10 +437,6 @@
   z-index: 30;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
   animation: toast-in 0.2s ease;
-}
-
-.app.standalone .undo-toast {
-  position: absolute;
 }
 
 @keyframes toast-in {


### PR DESCRIPTION
## 変更内容

- PWA standalone時だけ `.app-footer` を `position: absolute` にする上書きを削除しました。
- Undoトーストも standalone時だけ `absolute` にする上書きを削除しました。
- フッターはブラウザ/PWAともに `position: fixed; bottom: 0` でviewport下端に固定します。

## 理由

#239 で下端に露出する色は紫からアプリ背景色に変わりましたが、不要な余白領域そのものは残っていました。

原因候補として、#233で入れた standalone時の `absolute` 配置により、iOS PWA実機でフッターがviewport下端へ追従できず、フッター下にアプリ背景が露出していた可能性があります。

フッターは本来画面最下部に固定されるべきなので、standalone時の例外を削除して下端固定へ戻します。

## 確認方法

- `npm run build` 成功

## iPhone/PWA影響

- PWA standalone時のフッター配置に関わる変更です。
- 新しくホーム画面に追加したPWAで、フッター下にグレー/紫の不要領域が出ないことを確認してください。
- フッター内の白いsafe-area余白は維持される想定です。

## 想定リスク

- 実機PWA固有の下端挙動はローカルでは完全再現できないため、ホーム画面追加済みPWAで確認してください。

Refs #231