### PR TITLE
fix: PWA standalone の白余白をshell背景色統一で修正 (#248)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -48,12 +48,6 @@ html, body {
   background: var(--color-bg);
 }
 
-html.pwa-standalone,
-html.pwa-standalone body,
-html.pwa-standalone #root {
-  background: var(--color-surface);
-}
-
 html.pwa-standalone body::after {
   content: "";
   position: fixed;


### PR DESCRIPTION
## 概要

ISSUE #248 追記への対応。PWA standalone で画面下に白い余白が見える問題を修正。

## 原因

`html.pwa-standalone body` / `html.pwa-standalone #root` の背景色が `var(--color-surface)`（白）に設定されており、`--app-screen-height` の計算タイミングがずれて `.app` の高さが不足した際に白背景が露出していた。

## 修正内容

- `src/index.css` の `html.pwa-standalone body` / `html.pwa-standalone #root` を白背景にするルールを削除
- `body` / `#root` が常に `var(--color-bg)`（グレー）になり `.app` と同色になるため、高さギャップが生じても視覚的に露出しない

## 関連

#248