### PR TITLE
fix: カード間の余白を全体で均一にそろえる (#271)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -207,6 +207,13 @@
   overflow: hidden;
 }
 
+/* セクショングループ: RecordView/StatsViewなど複数sectionを返すコンポーネントの外側コンテナ */
+.section-group {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 /* Section */
 .section {
   background: var(--color-surface);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -571,7 +571,7 @@ export default function App() {
           )}
 
           {/* 実績セクション */}
-          <div id="section-record">
+          <div id="section-record" className="section-group">
             <RecordView
               calendarDate={calendarDate}
               onCalendarDateChange={setCalendarDate}
@@ -584,7 +584,7 @@ export default function App() {
           </div>
 
           {/* 分析セクション */}
-          <div id="section-stats">
+          <div id="section-stats" className="section-group">
             <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} />
           </div>
         </div>

--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -162,10 +162,3 @@
   line-height: 1.5;
 }
 
-.phase-highlight-heading {
-  font-size: 0.72rem;
-  font-weight: 700;
-  opacity: 0.75;
-  letter-spacing: 0.04em;
-  margin-bottom: 6px;
-}


### PR DESCRIPTION
## 変更内容

- `section-group` クラスを導入し、`gap: 16px` でセクション間隔を統一
- `#section-record` / `#section-stats` のコンテナ div に `section-group` クラスを付与
- RecordView.css の重複した `.phase-highlight-heading` 定義を削除

## 背景

RecordView / StatsView は複数の `<section>` を Fragment で返すが、外側の `<div>` にギャップ指定がなかったため、セクション間の余白が詰まって見えた。`section-group` でコンテナの gap を `main-content` と同じ 16px に統一することで全画面のリズムを揃えた。

## 確認事項

- [ ] iPhone幅で余白が均一に見える
- [ ] `npm run build` 成功

Closes #271