### PR TITLE
fix: フッター背景をsafe-areaまで塗る

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -392,7 +392,7 @@
 .app-footer {
   position: fixed;
   right: 0;
-  bottom: var(--app-safe-area-bottom);
+  bottom: 0;
   left: 0;
   margin: 0 auto;
   width: 100%;
@@ -400,7 +400,7 @@
   background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-  height: var(--footer-content-height);
+  height: var(--footer-total-height);
   z-index: 20;
   touch-action: none;
 }
@@ -409,7 +409,7 @@
   display: flex;
   align-items: center;
   justify-content: space-around;
-  height: 100%;
+  height: var(--footer-content-height);
 }
 
 .undo-toast {


### PR DESCRIPTION
## 概要

PR #243 の修正で `.app-footer` を `bottom: var(--app-safe-area-bottom)` にした結果、フッターがホームインジケータ分だけ上に浮き、下に body / #root のグレー背景が露出していました。

今回の修正では、フッター自体は `bottom: 0` に戻し、`height: var(--footer-total-height)` で safe-area-bottom まで白背景で塗ります。操作ボタン領域は `.app-footer-inner` の `60px` に収めたままです。

## 変更内容

- `.app-footer` を `bottom: 0` に戻す
- `.app-footer` の高さを `var(--footer-total-height)` に戻す
- `.app-footer-inner` の高さを `var(--footer-content-height)` に戻す
- `.tab-panel::after` のスクロール余白計算は変更なし

## 期待される状態

- ホームインジケータ周辺まで footer の白背景になる
- footer 下にグレー余白が出ない
- ボタンはホームインジケータに被らない
- コンテンツ最下部はフッターに隠れない

## 確認

- `npm run build` 成功