### PR TITLE
fix: showDeepTip未定義による白画面を修正

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,7 +104,7 @@ export default function App() {
   }, [setHabits, setRecords])
 
   const {
-    pullY, pullReturning, refreshing, refreshComplete, scrolled,
+    pullY, pullReturning, refreshing, refreshComplete, scrolled, showDeepTip,
     handleTouchStart, handleTouchMove, handleTouchEnd,
   } = usePullToRefresh({ mainRef, onRefresh })
 


### PR DESCRIPTION
## 概要

PR #287 で追加した深いスワイプヒント機能により `showDeepTip` が未定義となり、白画面クラッシュが発生していた。

## 原因

`usePullToRefresh()` の分割代入から `showDeepTip` が抜けていたため、`<HabitTip visible={showDeepTip} />` で `ReferenceError` が発生。

## 修正内容

`src/App.jsx` の分割代入に `showDeepTip` を追加した。

```jsx
const {
  pullY, pullReturning, refreshing, refreshComplete, scrolled, showDeepTip,
  handleTouchStart, handleTouchMove, handleTouchEnd,
} = usePullToRefresh({ mainRef, onRefresh })
```

Closes #288