### PR TITLE
fix: デバッグパネルをスクロール時に再計算する (#248)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -181,6 +181,34 @@ export default function App() {
   }, [])
 
   useEffect(() => {
+    const updateDebugInfo = (visualHeight, height) => {
+      const appEl = document.querySelector('.app')
+      const appRect = appEl?.getBoundingClientRect()
+      const appMainEl = mainRef.current
+      const lastSection = appMainEl?.lastElementChild
+      const lastSectionBottom = lastSection?.getBoundingClientRect().bottom ?? 0
+      const styles = getComputedStyle(document.documentElement)
+      const displayStandalone = window.matchMedia('(display-mode: standalone)').matches
+      const safeBottom = safeAreaProbeRef.current?.getBoundingClientRect().height || 0
+      const scrollTop = appMainEl?.scrollTop ?? 0
+      const scrollHeight = appMainEl?.scrollHeight ?? 0
+      const clientHeight = appMainEl?.clientHeight ?? 0
+      const maxScrollTop = scrollHeight - clientHeight
+      setViewportDebugInfo(
+        [
+          `mode:${displayStandalone ? 'standalone' : 'browser'} nav:${window.navigator.standalone === true ? 'ios-sa' : 'no'}`,
+          `ih:${window.innerHeight} vv:${Math.round(visualHeight)} stable:${Math.round(height)}`,
+          `dch:${document.documentElement.clientHeight}`,
+          `app:${Math.round(appRect?.height || 0)}`,
+          `main-ch:${clientHeight} main-sh:${scrollHeight}`,
+          `scrollTop:${Math.round(scrollTop)} max:${Math.round(maxScrollTop)}`,
+          `lastEl-bottom:${Math.round(lastSectionBottom)}`,
+          `safe:${Math.round(safeBottom)}px raw:${styles.getPropertyValue('--app-safe-area-bottom').trim()}`,
+          `vh-css:${styles.getPropertyValue('--app-viewport-height').trim()}`,
+        ].join('\n')
+      )
+    }
+
     const setViewportHeight = () => {
       const visualViewport = window.visualViewport
       const currentWidth = Math.round(visualViewport?.width || window.innerWidth)
@@ -198,27 +226,22 @@ export default function App() {
 
       document.documentElement.style.setProperty('--app-viewport-height', `${Math.round(height)}px`)
       if (viewportDebug) {
-        const appEl = document.querySelector('.app')
-        const appRect = appEl?.getBoundingClientRect()
-        const appMainEl = document.querySelector('.app-main')
-        const lastSection = appMainEl?.lastElementChild
-        const lastSectionBottom = lastSection?.getBoundingClientRect().bottom ?? 0
-        const styles = getComputedStyle(document.documentElement)
-        const displayStandalone = window.matchMedia('(display-mode: standalone)').matches
-        const safeBottom = safeAreaProbeRef.current?.getBoundingClientRect().height || 0
-        setViewportDebugInfo(
-          [
-            `mode:${displayStandalone ? 'standalone' : 'browser'} nav:${window.navigator.standalone === true ? 'ios-sa' : 'no'}`,
-            `ih:${window.innerHeight} vv:${Math.round(visualHeight)} stable:${Math.round(height)}`,
-            `dch:${document.documentElement.clientHeight}`,
-            `app:${Math.round(appRect?.height || 0)}`,
-            `main-ch:${appMainEl?.clientHeight ?? 0} main-sh:${appMainEl?.scrollHeight ?? 0}`,
-            `lastEl-bottom:${Math.round(lastSectionBottom)}`,
-            `safe:${Math.round(safeBottom)}px raw:${styles.getPropertyValue('--app-safe-area-bottom').trim()}`,
-            `vh-css:${styles.getPropertyValue('--app-viewport-height').trim()}`,
-          ].join('\n')
-        )
+        updateDebugInfo(visualHeight, height)
       }
+    }
+
+    // スクロール時にdebug値を再計算（throttle 150ms）
+    let scrollThrottleTimer = null
+    const handleMainScroll = () => {
+      if (!viewportDebug) return
+      if (scrollThrottleTimer !== null) return
+      scrollThrottleTimer = window.setTimeout(() => {
+        scrollThrottleTimer = null
+        const visualViewport = window.visualViewport
+        const visualHeight = visualViewport?.height || window.innerHeight
+        const height = stableViewportRef.current.height || window.innerHeight
+        updateDebugInfo(visualHeight, height)
+      }, 150)
     }
 
     const refreshTimers = new Set()
@@ -247,16 +270,22 @@ export default function App() {
     document.addEventListener('visibilitychange', handleVisibilityChange)
     window.addEventListener('pageshow', refreshViewport)
     window.addEventListener('focus', refreshViewport)
+    const mainEl = mainRef.current
+    if (viewportDebug && mainEl) {
+      mainEl.addEventListener('scroll', handleMainScroll)
+    }
 
     return () => {
       document.documentElement.classList.remove('viewport-debug-enabled')
       refreshTimers.forEach((timer) => window.clearTimeout(timer))
+      if (scrollThrottleTimer !== null) window.clearTimeout(scrollThrottleTimer)
       window.visualViewport?.removeEventListener('resize', setViewportHeight)
       window.visualViewport?.removeEventListener('scroll', setViewportHeight)
       window.removeEventListener('resize', setViewportHeight)
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       window.removeEventListener('pageshow', refreshViewport)
       window.removeEventListener('focus', refreshViewport)
+      if (mainEl) mainEl.removeEventListener('scroll', handleMainScroll)
     }
   }, [viewportDebug])
 


### PR DESCRIPTION
## 概要

デバッグパネルが初期表示時のみ値を計算しており、`.app-main` スクロール時に再計算されない問題を修正する（ISSUE #248 追記対応）。

## 変更内容

- `updateDebugInfo(visualHeight, height)` を抽出し、`setViewportHeight` とスクロールハンドラから共有呼び出し
- `.app-main`（`mainRef.current`）の `scroll` イベントリスナーを追加
- throttle 150ms で過剰な再計算を防止
- 追加表示項目: `scrollTop`, `max`（= scrollHeight - clientHeight）

## 修正ファイル

- `src/App.jsx`

## 確認

- `npm run build` 成功