### PR TITLE
refactor: App.jsxからカスタムhookへの段階的分離 (#221)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,6 @@ import {
 import {
   SortableContext,
   verticalListSortingStrategy,
-  arrayMove,
 } from '@dnd-kit/sortable'
 import HabitButton from './components/HabitButton'
 import HabitEditItem from './components/HabitEditItem'
@@ -33,15 +32,16 @@ import { useHabitsStorage, loadData } from './hooks/useHabitsStorage'
 import { useTheme } from './hooks/useTheme'
 import { usePullToRefresh, PULL_THRESHOLD } from './hooks/usePullToRefresh'
 import { useModalState } from './hooks/useModalState'
+import { useHabitActions } from './hooks/useHabitActions'
+import { useBackupManager } from './hooks/useBackupManager'
 import { getToday, getYesterday } from './utils/date'
 import { calcCurrentStreak } from './utils/stats'
-import { sanitizeImportData, validateImportData } from './utils/validation'
 import './App.css'
 
 const LAST_BACKUP_KEY = 'habit-tracker-last-backup'
 const ONBOARDING_KEY = 'habit-tracker-onboarding-done'
-const EDIT_HINT_KEY = 'habit-tracker-edit-hint-seen'
 const BACKUP_DIR_NAME = 'habit-tracker-backups'
+const EDIT_HINT_KEY = 'habit-tracker-edit-hint-seen'
 const DEBUG_VIEWPORT_KEY = 'habit-tracker-debug-viewport'
 
 export default function App() {
@@ -88,16 +88,10 @@ export default function App() {
   const [editMode, setEditMode] = useState(false)
   const { modal, setModal, closeModal } = useModalState()
   const [toast, setToast] = useState(null)
-  const [lastBackupDate, setLastBackupDate] = useState(() => {
-    try { return localStorage.getItem(LAST_BACKUP_KEY) || null } catch { return null }
-  })
   const [viewportDebugInfo, setViewportDebugInfo] = useState('')
-  const [undoAction, setUndoAction] = useState(null)
-  const undoTimerRef = useRef(null)
   const mainRef = useRef(null)
   const headerRef = useRef(null)
   const safeAreaProbeRef = useRef(null)
-  const fileInputRef = useRef(null)
   const stableViewportRef = useRef({ width: window.innerWidth, height: 0 })
   const stableHandlersRef = useRef(null)
 
@@ -118,6 +112,45 @@ export default function App() {
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
   )
+
+  const {
+    undoAction,
+    toggleHabit,
+    handleUndo,
+    addHabit,
+    updateHabit,
+    deleteHabit,
+    archiveHabit,
+    restoreHabit,
+    handleDragEnd,
+  } = useHabitActions({
+    records,
+    today,
+    setHabits,
+    setRecords,
+    setModal,
+    onAddHabit: dismissWelcome,
+  })
+
+  const {
+    lastBackupDate,
+    fileInputRef,
+    handleExport,
+    handleImportClick,
+    handleFileChange,
+    handleImportConfirm,
+  } = useBackupManager({
+    habits,
+    records,
+    colorCategories,
+    today,
+    setHabits,
+    setRecords,
+    setColorCategories,
+    setModal,
+    setToast,
+    modal,
+  })
 
   useEffect(() => {
     document.documentElement.classList.toggle('pwa-standalone', isStandalone)
@@ -289,183 +322,15 @@ export default function App() {
     }
   }, [viewportDebug])
 
-  const toggleHabit = useCallback((habitId, dateStr) => {
-    const wasOn = (records[dateStr] || []).includes(habitId)
-    setRecords(prev => {
-      const dr = prev[dateStr] || []
-      const on = dr.includes(habitId)
-      return {
-        ...prev,
-        [dateStr]: on ? dr.filter(id => id !== habitId) : [...dr, habitId],
-      }
-    })
-    clearTimeout(undoTimerRef.current)
-    if (wasOn) {
-      setUndoAction({ habitId, dateStr })
-      undoTimerRef.current = setTimeout(() => setUndoAction(null), 4000)
-    } else {
-      setUndoAction(null)
-    }
-  }, [records])
-
-  const handleUndo = useCallback(() => {
-    if (!undoAction) return
-    clearTimeout(undoTimerRef.current)
-    const { habitId, dateStr } = undoAction
-    setRecords(prev => {
-      const dr = prev[dateStr] || []
-      if (dr.includes(habitId)) return prev
-      return { ...prev, [dateStr]: [...dr, habitId] }
-    })
-    setUndoAction(null)
-  }, [undoAction])
-
-  const addHabit = useCallback(({ name, color }) => {
-    const id = `h_${Date.now()}`
-    setHabits(prev => [...prev, { id, name, color, createdAt: today }])
-    setModal(null)
-    dismissWelcome()
-  }, [today, dismissWelcome])
-
-  const updateHabit = useCallback(({ name, color }) => {
-    setHabits(prev =>
-      prev.map(h => h.id === modal.habit.id ? { ...h, name, color } : h)
-    )
-    setModal(null)
-  }, [modal])
-
   const handleColorCategoriesUpdate = useCallback((updated) => {
     setColorCategories(updated)
   }, [setColorCategories])
-
-  const deleteHabit = useCallback((habitId) => {
-    setHabits(prev => prev.filter(h => h.id !== habitId))
-    setRecords(prev => {
-      const next = {}
-      for (const [date, ids] of Object.entries(prev)) {
-        const filtered = ids.filter(id => id !== habitId)
-        if (filtered.length > 0) next[date] = filtered
-      }
-      return next
-    })
-    setModal(null)
-  }, [])
-
-  const archiveHabit = useCallback((habitId) => {
-    setHabits(prev => prev.map(h => h.id === habitId ? { ...h, archivedAt: today } : h))
-    setModal(null)
-  }, [today])
-
-  const restoreHabit = useCallback((habitId) => {
-    setHabits(prev => prev.map(h => h.id === habitId ? { ...h, archivedAt: null } : h))
-    setModal(null)
-  }, [])
-
-  const handleDragEnd = useCallback(({ active, over }) => {
-    if (over && active.id !== over.id) {
-      setHabits(prev => {
-        const oldIndex = prev.findIndex(h => h.id === active.id)
-        const newIndex = prev.findIndex(h => h.id === over.id)
-        return arrayMove(prev, oldIndex, newIndex)
-      })
-    }
-  }, [])
 
   const isEditableDate = (dateStr) => dateStr === today || dateStr === yesterday
 
   const activeHabits = habits.filter(h => !h.archivedAt)
   const archivedHabits = habits.filter(h => h.archivedAt)
   const todayRecords = records[today] || []
-
-  // --- Export / Import ---
-  const handleExport = useCallback(async () => {
-    const sanitized = sanitizeImportData({ habits, records })
-    const json = JSON.stringify({ ...sanitized.data, colorCategories }, null, 2)
-    const blob = new Blob([json], { type: 'application/json' })
-    const filename = `habit-tracker-${today}.json`
-    const skippedText = sanitized.skippedUnknownRecords > 0
-      ? `（不明な記録 ${sanitized.skippedUnknownRecords}件を除外）`
-      : ''
-
-    const markSaved = () => {
-      try { localStorage.setItem(LAST_BACKUP_KEY, today) } catch {}
-      setLastBackupDate(today)
-    }
-
-    if ('showDirectoryPicker' in window) {
-      try {
-        const rootDir = await window.showDirectoryPicker({ mode: 'readwrite' })
-        const backupDir = await rootDir.getDirectoryHandle(BACKUP_DIR_NAME, { create: true })
-        const fileHandle = await backupDir.getFileHandle(filename, { create: true })
-        const writable = await fileHandle.createWritable()
-        await writable.write(blob)
-        await writable.close()
-        markSaved()
-        setToast(`バックアップを保存しました${skippedText}`)
-        return
-      } catch (error) {
-        if (error?.name === 'AbortError') {
-          setToast('保存をキャンセルしました')
-          return
-        }
-        console.warn('Directory backup failed, falling back to download', error)
-      }
-    }
-
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = filename
-    a.click()
-    URL.revokeObjectURL(url)
-    markSaved()
-    setToast(`バックアップを保存しました${skippedText}`)
-  }, [habits, records, today, colorCategories])
-
-  const handleImportClick = () => fileInputRef.current?.click()
-
-  const handleFileChange = useCallback((e) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    const MAX_FILE_SIZE = 2 * 1024 * 1024
-    if (file.size > MAX_FILE_SIZE) {
-      setModal({ type: 'importError', message: 'ファイルサイズが大きすぎます（上限 2MB）。\nバックアップファイルを確認してください。' })
-      e.target.value = ''
-      return
-    }
-    const reader = new FileReader()
-    reader.onload = (ev) => {
-      try {
-        const data = JSON.parse(ev.target.result)
-        const error = validateImportData(data)
-        if (error) {
-          setModal({ type: 'importError', message: error })
-        } else {
-          const sanitized = sanitizeImportData(data)
-          setModal({
-            type: 'importFile',
-            data: sanitized.data,
-            filename: file.name,
-            skippedUnknownRecords: sanitized.skippedUnknownRecords,
-          })
-        }
-      } catch {
-        setModal({ type: 'importError', message: 'JSONの解析に失敗しました。\nファイルが壊れているか、形式が正しくありません。' })
-      }
-      e.target.value = ''
-    }
-    reader.readAsText(file)
-  }, [])
-
-  const handleImportConfirm = useCallback(() => {
-    const habitCount = modal.data.habits.length
-    const dayCount = Object.keys(modal.data.records).length
-    setHabits(modal.data.habits)
-    setRecords(modal.data.records)
-    if (modal.data.colorCategories) setColorCategories(modal.data.colorCategories)
-    setModal(null)
-    setToast(`復元しました（${habitCount}件・${dayCount}日分）`)
-  }, [modal])
 
   // セクションへスクロール（ヘッダーのアイコンボタンから呼ぶ）
   const scrollToSection = useCallback((id) => {
@@ -730,7 +595,7 @@ export default function App() {
       {modal?.type === 'edit' && (
         <AddHabitModal
           initialHabit={modal.habit}
-          onSave={updateHabit}
+          onSave={({ name, color }) => updateHabit({ name, color, habitId: modal.habit.id })}
           onClose={closeModal}
         />
       )}

--- a/src/hooks/useBackupManager.js
+++ b/src/hooks/useBackupManager.js
@@ -1,0 +1,133 @@
+import { useState, useCallback, useRef } from 'react'
+import { sanitizeImportData, validateImportData } from '../utils/validation'
+
+const LAST_BACKUP_KEY = 'habit-tracker-last-backup'
+const BACKUP_DIR_NAME = 'habit-tracker-backups'
+
+/**
+ * バックアップ/リストア処理を管理するフック。
+ *
+ * 責務:
+ * - JSONへのエクスポート（File System Access API / ダウンロードフォールバック）
+ * - ファイル入力トリガー
+ * - インポートファイルの検証・確認モーダル表示
+ * - インポート確定時のデータ置き換え
+ */
+export function useBackupManager({
+  habits,
+  records,
+  colorCategories,
+  today,
+  setHabits,
+  setRecords,
+  setColorCategories,
+  setModal,
+  setToast,
+  modal,
+}) {
+  const [lastBackupDate, setLastBackupDate] = useState(() => {
+    try { return localStorage.getItem(LAST_BACKUP_KEY) || null } catch { return null }
+  })
+  const fileInputRef = useRef(null)
+
+  const handleExport = useCallback(async () => {
+    const sanitized = sanitizeImportData({ habits, records })
+    const json = JSON.stringify({ ...sanitized.data, colorCategories }, null, 2)
+    const blob = new Blob([json], { type: 'application/json' })
+    const filename = `habit-tracker-${today}.json`
+    const skippedText = sanitized.skippedUnknownRecords > 0
+      ? `（不明な記録 ${sanitized.skippedUnknownRecords}件を除外）`
+      : ''
+
+    const markSaved = () => {
+      try { localStorage.setItem(LAST_BACKUP_KEY, today) } catch {}
+      setLastBackupDate(today)
+    }
+
+    if ('showDirectoryPicker' in window) {
+      try {
+        const rootDir = await window.showDirectoryPicker({ mode: 'readwrite' })
+        const backupDir = await rootDir.getDirectoryHandle(BACKUP_DIR_NAME, { create: true })
+        const fileHandle = await backupDir.getFileHandle(filename, { create: true })
+        const writable = await fileHandle.createWritable()
+        await writable.write(blob)
+        await writable.close()
+        markSaved()
+        setToast(`バックアップを保存しました${skippedText}`)
+        return
+      } catch (error) {
+        if (error?.name === 'AbortError') {
+          setToast('保存をキャンセルしました')
+          return
+        }
+        console.warn('Directory backup failed, falling back to download', error)
+      }
+    }
+
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    a.click()
+    URL.revokeObjectURL(url)
+    markSaved()
+    setToast(`バックアップを保存しました${skippedText}`)
+  }, [habits, records, today, colorCategories, setToast])
+
+  const handleImportClick = useCallback(() => {
+    fileInputRef.current?.click()
+  }, [])
+
+  const handleFileChange = useCallback((e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const MAX_FILE_SIZE = 2 * 1024 * 1024
+    if (file.size > MAX_FILE_SIZE) {
+      setModal({ type: 'importError', message: 'ファイルサイズが大きすぎます（上限 2MB）。\nバックアップファイルを確認してください。' })
+      e.target.value = ''
+      return
+    }
+    const reader = new FileReader()
+    reader.onload = (ev) => {
+      try {
+        const data = JSON.parse(ev.target.result)
+        const error = validateImportData(data)
+        if (error) {
+          setModal({ type: 'importError', message: error })
+        } else {
+          const sanitized = sanitizeImportData(data)
+          setModal({
+            type: 'importFile',
+            data: sanitized.data,
+            filename: file.name,
+            skippedUnknownRecords: sanitized.skippedUnknownRecords,
+          })
+        }
+      } catch {
+        setModal({ type: 'importError', message: 'JSONの解析に失敗しました。\nファイルが壊れているか、形式が正しくありません。' })
+      }
+      e.target.value = ''
+    }
+    reader.readAsText(file)
+  }, [setModal])
+
+  const handleImportConfirm = useCallback(() => {
+    if (!modal?.data) return
+    const habitCount = modal.data.habits.length
+    const dayCount = Object.keys(modal.data.records).length
+    setHabits(modal.data.habits)
+    setRecords(modal.data.records)
+    if (modal.data.colorCategories) setColorCategories(modal.data.colorCategories)
+    setModal(null)
+    setToast(`復元しました（${habitCount}件・${dayCount}日分）`)
+  }, [modal, setHabits, setRecords, setColorCategories, setModal, setToast])
+
+  return {
+    lastBackupDate,
+    fileInputRef,
+    handleExport,
+    handleImportClick,
+    handleFileChange,
+    handleImportConfirm,
+  }
+}

--- a/src/hooks/useHabitActions.js
+++ b/src/hooks/useHabitActions.js
@@ -1,0 +1,106 @@
+import { useState, useCallback, useRef } from 'react'
+import { arrayMove } from '@dnd-kit/sortable'
+
+/**
+ * 習慣のCRUD操作とundo機能を管理するフック。
+ *
+ * 責務:
+ * - 習慣の追加・編集・削除・アーカイブ・復元
+ * - 記録の切り替え（toggle）とundo
+ * - ドラッグによる並び替え
+ */
+export function useHabitActions({ records, today, setHabits, setRecords, setModal, onAddHabit }) {
+  const [undoAction, setUndoAction] = useState(null)
+  const undoTimerRef = useRef(null)
+
+  const toggleHabit = useCallback((habitId, dateStr) => {
+    const wasOn = (records[dateStr] || []).includes(habitId)
+    setRecords(prev => {
+      const dr = prev[dateStr] || []
+      const on = dr.includes(habitId)
+      return {
+        ...prev,
+        [dateStr]: on ? dr.filter(id => id !== habitId) : [...dr, habitId],
+      }
+    })
+    clearTimeout(undoTimerRef.current)
+    if (wasOn) {
+      setUndoAction({ habitId, dateStr })
+      undoTimerRef.current = setTimeout(() => setUndoAction(null), 4000)
+    } else {
+      setUndoAction(null)
+    }
+  }, [records, setRecords])
+
+  const handleUndo = useCallback(() => {
+    if (!undoAction) return
+    clearTimeout(undoTimerRef.current)
+    const { habitId, dateStr } = undoAction
+    setRecords(prev => {
+      const dr = prev[dateStr] || []
+      if (dr.includes(habitId)) return prev
+      return { ...prev, [dateStr]: [...dr, habitId] }
+    })
+    setUndoAction(null)
+  }, [undoAction, setRecords])
+
+  const addHabit = useCallback(({ name, color }) => {
+    const id = `h_${Date.now()}`
+    setHabits(prev => [...prev, { id, name, color, createdAt: today }])
+    setModal(null)
+    onAddHabit?.()
+  }, [today, setHabits, setModal, onAddHabit])
+
+  // updateHabit は modal.habit.id が必要なため、habitId を明示的に引数として受け取る
+  const updateHabit = useCallback(({ name, color, habitId }) => {
+    setHabits(prev =>
+      prev.map(h => h.id === habitId ? { ...h, name, color } : h)
+    )
+    setModal(null)
+  }, [setHabits, setModal])
+
+  const deleteHabit = useCallback((habitId) => {
+    setHabits(prev => prev.filter(h => h.id !== habitId))
+    setRecords(prev => {
+      const next = {}
+      for (const [date, ids] of Object.entries(prev)) {
+        const filtered = ids.filter(id => id !== habitId)
+        if (filtered.length > 0) next[date] = filtered
+      }
+      return next
+    })
+    setModal(null)
+  }, [setHabits, setRecords, setModal])
+
+  const archiveHabit = useCallback((habitId) => {
+    setHabits(prev => prev.map(h => h.id === habitId ? { ...h, archivedAt: today } : h))
+    setModal(null)
+  }, [today, setHabits, setModal])
+
+  const restoreHabit = useCallback((habitId) => {
+    setHabits(prev => prev.map(h => h.id === habitId ? { ...h, archivedAt: null } : h))
+    setModal(null)
+  }, [setHabits, setModal])
+
+  const handleDragEnd = useCallback(({ active, over }) => {
+    if (over && active.id !== over.id) {
+      setHabits(prev => {
+        const oldIndex = prev.findIndex(h => h.id === active.id)
+        const newIndex = prev.findIndex(h => h.id === over.id)
+        return arrayMove(prev, oldIndex, newIndex)
+      })
+    }
+  }, [setHabits])
+
+  return {
+    undoAction,
+    toggleHabit,
+    handleUndo,
+    addHabit,
+    updateHabit,
+    deleteHabit,
+    archiveHabit,
+    restoreHabit,
+    handleDragEnd,
+  }
+}


### PR DESCRIPTION
## 対応ISSUE
Closes #221

## 変更内容

### 追加したhook
- `src/hooks/useHabitActions.js` — 習慣のCRUD操作・record切り替え・undo機能
- `src/hooks/useBackupManager.js` — バックアップ/リストア処理（export・import）

### 既存hookの活用
- `src/hooks/useModalState.js` — すでにorigin/mainで使用済みのため変更なし

### App.jsxの変更
- インラインの関数定義178行を削除
- useHabitActions・useBackupManagerの呼び出しに置き換え
- updateHabitの呼び出し時にhabitIdを明示的に渡すように変更（`{ name, color, habitId }`）
- arrayMove importをApp.jsxから削除（useHabitActionsに移動）

## 方針
- 既存の動作・UIは一切変更なし
- 大規模リライトは実施せず、既存挙動を完全維持したまま関数を移動
- 1コミットで完結（段階的実行済み）

## 確認事項
- [x] `npm run build` 成功（89モジュール変換）
- [x] 既存の全モーダル・習慣操作・バックアップ処理の挙動は変更なし

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>