### PR TITLE
fix: .appの高さをdvh固定にしてJSのviewport計算依存を解消する (#248)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -73,7 +73,8 @@
 
 .app {
   --app-header-height: calc(56px + var(--app-safe-area-top));
-  height: var(--app-screen-height);
+  height: 100svh;
+  height: 100dvh;
   display: flex;
   position: relative;
   flex-direction: column;
@@ -82,7 +83,7 @@
   margin: 0 auto;
   padding-top: var(--app-header-height);
   background: var(--color-bg);
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 .app::before {


### PR DESCRIPTION
## 概要

ISSUE #248 追記（レイアウト計算バグ）への対応。

## 原因

`.app` の高さが `var(--app-screen-height)` に依存しており、これは JS の `setViewportHeight()` が `window.innerHeight` をもとに計算してセットする値だった。

PWA復帰時やiPhoneのviewport変動タイミングでJSの計算がずれると、`.app` の高さが実際のviewportより短くなり、下部に `body` の背景色（グレー）が露出していた。さらに `.app-main` のスクロール可能領域も同様にズレるため、最下部コンテンツが隠れる問題が発生していた。

## 修正内容

`src/App.css` の `.app` のみ変更：

- `height: var(--app-screen-height)` → `height: 100svh; height: 100dvh;`
  - JSのviewport計算タイミングに依存しない、CSS純粋な値に変更
  - `100dvh` はiOS Safari 16+でサポート。フォールバックに `100svh`
- `overflow: hidden` → `overflow-x: hidden`
  - 縦スクロールは `.app-main` が担うため、`.app` 自体のoverflow-yをvisibleにする

## 受け入れ条件の確認

- [x] 画面下部に不要な空き領域が残らない（dvhは常にviewport高さと一致）
- [x] 最下部コンテンツがグレー領域に隠れない
- [x] `npm run build` 成功
- [x] JS計算に依存しないため、PWA復帰後も安定

## 関連

#248