### PR TITLE
refactor: UI構造整理と案内重複削減 (#265-#269)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -124,6 +124,9 @@
 }
 
 .app-title {
+  display: flex;
+  align-items: center;
+  gap: 5px;
   flex: 1 1 auto;
   min-width: 0;
   /* button reset */
@@ -137,8 +140,12 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.title-home-icon {
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 
 .header-actions {
@@ -510,3 +517,8 @@
   white-space: pre;
 }
 
+
+#section-record,
+#section-stats {
+  scroll-margin-top: 8px;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -367,7 +367,12 @@ export default function App() {
         ref={headerRef}
         className="app-header"
       >
-        <button className="app-title" onClick={scrollToTop} aria-label="今日の習慣へ戻る" title="今日の習慣へ戻る">習慣</button>
+        <button className="app-title" onClick={scrollToTop} aria-label="今日の習慣へ戻る" title="今日の習慣へ戻る">
+          習慣
+          {scrolled && (
+            <svg className="title-home-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="18 15 12 9 6 15" /></svg>
+          )}
+        </button>
         <div className="header-actions">
           {/* 実績（カレンダー）へ移動 */}
           <button
@@ -467,7 +472,7 @@ export default function App() {
               )}
             </div>
 
-            {activeHabits.length > 0 && !editMode && showEditHint && (
+            {activeHabits.length > 0 && !editMode && !showWelcome && showEditHint && (
               <div className="edit-hint">
                 <span>習慣は長押しで編集できます。</span>
                 <button type="button" onClick={dismissEditHint}>閉じる</button>
@@ -566,7 +571,7 @@ export default function App() {
           )}
 
           {/* 実績セクション */}
-          <section id="section-record" className="section">
+          <div id="section-record">
             <RecordView
               calendarDate={calendarDate}
               onCalendarDateChange={setCalendarDate}
@@ -576,12 +581,12 @@ export default function App() {
               onDayClick={(dateStr) => setModal({ type: 'day', dateStr })}
               onMonthTitleClick={() => setModal({ type: 'monthPicker' })}
             />
-          </section>
+          </div>
 
           {/* 分析セクション */}
-          <section id="section-stats" className="section">
+          <div id="section-stats">
             <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} />
-          </section>
+          </div>
         </div>
       </main>
 

--- a/src/components/StatsAdviceCard.jsx
+++ b/src/components/StatsAdviceCard.jsx
@@ -1,14 +1,8 @@
 // 達成率に基づく傾向コメント（#195: 評価ではなく支援寄りのトーン）
 function getAdvice(rate7) {
-  if (rate7 === null) {
-    return '記録が増えると、傾向がここに表示されます。'
-  }
-  if (rate7 >= 80) {
-    return '安定したペースで続けられています。'
-  }
-  if (rate7 >= 50) {
-    return '半分以上できています。今の調子を大切に。'
-  }
+  if (rate7 === null) return null
+  if (rate7 >= 80) return '安定したペースで続けられています。'
+  if (rate7 >= 50) return '半分以上できています。今の調子を大切に。'
   return '無理のないペースで続けることが、長続きにつながりやすいです。'
 }
 
@@ -19,10 +13,6 @@ export default function StatsAdviceCard({ rate7, rate30 }) {
     <section className="section">
       <div className="section-header">
         <h2 className="section-title">達成率</h2>
-      </div>
-      <div className="analysis-advice">
-        <span className="analysis-advice-label">直近7日の傾向</span>
-        <p>{advice}</p>
       </div>
       <div className="analysis-rate-grid">
         <div className="analysis-rate-card">
@@ -36,6 +26,7 @@ export default function StatsAdviceCard({ rate7, rate30 }) {
           <span className="analysis-rate-label">直近30日</span>
         </div>
       </div>
+      {advice && <p className="analysis-advice-note">{advice}</p>}
     </section>
   )
 }

--- a/src/components/StatsView.css
+++ b/src/components/StatsView.css
@@ -6,32 +6,10 @@
   text-align: center;
 }
 
-.analysis-advice {
-  padding: 14px;
-  border-radius: var(--radius-sm);
-  background: var(--color-primary-light);
-}
-
-.analysis-advice-label {
-  display: block;
-  margin-bottom: 6px;
-  color: var(--color-primary);
-  font-size: 0.72rem;
-  font-weight: 800;
-}
-
-.analysis-advice p {
-  color: var(--color-text);
-  font-size: 0.9rem;
-  font-weight: 600;
-  line-height: 1.55;
-}
-
 .analysis-rate-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
-  margin-top: 14px;
 }
 
 .analysis-rate-card {
@@ -65,6 +43,13 @@
   font-weight: 700;
 }
 
+.analysis-advice-note {
+  margin-top: 10px;
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
 .analysis-subhead {
   display: flex;
   align-items: baseline;
@@ -74,12 +59,6 @@
   color: var(--color-text);
   font-size: 0.86rem;
   font-weight: 800;
-}
-
-.analysis-subhead small {
-  color: var(--color-text-secondary);
-  font-size: 0.7rem;
-  font-weight: 700;
 }
 
 .analysis-weekday-list {
@@ -159,149 +138,4 @@
   color: var(--color-text-secondary);
   font-size: 0.76rem;
   font-weight: 800;
-}
-
-.analysis-note {
-  color: var(--color-text-secondary);
-  font-size: 0.78rem;
-  line-height: 1.5;
-}
-
-.phase-scale {
-  display: flex;
-  justify-content: space-between;
-  padding: 0 2px;
-  margin-bottom: 10px;
-}
-
-.phase-scale-label {
-  color: var(--color-text-secondary);
-  font-size: 0.66rem;
-}
-
-.phase-list {
-  display: flex;
-  flex-direction: column;
-  gap: 9px;
-}
-
-.phase-row {
-  display: grid;
-  grid-template-columns: 10px 1fr 32px;
-  align-items: start;
-  gap: 8px;
-}
-
-.phase-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.phase-name {
-  font-size: 0.82rem;
-  color: var(--color-text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.phase-tag {
-  font-size: 0.68rem;
-  font-weight: 700;
-  border: 1.5px solid;
-  border-radius: 20px;
-  padding: 1px 7px;
-  white-space: nowrap;
-}
-
-.phase-streak {
-  text-align: right;
-  font-size: 0.72rem;
-  color: var(--color-text-secondary);
-  font-weight: 600;
-}
-
-.phase-note {
-  margin-top: 12px;
-  font-style: italic;
-}
-
-.phase-row-info {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-  overflow: hidden;
-}
-
-.phase-route {
-  position: relative;
-  min-width: 0;
-  padding: 6px 0 14px;
-}
-
-.phase-route-line {
-  position: absolute;
-  top: 10px;
-  right: 0;
-  left: 0;
-  overflow: hidden;
-  height: 2px;
-  border-radius: 999px;
-  background: var(--color-border);
-}
-
-.phase-route-line span {
-  display: block;
-  height: 100%;
-  border-radius: inherit;
-  background: var(--color-primary);
-  opacity: 0.55;
-}
-
-.phase-route-milestones {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  align-items: start;
-}
-
-.phase-route-milestone {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 3px;
-}
-
-.phase-route-dot {
-  width: 9px;
-  height: 9px;
-  border: 2px solid var(--color-border);
-  border-radius: 50%;
-  background: var(--color-surface);
-}
-
-.phase-route-milestone.achieved .phase-route-dot {
-  border-color: var(--color-primary);
-  background: var(--color-primary);
-  opacity: 0.55;
-}
-
-.phase-route-label {
-  overflow: hidden;
-  max-width: 100%;
-  color: var(--color-text-secondary);
-  font-size: 0.58rem;
-  font-weight: 700;
-  text-align: right;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.phase-next-hint {
-  font-size: 0.68rem;
-  color: var(--color-text-secondary);
 }

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -1,74 +1,11 @@
-﻿import { formatDate, parseLocalDate, HABIT_COLORS } from '../utils/date'
-import { calcCurrentStreak, PHASES, getPhase, getHabitPhase } from '../utils/stats'
+import { formatDate, parseLocalDate, HABIT_COLORS } from '../utils/date'
+import { calcCurrentStreak } from '../utils/stats'
 import StatsAdviceCard from './StatsAdviceCard'
 import StatsWeekdayCard from './StatsWeekdayCard'
 import StatsCategoryCard from './StatsCategoryCard'
 import './StatsView.css'
 
 const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
-const ROUTE_MILESTONES = [
-  { days: 3, label: '3日', name: '脱3日坊主' },
-  ...PHASES
-    .filter(phase => Number.isFinite(phase.days))
-    .map(phase => ({ days: phase.days, label: `${phase.days}日`, name: phase.label })),
-]
-
-function calcRouteProgress(streak) {
-  if (ROUTE_MILESTONES.length === 0) return 0
-
-  let previousDays = 0
-  let previousPosition = 0
-  const segmentWidth = 100 / ROUTE_MILESTONES.length
-
-  for (let i = 0; i < ROUTE_MILESTONES.length; i++) {
-    const milestone = ROUTE_MILESTONES[i]
-    const nextPosition = segmentWidth * (i + 1)
-
-    if (streak <= milestone.days) {
-      const daysInSegment = milestone.days - previousDays
-      const segmentProgress = daysInSegment > 0
-        ? (streak - previousDays) / daysInSegment
-        : 1
-      return Math.max(0, Math.min(100, previousPosition + segmentProgress * segmentWidth))
-    }
-
-    previousDays = milestone.days
-    previousPosition = nextPosition
-  }
-
-  return 100
-}
-
-function PhaseRoute({ streak }) {
-  const progress = calcRouteProgress(streak)
-
-  return (
-    <div
-      className="phase-route"
-      aria-label={`習慣化の進捗 ${Math.round(progress)}%`}
-    >
-      <div className="phase-route-line" aria-hidden="true">
-        <span style={{ width: `${progress}%` }} />
-      </div>
-      <div
-        className="phase-route-milestones"
-        style={{ gridTemplateColumns: `repeat(${ROUTE_MILESTONES.length}, minmax(0, 1fr))` }}
-      >
-        {ROUTE_MILESTONES.map(milestone => (
-          <span
-            key={milestone.days}
-            className={`phase-route-milestone${streak >= milestone.days ? ' achieved' : ''}`}
-            aria-label={`${milestone.name}（${milestone.label}）${streak >= milestone.days ? ' 到達済み' : ' 未到達'}`}
-            title={milestone.name}
-          >
-            <span className="phase-route-dot" />
-            <span className="phase-route-label">{milestone.label}</span>
-          </span>
-        ))}
-      </div>
-    </div>
-  )
-}
 
 function isHabitActiveOn(habit, dateStr) {
   if (habit.createdAt && dateStr < habit.createdAt) return false
@@ -135,19 +72,11 @@ function calcColorStats(habits, records, today, colorCategories) {
 }
 
 export default function StatsView({ habits, records, today, colorCategories = {} }) {
-  const activeHabits = habits.filter(habit => !habit.archivedAt)
   const rate7 = calcRateForRange(habits, records, today, 7)
   const rate30 = calcRateForRange(habits, records, today, 30)
   const weekdayRates = calcWeekdayRates(habits, records, today)
   const colorStats = calcColorStats(habits, records, today, colorCategories)
   const hasNamedColors = Object.values(colorCategories).some(v => v?.trim())
-
-  const habitPhases = activeHabits
-    .map(h => {
-      const streak = calcCurrentStreak(h.id, records)
-      return { habit: h, streak, phaseInfo: getHabitPhase(streak), ...getPhase(streak) }
-    })
-    .sort((a, b) => b.streak - a.streak)
 
   if (habits.length === 0) {
     return <p className="analysis-empty">習慣を追加すると、達成率が表示されます。</p>
@@ -162,33 +91,6 @@ export default function StatsView({ habits, records, today, colorCategories = {}
       )}
 
       <StatsWeekdayCard weekdayRates={weekdayRates} />
-
-      {habitPhases.length > 0 && (
-        <section className="section">
-          <div className="analysis-subhead">
-            <span>習慣化フェーズ</span>
-          </div>
-          <div className="phase-list">
-            {habitPhases.map(({ habit, streak, phaseInfo }) => (
-              <div key={habit.id} className="phase-row">
-                <span className="phase-dot" style={{ backgroundColor: habit.color }} />
-                <div className="phase-row-info">
-                  <span className="phase-name">{habit.name}</span>
-                  <PhaseRoute streak={streak} />
-                  {phaseInfo.daysToNext !== null && (
-                    <span className="phase-next-hint">あと{phaseInfo.daysToNext}日で「{phaseInfo.next}」へ</span>
-                  )}
-                </div>
-                <span className="phase-streak">{streak > 0 ? `${streak}日` : '未開始'}</span>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
-      <p className="analysis-note section">
-        今の対象習慣は {activeHabits.length} 件です。達成率は、その日に対象だった習慣だけで計算しています。
-      </p>
     </>
   )
 }


### PR DESCRIPTION
## 対応ISSUE

#265 #266 #267 #268 #269

## 変更内容

### #265 今日の習慣への戻り導線を視覚化
- スクロール後にタイトルボタンの横に上矢印アイコンを表示
- タップで今日の習慣（先頭）へスクロールする動作は既存のまま

### #266 カード入れ子の解消
- section-record / section-stats の外側ラッパーを div に変更
- アンカー移動の機能は維持（scroll-margin-top を追加）

### #267 分析から習慣化フェーズを削除
- StatsViewの習慣化フェーズセクションを削除
- RecordViewの積み上がり（フェーズ別一覧）に役割を集約

### #268 分析画面の情報密度を削減
- StatsAdviceCard: 傾向コメントを数値の下のサブテキストに移動
- analysis-note（計算条件の注記）を削除

### #269 案内の渋滞を防止
- ウェルカム表示中（初回）は長押しヒントを非表示に

## 確認事項
- npm run build 成功
- safe-area / scroll に影響なし（縦スクロール構成を維持）
