### PR TITLE
feat: カレンダー配置移動・マイルストン統一・連続記録表現改善 (#272/#273/#274)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -207,6 +207,13 @@
   overflow: hidden;
 }
 
+/* セクショングループ: RecordView/StatsViewなど複数sectionを返すコンポーネントの外側コンテナ */
+.section-group {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 /* Section */
 .section {
   background: var(--color-surface);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -571,7 +571,7 @@ export default function App() {
           )}
 
           {/* 実績セクション */}
-          <div id="section-record">
+          <div id="section-record" className="section-group">
             <RecordView
               calendarDate={calendarDate}
               onCalendarDateChange={setCalendarDate}
@@ -584,7 +584,7 @@ export default function App() {
           </div>
 
           {/* 分析セクション */}
-          <div id="section-stats">
+          <div id="section-stats" className="section-group">
             <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} />
           </div>
         </div>

--- a/src/components/HabitProgressLine.jsx
+++ b/src/components/HabitProgressLine.jsx
@@ -1,34 +1,31 @@
+import { MILESTONES, getNextMilestone } from '../utils/stats'
 import './HabitProgressLine.css'
 
-const STAGES = [
-  { label: '脱3日坊主', minDays: 4 },
-  { label: '1週間継続', minDays: 8 },
-  { label: '定着期', minDays: 22 },
-  { label: '安定期', minDays: 67 },
-]
+// 表示するマイルストン（最初の4件 = 1日・4日・1週間・2週間）
+const DISPLAY_MILESTONES = MILESTONES.slice(0, 4)
 
 export default function HabitProgressLine({ habit, streak }) {
-  const nextStage = STAGES.find(s => streak < s.minDays)
+  const next = getNextMilestone(streak)
 
   return (
     <div className="hpl-row">
       <div className="hpl-header">
         <span className="hpl-habit-dot" style={{ backgroundColor: habit.color }} />
         <span className="hpl-habit-name">{habit.name}</span>
-        {nextStage && (
-          <span className="hpl-next">NEXT：{nextStage.label}まであと{nextStage.minDays - streak}日</span>
+        {next && (
+          <span className="hpl-next">あと{next.days - streak}日で{next.label}</span>
         )}
       </div>
       <div className="hpl-track">
-        {STAGES.map((stage, i) => {
-          const reached = streak >= stage.minDays
+        {DISPLAY_MILESTONES.map((milestone) => {
+          const reached = streak >= milestone.days
           return (
             <div
-              key={stage.label}
+              key={milestone.days}
               className={`hpl-stage${reached ? ' hpl-stage--reached' : ''}`}
             >
               <div className="hpl-node" />
-              <span className="hpl-stage-label">{stage.label}</span>
+              <span className="hpl-stage-label">{milestone.label}</span>
             </div>
           )
         })}

--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -162,3 +162,62 @@
   line-height: 1.5;
 }
 
+
+/* 積み上がり一覧（#273: マイルストンラベル付き） */
+.streak-summary-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.streak-summary-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+}
+
+.streak-summary-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.streak-summary-name {
+  flex: 1;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.streak-summary-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+  flex-shrink: 0;
+}
+
+.streak-summary-milestone {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+  padding: 1px 6px;
+  border-radius: 20px;
+  white-space: nowrap;
+}
+
+.streak-summary-days {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  white-space: nowrap;
+}

--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -162,10 +162,3 @@
   line-height: 1.5;
 }
 
-.phase-highlight-heading {
-  font-size: 0.72rem;
-  font-weight: 700;
-  opacity: 0.75;
-  letter-spacing: 0.04em;
-  margin-bottom: 6px;
-}

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -1,9 +1,7 @@
 import Calendar from './Calendar'
 import HabitProgressLine from './HabitProgressLine'
-import { calcCurrentStreak, getHabitPhase } from '../utils/stats'
+import { calcCurrentStreak, MILESTONES } from '../utils/stats'
 import './RecordView.css'
-
-const PHASE_ORDER = ['生活の一部', '日常に馴染んできた', 'リズムができてきた', 'まず2週間続けてみよう']
 
 function formatMonthKey(date) {
   const y = date.getFullYear()
@@ -20,6 +18,13 @@ function countRecordsInMonth(records, monthKey) {
 
 function countTotalRecords(records) {
   return Object.values(records).reduce((total, ids) => total + new Set(ids).size, 0)
+}
+
+// 達成したマイルストン数をラベル付きで返す
+function getMilestoneLabel(streak) {
+  const reached = MILESTONES.filter(m => streak >= m.days)
+  if (reached.length === 0) return null
+  return reached[reached.length - 1].label
 }
 
 export default function RecordView({
@@ -39,36 +44,15 @@ export default function RecordView({
 
   const habitPhaseList = activeHabits.map(habit => {
     const streak = calcCurrentStreak(habit.id, records)
-    return { habit, streak, phase: getHabitPhase(streak) }
+    const milestoneLabel = getMilestoneLabel(streak)
+    return { habit, streak, milestoneLabel }
   })
-
-  const groupedByPhase = {}
-  for (const item of habitPhaseList) {
-    const label = item.phase.label
-    if (!groupedByPhase[label]) groupedByPhase[label] = []
-    groupedByPhase[label].push(item)
-  }
-  for (const label of PHASE_ORDER) {
-    if (groupedByPhase[label]) {
-      groupedByPhase[label].sort((a, b) => b.streak - a.streak)
-    }
-  }
 
   const sortedHabits = [...habitPhaseList].sort((a, b) => b.streak - a.streak)
 
   return (
     <>
-      {activeHabits.length > 0 && (
-        <section className="section record-phase-highlight-section">
-          <div className="phase-highlight-heading">習慣の進捗</div>
-          <div className="progress-line-list">
-            {sortedHabits.map(({ habit, streak }) => (
-              <HabitProgressLine key={habit.id} habit={habit} streak={streak} />
-            ))}
-          </div>
-        </section>
-      )}
-
+      {/* #272: カレンダーを今日の習慣の直後（最上部）に配置 */}
       <section className="section record-calendar-section">
         <Calendar
           date={calendarDate}
@@ -81,6 +65,19 @@ export default function RecordView({
         />
       </section>
 
+      {/* 習慣の進捗（#272: カレンダーの後に移動） */}
+      {activeHabits.length > 0 && (
+        <section className="section record-phase-highlight-section">
+          <div className="phase-highlight-heading">習慣の進捗</div>
+          <div className="progress-line-list">
+            {sortedHabits.map(({ habit, streak }) => (
+              <HabitProgressLine key={habit.id} habit={habit} streak={streak} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* 積み上がり（#273: マイルストン到達ラベルで表示） */}
       <section className="section record-summary-section">
         <div className="section-header">
           <h2 className="section-title">積み上がり</h2>
@@ -93,28 +90,22 @@ export default function RecordView({
         {activeHabits.length === 0 ? (
           <p className="record-empty">習慣を追加すると、積み上がりがここに表示されます。</p>
         ) : (
-          <div className="phase-groups">
-            {PHASE_ORDER.map(phaseLabel => {
-              const items = groupedByPhase[phaseLabel]
-              if (!items || items.length === 0) return null
-              return (
-                <div key={phaseLabel} className="phase-group">
-                  <h3 className="phase-group-title">{phaseLabel}</h3>
-                  {items.map(({ habit, streak, phase }) => (
-                    <div key={habit.id} className="phase-habit-row">
-                      <span className="phase-habit-dot" style={{ backgroundColor: habit.color }} />
-                      <div className="phase-habit-info">
-                        <span className="phase-habit-name">{habit.name}</span>
-                        {streak > 0 && <span className="phase-habit-streak">{streak}日継続中</span>}
-                        {phase.daysToNext !== null && (
-                          <span className="phase-habit-next">あと{phase.daysToNext}日で「{phase.next}」へ</span>
-                        )}
-                      </div>
-                    </div>
-                  ))}
+          <div className="streak-summary-list">
+            {sortedHabits.map(({ habit, streak, milestoneLabel }) => (
+              <div key={habit.id} className="streak-summary-row">
+                <span className="streak-summary-dot" style={{ backgroundColor: habit.color }} />
+                <span className="streak-summary-name">{habit.name}</span>
+                <div className="streak-summary-right">
+                  {milestoneLabel && (
+                    <span className="streak-summary-milestone">{milestoneLabel}</span>
+                  )}
+                  {/* #274: streak 0 のとき「未開始」ではなく空欄にしてやわらかく */}
+                  <span className="streak-summary-days">
+                    {streak > 0 ? `${streak}日継続中` : 'まだ記録なし'}
+                  </span>
                 </div>
-              )
-            })}
+              </div>
+            ))}
           </div>
         )}
       </section>

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -2,7 +2,25 @@ import { formatDate, parseLocalDate } from './date'
 
 const MS_PER_DAY = 86400000
 
-// 習慣化フェーズ定義（habitPhase.js を廃止しここに一本化）
+// 共通マイルストン定義（#273: 全画面で同じ定義を使う）
+export const MILESTONES = [
+  { days: 1,   label: '1日目' },
+  { days: 4,   label: '4日目' },
+  { days: 7,   label: '1週間' },
+  { days: 14,  label: '2週間' },
+  { days: 30,  label: '1か月' },
+  { days: 60,  label: '2か月' },
+  { days: 90,  label: '3か月' },
+  { days: 180, label: '6か月' },
+  { days: 365, label: '1年' },
+]
+
+// 次のマイルストンを返す（null = 全達成）
+export function getNextMilestone(streak) {
+  return MILESTONES.find(m => streak < m.days) ?? null
+}
+
+// 後方互換: 旧 PHASES ベースのAPI（RecordViewの積み上がりグループ表示で使用）
 export const PHASES = [
   { label: 'まず2週間続けてみよう', days: 14 },
   { label: 'リズムができてきた', days: 30 },


### PR DESCRIPTION
## 変更内容

### #272 今日の習慣の直後にカレンダーを配置
- RecordView の表示順を変更: カレンダー → 習慣の進捗 → 積み上がり
- 日々の記録 → 日付確認の流れが自然になる

### #273 進捗フェーズを共通マイルストンへ統一
- `stats.js` に `MILESTONES` 定数を追加（1日/4日/1週間/2週間/1か月/2か月/3か月/6か月/1年）
- `getNextMilestone(streak)` ユーティリティを追加
- `HabitProgressLine` を内部定義から `MILESTONES` 使用に統一
- 積み上がりセクションをフェーズグループ表示からマイルストン到達ラベル付き一覧に変更

### #274 未達成時の表現改善
- 継続日数 0 のときの表示を「まだ記録なし」に変更（「未開始」より穏やかな表現）
- 連続記録ロジックは現行維持（完全リセット）

## 確認事項

- [ ] iPhone幅で表示が崩れない
- [ ] カレンダーが実績セクション先頭に表示される
- [ ] `npm run build` 成功

Closes #272
Closes #273
Closes #274