### PR TITLE
fix: PWAテーマ変更・バックアップの不具合を修正（#257 #258 #259）

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -418,8 +418,9 @@ export default function App() {
     a.download = filename
     a.click()
     URL.revokeObjectURL(url)
+    markSaved()
     setToast(`バックアップを保存しました${skippedText}`)
-  }, [habits, records, today])
+  }, [habits, records, today, colorCategories])
 
   const handleImportClick = () => fileInputRef.current?.click()
 

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -17,10 +17,6 @@ export function applyTheme(theme) {
   root.setProperty('--color-today', theme.today)
   root.setProperty('--color-today-dark', theme.todayDark)
   document.querySelector('meta[name="theme-color"]')?.setAttribute('content', theme.primary)
-  // PWAモードではbody背景をインラインで直接更新しSafe Areaに即反映
-  if (document.documentElement.classList.contains('pwa-standalone')) {
-    document.body.style.background = theme.primary
-  }
 }
 
 export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate, debugEnabled, onToggleDebug }) {


### PR DESCRIPTION
## 変更概要

3つのISSUEをまとめて対応。変更ファイルはいずれも異なる箇所のため同一PRとした。

## #257 PWAテーマ変更時にbody背景を書き換えない

`applyTheme()` でstandalone時に `document.body.style.background = theme.primary` を設定していた。これはshell背景を `var(--color-bg)` に統一する方針と矛盾するため削除。テーマ色の反映はCSS変数と `meta[name="theme-color"]` に一本化。

## #258 カテゴリ名変更後のバックアップに最新のcolorCategoriesを含める

`handleExport` の `useCallback` 依存配列に `colorCategories` が欠けていた。追加により、カテゴリ名変更直後のバックアップでも最新の状態が出力される。

## #259 ダウンロード経路でも最終バックアップ日を更新する

`showDirectoryPicker` 非対応環境（iPhone等）へのフォールバック時に `markSaved()` を呼んでいなかった。ダウンロード後に `markSaved()` を追加し、設定画面の最終バックアップ日が正しく更新されるよう修正。キャンセル時は従来通り更新しない。

## 確認観点

- PWAでテーマ変更後も下部shell背景が維持される
- カテゴリ名変更後のバックアップJSONに最新カテゴリ名が入る
- iPhone等でバックアップ後に最終日付が更新される