### PR TITLE
feat: 集計開始日設定を追加し開始前の期間を達成率から除外 (#275)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,7 +81,7 @@ export default function App() {
     setShowEditHint(false)
   }, [])
 
-  const { habits, records, colorCategories, setHabits, setRecords, setColorCategories } = useHabitsStorage()
+  const { habits, records, colorCategories, statsStartDate, setHabits, setRecords, setColorCategories, setStatsStartDate } = useHabitsStorage()
   const { themeId, handleThemeSelect } = useTheme()
 
   const [calendarDate, setCalendarDate] = useState(() => new Date())
@@ -585,7 +585,7 @@ export default function App() {
 
           {/* 分析セクション */}
           <div id="section-stats" className="section-group">
-            <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} />
+            <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} statsStartDate={statsStartDate} />
           </div>
         </div>
       </main>
@@ -696,6 +696,8 @@ export default function App() {
           onManageCategories={() => { closeModal(); setTimeout(() => setModal({ type: 'categoryManage' }), 50) }}
           onClose={closeModal}
           lastBackupDate={lastBackupDate}
+          statsStartDate={statsStartDate}
+          onStatsStartDateChange={setStatsStartDate}
           debugEnabled={viewportDebug}
           onToggleDebug={toggleViewportDebug}
         />

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -125,3 +125,41 @@
   color: var(--color-text-secondary);
   font-weight: 400;
 }
+
+/* 集計開始日設定（#275） */
+.stats-start-date-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.stats-start-date-label {
+  font-size: 0.9rem;
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.stats-start-date-input {
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.88rem;
+  min-width: 0;
+  flex-shrink: 0;
+}
+
+.stats-start-date-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.stats-start-date-hint {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -19,7 +19,7 @@ export function applyTheme(theme) {
   document.querySelector('meta[name="theme-color"]')?.setAttribute('content', theme.primary)
 }
 
-export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate, debugEnabled, onToggleDebug }) {
+export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate, debugEnabled, onToggleDebug, statsStartDate, onStatsStartDateChange }) {
   return (
     <Modal title="設定" onClose={onClose}>
       <p className="settings-section-title">見た目</p>
@@ -59,6 +59,24 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
           <span>カテゴリを管理</span>
         </button>
       </div>
+
+      <hr className="settings-divider" />
+
+      <p className="settings-section-title">分析</p>
+      <div className="stats-start-date-row">
+        <label className="stats-start-date-label" htmlFor="stats-start-date">集計開始日</label>
+        <input
+          id="stats-start-date"
+          type="date"
+          className="stats-start-date-input"
+          value={statsStartDate ?? ''}
+          onChange={e => onStatsStartDateChange(e.target.value || null)}
+          aria-describedby="stats-start-date-hint"
+        />
+      </div>
+      <p className="stats-start-date-hint" id="stats-start-date-hint">
+        この日より前を達成率の分母に含めません
+      </p>
 
       <hr className="settings-divider" />
 

--- a/src/components/StatsAdviceCard.jsx
+++ b/src/components/StatsAdviceCard.jsx
@@ -6,7 +6,14 @@ function getAdvice(rate7) {
   return '無理のないペースで続けることが、長続きにつながりやすいです。'
 }
 
-export default function StatsAdviceCard({ rate7, rate30 }) {
+// statsStartDate がある場合、ラベルを実態に合わせて調整する
+function getRangeLabel(days, statsStartDate) {
+  if (!statsStartDate) return `直近${days}日`
+  // 開始日が設定されている場合はシンプルに表示
+  return `直近${days}日（開始日以降）`
+}
+
+export default function StatsAdviceCard({ rate7, rate30, statsStartDate = null }) {
   const advice = getAdvice(rate7)
 
   return (
@@ -18,12 +25,12 @@ export default function StatsAdviceCard({ rate7, rate30 }) {
         <div className="analysis-rate-card">
           <span className="analysis-rate-value">{rate7 ?? '-'}</span>
           {rate7 !== null && <span className="analysis-rate-unit">%</span>}
-          <span className="analysis-rate-label">直近7日</span>
+          <span className="analysis-rate-label">{getRangeLabel(7, statsStartDate)}</span>
         </div>
         <div className="analysis-rate-card">
           <span className="analysis-rate-value">{rate30 ?? '-'}</span>
           {rate30 !== null && <span className="analysis-rate-unit">%</span>}
-          <span className="analysis-rate-label">直近30日</span>
+          <span className="analysis-rate-label">{getRangeLabel(30, statsStartDate)}</span>
         </div>
       </div>
       {advice && <p className="analysis-advice-note">{advice}</p>}

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -13,14 +13,18 @@ function isHabitActiveOn(habit, dateStr) {
   return true
 }
 
-function calcRateForRange(habits, records, today, days) {
+// statsStartDate が設定されている場合、その日より前は集計対象外にする
+function calcRateForRange(habits, records, today, days, statsStartDate) {
   const end = parseLocalDate(today)
+  const startBound = statsStartDate ? parseLocalDate(statsStartDate) : null
   let achieved = 0
   let total = 0
 
   for (let offset = days - 1; offset >= 0; offset--) {
     const date = new Date(end)
     date.setDate(date.getDate() - offset)
+    // statsStartDate より前の日は集計に含めない
+    if (startBound && date < startBound) continue
     const dateStr = formatDate(date)
     const activeHabits = habits.filter(habit => isHabitActiveOn(habit, dateStr))
     const dayRecords = records[dateStr] || []
@@ -32,13 +36,15 @@ function calcRateForRange(habits, records, today, days) {
   return total > 0 ? Math.round((achieved / total) * 100) : null
 }
 
-function calcWeekdayRates(habits, records, today, days = 30) {
+function calcWeekdayRates(habits, records, today, days = 30, statsStartDate) {
   const end = parseLocalDate(today)
+  const startBound = statsStartDate ? parseLocalDate(statsStartDate) : null
   const buckets = DOW_LABELS.map(label => ({ label, achieved: 0, total: 0 }))
 
   for (let offset = days - 1; offset >= 0; offset--) {
     const date = new Date(end)
     date.setDate(date.getDate() - offset)
+    if (startBound && date < startBound) continue
     const dateStr = formatDate(date)
     const bucket = buckets[date.getDay()]
     const activeHabits = habits.filter(habit => isHabitActiveOn(habit, dateStr))
@@ -54,7 +60,7 @@ function calcWeekdayRates(habits, records, today, days = 30) {
   }))
 }
 
-function calcColorStats(habits, records, today, colorCategories) {
+function calcColorStats(habits, records, today, colorCategories, statsStartDate) {
   const activeHabits = habits.filter(h => !h.archivedAt)
   return HABIT_COLORS
     .filter(color => colorCategories[color]?.trim())
@@ -64,18 +70,18 @@ function calcColorStats(habits, records, today, colorCategories) {
         color,
         name: colorCategories[color],
         count: colorHabits.length,
-        rate: calcRateForRange(colorHabits, records, today, 30),
+        rate: calcRateForRange(colorHabits, records, today, 30, statsStartDate),
       }
     })
     .filter(c => c.count > 0)
     .sort((a, b) => (b.rate ?? -1) - (a.rate ?? -1))
 }
 
-export default function StatsView({ habits, records, today, colorCategories = {} }) {
-  const rate7 = calcRateForRange(habits, records, today, 7)
-  const rate30 = calcRateForRange(habits, records, today, 30)
-  const weekdayRates = calcWeekdayRates(habits, records, today)
-  const colorStats = calcColorStats(habits, records, today, colorCategories)
+export default function StatsView({ habits, records, today, colorCategories = {}, statsStartDate = null }) {
+  const rate7 = calcRateForRange(habits, records, today, 7, statsStartDate)
+  const rate30 = calcRateForRange(habits, records, today, 30, statsStartDate)
+  const weekdayRates = calcWeekdayRates(habits, records, today, 30, statsStartDate)
+  const colorStats = calcColorStats(habits, records, today, colorCategories, statsStartDate)
   const hasNamedColors = Object.values(colorCategories).some(v => v?.trim())
 
   if (habits.length === 0) {
@@ -84,7 +90,7 @@ export default function StatsView({ habits, records, today, colorCategories = {}
 
   return (
     <>
-      <StatsAdviceCard rate7={rate7} rate30={rate30} />
+      <StatsAdviceCard rate7={rate7} rate30={rate30} statsStartDate={statsStartDate} />
 
       {hasNamedColors && (
         <StatsCategoryCard colorStats={colorStats} />

--- a/src/hooks/useHabitsStorage.js
+++ b/src/hooks/useHabitsStorage.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 
 const STORAGE_KEY = 'habit-tracker-v1'
+const SETTINGS_KEY = 'habit-tracker-settings'
 
 export function loadData() {
   try {
@@ -27,16 +28,36 @@ export function loadData() {
   return { habits: [], records: {}, colorCategories: {} }
 }
 
+function loadSettings() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY)
+    if (raw) {
+      const s = JSON.parse(raw)
+      if (s && typeof s === 'object') return s
+    }
+  } catch {}
+  return {}
+}
+
 const _initial = loadData()
+const _initialSettings = loadSettings()
 
 export function useHabitsStorage() {
   const [habits, setHabits] = useState(_initial.habits)
   const [records, setRecords] = useState(_initial.records)
   const [colorCategories, setColorCategories] = useState(_initial.colorCategories)
+  // 集計開始日（YYYY-MM-DD 形式。未設定なら null）
+  const [statsStartDate, setStatsStartDate] = useState(_initialSettings.statsStartDate ?? null)
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ habits, records, colorCategories }))
   }, [habits, records, colorCategories])
 
-  return { habits, records, colorCategories, setHabits, setRecords, setColorCategories }
+  useEffect(() => {
+    const settings = {}
+    if (statsStartDate) settings.statsStartDate = statsStartDate
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings))
+  }, [statsStartDate])
+
+  return { habits, records, colorCategories, statsStartDate, setHabits, setRecords, setColorCategories, setStatsStartDate }
 }


### PR DESCRIPTION
## 変更内容

### 新機能: 集計開始日の設定

- **設定画面** に「分析」セクションを追加し、集計開始日（YYYY-MM-DD）を入力できるようにした
- **データ永続化**: `habit-tracker-settings` キーで localStorage に保存（バックアップ対象外）
- **達成率の計算**: 集計開始日より前の日を分母から除外（直近7日・30日・曜日別・カテゴリ別すべて対応）
- **ラベル表示**: 開始日設定時は「直近N日（開始日以降）」と表示して実態を明示

### 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/hooks/useHabitsStorage.js` | `statsStartDate` / `setStatsStartDate` を追加 |
| `src/components/SettingsModal.jsx` | 「分析」セクションに日付入力フィールドを追加 |
| `src/components/SettingsModal.css` | 日付入力のスタイル追加 |
| `src/components/StatsView.jsx` | `statsStartDate` を各計算関数に伝播 |
| `src/components/StatsAdviceCard.jsx` | `statsStartDate` に応じてラベルを変更 |
| `src/App.jsx` | `statsStartDate` / `setStatsStartDate` を各コンポーネントに渡す |

## 確認事項

- [ ] 設定画面に集計開始日の入力が表示される
- [ ] 開始日を設定すると達成率が変わる
- [ ] 開始日を未設定にすると従来通りの集計に戻る
- [ ] `npm run build` 成功

Closes #275