### PR TITLE
feat: タイトルタップで今日の習慣へ戻る導線を追加（#263）

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -126,6 +126,12 @@
 .app-title {
   flex: 1 1 auto;
   min-width: 0;
+  /* button reset */
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
   color: #fff;
   font-size: 1.25rem;
   font-weight: 700;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -343,6 +343,12 @@ export default function App() {
     main.scrollBy({ top: elTop - mainTop, behavior: 'smooth' })
   }, [])
 
+
+  // タイトルタップで今日の習慣へ戻る
+  const scrollToTop = useCallback(() => {
+    mainRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [])
+
   // handlers の最新版を常に参照できるよう ref で保持
   useLayoutEffect(() => {
     stableHandlersRef.current = {
@@ -361,7 +367,7 @@ export default function App() {
         ref={headerRef}
         className="app-header"
       >
-        <h1 className="app-title">習慣</h1>
+        <button className="app-title" onClick={scrollToTop} aria-label="今日の習慣へ戻る" title="今日の習慣へ戻る">習慣</button>
         <div className="header-actions">
           {/* 実績（カレンダー）へ移動 */}
           <button


### PR DESCRIPTION
## 変更概要

ISSUE #263 の対応。縦スクロール構成でセクションを下まで見たあと、今日の習慣へ素早く戻れる導線がなかった問題を修正。

## 変更内容

### 戻り導線の追加

- ヘッダーの「習慣」タイトルをタップすると `scrollTop: 0` へスムーズスクロールする
- `<h1>` から `<button>` へ変更し、`aria-label="今日の習慣へ戻る"` / `title="今日の習慣へ戻る"` を付与
- iOSでタイトルバーをタップしてトップへ戻るという慣習に合わせた実装

### CSSのボタンリセット

- `.app-title` に `background: none; border: none; padding: 0; cursor: pointer;` を追加
- 既存のビジュアル（色・フォント・レイアウト）は変更なし

## 確認観点

- 実績・分析を見たあと、タイトル「習慣」をタップすると今日の習慣へ戻る
- ヘッダーの外観・他のボタンの動作は変わらない
- iPhone/PWAで縦スクロール体験を損なわない
- `npm run build` 成功

Closes #263