### PR TITLE
fix: calcRateForRangeの返り値不整合による白画面を修正

### DIFF
--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -33,7 +33,11 @@ function calcRateForRange(habits, records, today, days, statsStartDate) {
     achieved += activeHabits.filter(habit => dayRecords.includes(habit.id)).length
   }
 
-  return total > 0 ? Math.round((achieved / total) * 100) : null
+  return {
+    rate: total > 0 ? Math.round((achieved / total) * 100) : null,
+    achieved,
+    total,
+  }
 }
 
 function calcWeekdayRates(habits, records, today, days = 30, statsStartDate) {


### PR DESCRIPTION
## 修正内容

`calcRateForRange()` が数値または `null` を返していたのに対し、呼び出し側がオブジェクト（`.rate`, `.achieved`, `.total`）として扱っていたため白画面が発生していた。

返り値を `{ rate, achieved, total }` オブジェクトに統一することで修正。

## 変更ファイル

- `src/components/StatsView.jsx` — `calcRateForRange` の `return` 文をオブジェクト形式に変更

## 確認済み

- `npm run build` 成功

Closes #290