### PR TITLE
fix: 固定フッタを廃止しflexレイアウトに変更 (#248)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -73,8 +73,6 @@
 
 .app {
   --app-header-height: calc(56px + var(--app-safe-area-top));
-  --footer-content-height: 60px;
-  --content-bottom-breathing: 24px;
   height: var(--app-screen-height);
   display: flex;
   position: relative;
@@ -101,9 +99,6 @@
   z-index: 29;
 }
 
-.app.standalone {
-  --content-bottom-breathing: 32px;
-}
 
 .app-header {
   position: fixed;
@@ -221,7 +216,7 @@
    flex item として末尾に挿入することで確実にスクロール余地を確保する */
 .tab-panel::after {
   content: "";
-  flex: 0 0 calc(var(--footer-content-height) + var(--content-bottom-breathing));
+  flex: 0 0 24px;
 }
 
 
@@ -388,18 +383,14 @@
 
 /* Footer */
 .app-footer {
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  margin: 0 auto;
+  position: static;
+  flex: 0 0 auto;
   width: 100%;
-  max-width: 480px;
   background: var(--color-surface);
   border-top: 2px solid var(--color-primary);
   box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.07);
-  height: var(--footer-content-height);
-  z-index: 20;
+  height: 60px;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
   touch-action: none;
 }
 
@@ -412,7 +403,7 @@
 
 .undo-toast {
   position: fixed;
-  bottom: calc(var(--footer-content-height) + 12px);
+  bottom: 80px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -86,7 +86,6 @@ export default function App() {
   const statsPanelRef = useRef(null)
   const scrollRef = useRef(null)
   const headerRef = useRef(null)
-  const footerRef = useRef(null)
   const safeAreaProbeRef = useRef(null)
   const fileInputRef = useRef(null)
   const stableViewportRef = useRef({ width: window.innerWidth, height: 0 })
@@ -127,7 +126,7 @@ export default function App() {
     const preventChromeScroll = (e) => {
       e.preventDefault()
     }
-    const chromeEls = [headerRef.current, footerRef.current].filter(Boolean)
+    const chromeEls = [headerRef.current].filter(Boolean)
     chromeEls.forEach(el => {
       el.addEventListener('touchmove', preventChromeScroll, { passive: false })
     })
@@ -205,14 +204,11 @@ export default function App() {
       if (viewportDebug) {
         const appEl = document.querySelector('.app')
         const appRect = appEl?.getBoundingClientRect()
-        const footerRect = footerRef.current?.getBoundingClientRect()
         const styles = getComputedStyle(document.documentElement)
         const appStyles = appEl ? getComputedStyle(appEl) : styles
-        const footerStyles = footerRef.current ? getComputedStyle(footerRef.current) : null
         const afterStyles = scrollRef.current ? getComputedStyle(scrollRef.current, '::after') : null
         const screenHeight = styles.getPropertyValue('--app-screen-height').trim()
         const displayStandalone = window.matchMedia('(display-mode: standalone)').matches
-        const footerGap = footerRect ? window.innerHeight - footerRect.bottom : 0
         const safeBottom = safeAreaProbeRef.current?.getBoundingClientRect().height || 0
         setViewportDebugInfo(
           [
@@ -220,11 +216,7 @@ export default function App() {
             `vv:${Math.round(visualHeight)} ih:${window.innerHeight} stable:${Math.round(height)}`,
             `app:${Math.round(appRect?.height || 0)} viewport:${styles.getPropertyValue('--app-viewport-height').trim()} shell:${screenHeight}`,
             `safe:${Math.round(safeBottom)}px raw:${styles.getPropertyValue('--app-safe-area-bottom').trim()}`,
-            `footerHeight:${footerStyles?.height || appStyles.getPropertyValue('--footer-content-height').trim()}`,
-            `footerBottom:${footerStyles?.bottom || 'n/a'}`,
-            `breath:${appStyles.getPropertyValue('--content-bottom-breathing').trim()}`,
             `after:${afterStyles?.flexBasis || 'n/a'}`,
-            `gap:${Math.round(footerGap)}`,
           ].join('\n')
         )
       }
@@ -875,7 +867,6 @@ export default function App() {
       {toast && <Toast message={toast} onDismiss={() => setToast(null)} />}
 
       <footer
-        ref={footerRef}
         className="app-footer"
       >
         <div className="app-footer-inner">


### PR DESCRIPTION
## 変更内容

- app-footer を position fixed から position static + flex 0 0 auto に変更
- CSS変数 --footer-content-height、--content-bottom-breathing を削除
- tab-panel::after のスペーサーを固定値 24px に変更
- undo-toast の bottom を固定値 80px に変更
- App.jsx から footerRef、フッタ向け touchmove リスナー、デバッグパネルの不要な参照を削除

## 方針

ISSUE #248 の実装計画に従い、固定フッタを廃止して .app の flex 子要素として配置する。
overflow: hidden チェーンと横スワイプ構造は維持し、縦スクロールのみのシンプルな構造に変更。

## テスト

- npm run build 成功確認済み
- safe-area-inset-bottom は padding-bottom: env(safe-area-inset-bottom, 0px) でフッタ要素に直接指定

Closes #248