### PR TITLE
fix: フッターをsafe-areaの上に固定する

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -392,7 +392,7 @@
 .app-footer {
   position: fixed;
   right: 0;
-  bottom: 0;
+  bottom: var(--app-safe-area-bottom);
   left: 0;
   margin: 0 auto;
   width: 100%;
@@ -400,7 +400,7 @@
   background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-  height: var(--footer-total-height);
+  height: var(--footer-content-height);
   z-index: 20;
   touch-action: none;
 }
@@ -409,7 +409,7 @@
   display: flex;
   align-items: center;
   justify-content: space-around;
-  height: var(--footer-content-height);
+  height: 100%;
 }
 
 .undo-toast {


### PR DESCRIPTION
## 概要

PWA standalone時にフッター下へ白い余白が見えていた原因として、`.app-footer` 自体の高さに safe-area-bottom を含めていた設計を修正しました。

## 変更内容

- `.app-footer` の高さを `--footer-content-height` の 60px 固定に変更
- `.app-footer` を `bottom: var(--app-safe-area-bottom)` でホームインジケータ領域の上に配置
- `.app-footer-inner` は親要素の高さに追従するよう `height: 100%` に変更
- `--footer-total-height` はスクロール余白・toast位置計算用として維持

## 修正意図

safe-area-bottom を footer 本体の内部余白として扱うと、iOS PWAで `34px` などが返った場合に footer が `60px + 34px` となり、innerとの差分が白い余白として見えていました。

今回の修正では safe-area を footer の外側配置に使い、footer 自体は見た目上 60px のままにしています。

## 確認

- `npm run build` 成功

## 期待される状態

- 新しくホーム画面へ追加したPWAでも、フッター本体の下に白い余白が出ない
- フッターはホームインジケータに被らない
- `--footer-total-height` によるスクロール余白は維持され、コンテンツ最下部がフッターに隠れない