### PR TITLE
fix: フッター直上の余白を調整する

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -223,7 +223,7 @@
    flex item として末尾に挿入することで確実にスクロール余地を確保する */
 .tab-panel::after {
   content: "";
-  flex: 0 0 calc(var(--footer-total-height) + var(--content-bottom-breathing));
+  flex: 0 0 calc(var(--footer-content-height) + var(--content-bottom-breathing));
 }
 
 


### PR DESCRIPTION
## 概要

footer 側で safe-area-bottom まで白背景を塗るようにした後、`.tab-panel::after` が `--footer-total-height` を使い続けていたため、スクロール余白側でも safe-area 分を確保していました。

今回の修正では、scroll spacer 側は `--footer-content-height` のみを使い、safe-area 分の二重確保を避けます。

## 変更内容

- `.tab-panel::after` の flex-basis を `var(--footer-total-height)` から `var(--footer-content-height)` に変更
- `--content-bottom-breathing` は維持
- footer 本体の `bottom: 0` / `height: var(--footer-total-height)` は維持

## 期待される状態

- footer 直上に不自然な巨大空白が出ない
- 最下部コンテンツが footer に隠れない
- standalone PWA / Safari の両方で自然な余白になる

## 確認

- `npm run build` 成功