### PR TITLE
feat: localStorageフラグによるPWA実機デバッグ表示の常駐化 (#248)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,9 +42,26 @@ const LAST_BACKUP_KEY = 'habit-tracker-last-backup'
 const ONBOARDING_KEY = 'habit-tracker-onboarding-done'
 const EDIT_HINT_KEY = 'habit-tracker-edit-hint-seen'
 const BACKUP_DIR_NAME = 'habit-tracker-backups'
+const DEBUG_VIEWPORT_KEY = 'habit-tracker-debug-viewport'
 
 export default function App() {
-  const viewportDebug = new URLSearchParams(window.location.search).has('debugViewport')
+  // ?debugViewport アクセス時に localStorage にフラグを保存してリダイレクト
+  if (new URLSearchParams(window.location.search).has('debugViewport')) {
+    try { localStorage.setItem(DEBUG_VIEWPORT_KEY, '1') } catch {}
+    const url = new URL(window.location.href)
+    url.searchParams.delete('debugViewport')
+    window.history.replaceState(null, '', url.toString())
+  }
+  const [viewportDebug, setViewportDebug] = useState(() => {
+    try { return localStorage.getItem(DEBUG_VIEWPORT_KEY) === '1' } catch { return false }
+  })
+  const toggleViewportDebug = useCallback(() => {
+    setViewportDebug(prev => {
+      const next = !prev
+      try { next ? localStorage.setItem(DEBUG_VIEWPORT_KEY, '1') : localStorage.removeItem(DEBUG_VIEWPORT_KEY) } catch {}
+      return next
+    })
+  }, [])
   const isStandalone =
     window.matchMedia('(display-mode: standalone)').matches ||
     window.navigator.standalone === true
@@ -183,16 +200,22 @@ export default function App() {
       if (viewportDebug) {
         const appEl = document.querySelector('.app')
         const appRect = appEl?.getBoundingClientRect()
+        const appMainEl = document.querySelector('.app-main')
+        const lastSection = appMainEl?.lastElementChild
+        const lastSectionBottom = lastSection?.getBoundingClientRect().bottom ?? 0
         const styles = getComputedStyle(document.documentElement)
-        const screenHeight = styles.getPropertyValue('--app-screen-height').trim()
         const displayStandalone = window.matchMedia('(display-mode: standalone)').matches
         const safeBottom = safeAreaProbeRef.current?.getBoundingClientRect().height || 0
         setViewportDebugInfo(
           [
-            `mode:${displayStandalone ? 'standalone' : 'browser'}/${window.navigator.standalone === true ? 'ios-standalone' : 'nav'}`,
-            `vv:${Math.round(visualHeight)} ih:${window.innerHeight} stable:${Math.round(height)}`,
-            `app:${Math.round(appRect?.height || 0)} viewport:${styles.getPropertyValue('--app-viewport-height').trim()} shell:${screenHeight}`,
+            `mode:${displayStandalone ? 'standalone' : 'browser'} nav:${window.navigator.standalone === true ? 'ios-sa' : 'no'}`,
+            `ih:${window.innerHeight} vv:${Math.round(visualHeight)} stable:${Math.round(height)}`,
+            `dch:${document.documentElement.clientHeight}`,
+            `app:${Math.round(appRect?.height || 0)}`,
+            `main-ch:${appMainEl?.clientHeight ?? 0} main-sh:${appMainEl?.scrollHeight ?? 0}`,
+            `lastEl-bottom:${Math.round(lastSectionBottom)}`,
             `safe:${Math.round(safeBottom)}px raw:${styles.getPropertyValue('--app-safe-area-bottom').trim()}`,
+            `vh-css:${styles.getPropertyValue('--app-viewport-height').trim()}`,
           ].join('\n')
         )
       }
@@ -767,6 +790,8 @@ export default function App() {
           onManageCategories={() => { closeModal(); setTimeout(() => setModal({ type: 'categoryManage' }), 50) }}
           onClose={closeModal}
           lastBackupDate={lastBackupDate}
+          debugEnabled={viewportDebug}
+          onToggleDebug={toggleViewportDebug}
         />
       )}
 

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -23,7 +23,7 @@ export function applyTheme(theme) {
   }
 }
 
-export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate }) {
+export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate, debugEnabled, onToggleDebug }) {
   return (
     <Modal title="設定" onClose={onClose}>
       <p className="settings-section-title">見た目</p>
@@ -84,6 +84,21 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
           <span>バックアップから復元</span>
         </button>
       </div>
+
+      {onToggleDebug && (
+        <>
+          <hr className="settings-divider" />
+          <p className="settings-section-title">開発者</p>
+          <div className="data-mgmt-list">
+            <button className="data-mgmt-btn" onClick={onToggleDebug}>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="3" /><path d="M19.07 4.93l-1.41 1.41M5.34 5.34l1.41 1.41M21 12h-2M5 12H3M19.07 19.07l-1.41-1.41M5.34 18.66l1.41-1.41M12 21v-2M12 5V3" />
+              </svg>
+              <span>viewport デバッグ: {debugEnabled ? 'ON' : 'OFF'}</span>
+            </button>
+          </div>
+        </>
+      )}
     </Modal>
   )
 }


### PR DESCRIPTION
## 概要

manifest.webmanifest の start_url が `/habit-tracker/` 固定のため、PWA起動時に `?debugViewport` クエリが落ちてデバッグ手段が使えない問題を解決する。

## 変更内容

### App.jsx
- `DEBUG_VIEWPORT_KEY = 'habit-tracker-debug-viewport'` 定数を追加
- `?debugViewport` アクセス時に localStorage へフラグ保存後リダイレクト（クエリパラメータを除去）
- `viewportDebug` を `const`（URLパラメータのみ）から `useState` に変更 → PWA起動後も状態維持
- デバッグパネル表示情報を拡張:
  - `appMain` の `clientHeight` / `scrollHeight`
  - 最下部セクション要素の `getBoundingClientRect().bottom`
  - `document.documentElement.clientHeight`
  - `navigator.standalone`（ios-sa表示）
  - `display-mode: standalone`

### SettingsModal.jsx
- 「開発者」セクションを追加（`onToggleDebug` props がある場合のみ表示）
- viewport デバッグ ON/OFF トグルボタンを追加

## 有効化方法

1. URLで有効化: `https://junkoma2.github.io/habit-tracker/?debugViewport` にアクセス → localStorageにフラグが保存されリダイレクト
2. 設定画面から: 設定 > 開発者 > viewport デバッグ トグル

PWAのホーム追加後も localStorage フラグが維持されるため、デバッグパネルが常駐表示される。

## 確認項目

- [x] `npm run build` 成功
- [x] `?debugViewport` アクセス時にフラグ保存 + リダイレクト
- [x] 設定画面にトグルが表示される
- [x] 既存の `viewportDebug` / `viewportDebugInfo` state を流用・拡張

Closes #248