### PR TITLE
fix: PWA新規インストール時のhome indicator 34px余白を解消 (#248)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#6366F1" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="習慣" />
     <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%icon.svg" />


### PR DESCRIPTION
## 問題

iOS PWAで、新規インストール時のみhome indicator zone（34px）がviewport外になり、下部に余白が残る。旧PWAでは同じコードでも発生しない。

## 原因分析

デバッグ値は旧PWA・新PWAで同一（ih=vv=dch=app=793, safe=34px）にもかかわらず視覚的に差がある。

`apple-mobile-web-app-status-bar-style: black-translucent` はiOSがviewportをステータスバーの下まで拡張するモードで、新規インストール時にhome indicator zoneとの干渉が起きやすい。iOSはPWAインストール時のシェル設定をキャッシュするため、旧PWAは以前の挙動で継続動作していたと推定される。

## 修正内容

`apple-mobile-web-app-status-bar-style` を `black-translucent` → `black` に変更。

- `black`はステータスバーを独立した不透過領域として確保する
- これによりiOSのviewport計算が安定し、bottom safe-areaがviewport内に正しく収まる
- `viewport-fit=cover` は維持（safe-area-inset-*の利用に必要）

## 副作用

- ステータスバーは黒背景・白文字の不透過表示になる（透過表示ではなくなる）
- アプリコンテンツがステータスバーの下に表示されなくなる（top safe-area相当が確保される）

## テスト

- [ ] iOS PWAで新規インストール後にhome indicator zoneの余白が消えることを確認
- [ ] `npm run build` 成功

Closes #248