### PR TITLE
fix: PWA復帰時にviewportを再同期する

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -230,17 +230,42 @@ export default function App() {
       }
     }
 
+    const refreshTimers = new Set()
+    const refreshViewport = () => {
+      requestAnimationFrame(setViewportHeight)
+      ;[100, 300].forEach((delay) => {
+        const timer = window.setTimeout(() => {
+          refreshTimers.delete(timer)
+          setViewportHeight()
+        }, delay)
+        refreshTimers.add(timer)
+      })
+    }
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        refreshViewport()
+      }
+    }
+
     document.documentElement.classList.toggle('viewport-debug-enabled', viewportDebug)
-    setViewportHeight()
+    refreshViewport()
     window.visualViewport?.addEventListener('resize', setViewportHeight)
     window.visualViewport?.addEventListener('scroll', setViewportHeight)
     window.addEventListener('resize', setViewportHeight)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('pageshow', refreshViewport)
+    window.addEventListener('focus', refreshViewport)
 
     return () => {
       document.documentElement.classList.remove('viewport-debug-enabled')
+      refreshTimers.forEach((timer) => window.clearTimeout(timer))
       window.visualViewport?.removeEventListener('resize', setViewportHeight)
       window.visualViewport?.removeEventListener('scroll', setViewportHeight)
       window.removeEventListener('resize', setViewportHeight)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('pageshow', refreshViewport)
+      window.removeEventListener('focus', refreshViewport)
     }
   }, [viewportDebug])
 


### PR DESCRIPTION
## 概要

iPad / iOS PWAで、ホーム画面アイコンからの新規起動時とアプリ切替からの復帰時に footer 位置が変わる問題に対して、PWA復帰タイミングで viewport 高さを再同期する処理を追加しました。

footer CSS自体は PR #246 の方針どおり `60px / bottom: 0` のまま維持し、復帰時に `--app-viewport-height` が古い値のまま残る可能性へ対応しています。

## 変更内容

- `visibilitychange` で表示復帰時に viewport 再計算
- `pageshow` で viewport 再計算
- `focus` で viewport 再計算
- 復帰直後の iOS viewport 遅延更新に備えて、以下の3段階で再計算
  - `requestAnimationFrame(setViewportHeight)`
  - `setTimeout(setViewportHeight, 100)`
  - `setTimeout(setViewportHeight, 300)`
- 既存の `resize` / `visualViewport.resize` / `visualViewport.scroll` での再計算は維持
- unmount時に追加イベントと遅延タイマーを cleanup

## 期待される状態

- ホーム画面アイコンから起動した時と、アプリ切替から復帰した時で footer 位置が一致する
- iPad / iPhone PWA standalone で footer 位置が変わらない
- Safari通常表示への影響を最小限に抑える

## 確認

- `npm run build` 成功