### PR TITLE
fix: フッタ下余白修正 — @supports強制値廃止・env(safe-area)のみに統一

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -74,9 +74,7 @@
 .app {
   --app-header-height: calc(56px + var(--app-safe-area-top));
   --footer-content-height: 60px;
-  --footer-safe-padding: 10px;
-  --footer-safe-bottom-max: 34px;
-  --footer-safe-bottom: clamp(var(--footer-safe-padding), var(--app-safe-area-bottom), var(--footer-safe-bottom-max));
+  --footer-safe-bottom: var(--app-safe-area-bottom);
   --footer-total-height: calc(var(--footer-content-height) + var(--footer-safe-bottom));
   --content-bottom-breathing: 24px;
   height: var(--app-screen-height);
@@ -103,12 +101,6 @@
   background: var(--color-primary);
   pointer-events: none;
   z-index: 29;
-}
-
-@supports (-webkit-touch-callout: none) {
-  .app {
-    --footer-safe-padding: 20px;
-  }
 }
 
 .app.standalone {
@@ -408,7 +400,7 @@
   background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-  padding-bottom: var(--footer-safe-bottom);
+  height: var(--footer-total-height);
   z-index: 20;
   touch-action: none;
 }


### PR DESCRIPTION
## 概要

フッタ下の白余白問題を修正。

### 変更前の問題
- `--footer-safe-padding: 10px`（デフォルト）、iOS `@supports` で `20px` に強制
- `--footer-safe-bottom: clamp(10px, env(safe-area-inset-bottom), 34px)` — 最低10〜20pxを保証
- home indicator なし端末（iPhone SE等）でも最低10〜20pxの余白が入り、フッタ下に白帯が見えていた
- `.app-footer` は `padding-bottom` でサイズを確保（height は内容依存）

### 変更後
- `--footer-safe-padding` 変数・`@supports` ブロックを完全削除
- `--footer-safe-bottom: var(--app-safe-area-bottom)` = `env(safe-area-inset-bottom, 0px)` のみ
- `.app-footer` を `height: var(--footer-total-height)` の明示的な height に変更
- `.app-footer-inner`（60px）がタブボタンを担い、残りの safe-area 分はフッタ背景が塗る

### 期待結果
- home indicator なし端末: `env() = 0px` → フッタ = 60px、白余白なし
- home indicator あり端末: `env() ≈ 34px` → フッタ = 94px、背景が safe-area を覆う
- `.tab-panel::after` は `--footer-total-height` を参照するため自動追従

## テスト
- [ ] Safari 通常表示でフッタが正常に表示されること
- [ ] iPhone ホーム画面追加（PWA standalone）でフッタ下に白余白が出ないこと
- [ ] ホームインジケータに tab ボタンが被らないこと
- [ ] 最下部コンテンツがフッタに隠れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)