### PR TITLE
fix: 習慣の進捗で2週間以降のマイルストンも表示する

### DIFF
--- a/src/components/HabitProgressLine.css
+++ b/src/components/HabitProgressLine.css
@@ -39,9 +39,13 @@
   flex-shrink: 0;
 }
 
+.hpl-next--done {
+  color: rgba(255, 255, 255, 0.5);
+}
+
 .hpl-track {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  /* grid-template-columns はインラインで動的に設定 */
 }
 
 .hpl-stage {
@@ -52,7 +56,7 @@
   position: relative;
 }
 
-/* Connecting line from previous stage to this stage */
+/* 前のステージからつながる線 */
 .hpl-stage:not(:first-child)::before {
   content: '';
   position: absolute;
@@ -65,6 +69,17 @@
 
 .hpl-stage--reached:not(:first-child)::before {
   background: #fff;
+}
+
+/* 先頭が達成済みで前にも達成済みがある場合、左端に省略を示す */
+.hpl-stage--has-prev::after {
+  content: '…';
+  position: absolute;
+  top: -1px;
+  left: -8px;
+  font-size: 0.6rem;
+  color: rgba(255, 255, 255, 0.5);
+  line-height: 1;
 }
 
 .hpl-node {
@@ -93,4 +108,11 @@
 .hpl-stage--reached .hpl-stage-label {
   color: rgba(255, 255, 255, 0.9);
   font-weight: 600;
+}
+
+.hpl-all-done {
+  margin-top: 6px;
+  font-size: 0.68rem;
+  color: rgba(255, 255, 255, 0.6);
+  text-align: center;
 }

--- a/src/components/HabitProgressLine.jsx
+++ b/src/components/HabitProgressLine.jsx
@@ -1,28 +1,49 @@
 import { MILESTONES, getNextMilestone } from '../utils/stats'
 import './HabitProgressLine.css'
 
-// 表示するマイルストン（最初の4件 = 1日・4日・1週間・2週間）
-const DISPLAY_MILESTONES = MILESTONES.slice(0, 4)
+// 表示するマイルストンを streak に応じて動的に選択する
+// - 達成済みの最後のものを含む
+// - 未達成のものを最大3件含む
+// - 常に最低1件は未達成を含む（全達成なら末尾を表示）
+function getDisplayMilestones(streak) {
+  const reachedIdx = MILESTONES.reduce((last, m, i) => (streak >= m.days ? i : last), -1)
+  // 未達成の先頭インデックス
+  const nextIdx = reachedIdx + 1
+
+  // 達成済みは最後の1件だけ表示（先頭なら省く）
+  const startIdx = reachedIdx >= 0 ? reachedIdx : 0
+  // 未達成は最大3件
+  const endIdx = Math.min(nextIdx + 2, MILESTONES.length - 1)
+
+  return MILESTONES.slice(startIdx, endIdx + 1)
+}
 
 export default function HabitProgressLine({ habit, streak }) {
   const next = getNextMilestone(streak)
+  const displayMilestones = getDisplayMilestones(streak)
+  const allDone = next === null
 
   return (
     <div className="hpl-row">
       <div className="hpl-header">
         <span className="hpl-habit-dot" style={{ backgroundColor: habit.color }} />
         <span className="hpl-habit-name">{habit.name}</span>
-        {next && (
+        {next ? (
           <span className="hpl-next">あと{next.days - streak}日で{next.label}</span>
+        ) : (
+          <span className="hpl-next hpl-next--done">全マイルストン達成</span>
         )}
       </div>
-      <div className="hpl-track">
-        {DISPLAY_MILESTONES.map((milestone) => {
+      <div className="hpl-track" style={{ gridTemplateColumns: `repeat(${displayMilestones.length}, 1fr)` }}>
+        {displayMilestones.map((milestone, i) => {
           const reached = streak >= milestone.days
+          const isFirst = i === 0
+          // 先頭が達成済みで、かつその前に達成済みマイルストンがある場合は「...」を示す
+          const showLeadingDots = isFirst && reached && MILESTONES.indexOf(milestone) > 0
           return (
             <div
               key={milestone.days}
-              className={`hpl-stage${reached ? ' hpl-stage--reached' : ''}`}
+              className={`hpl-stage${reached ? ' hpl-stage--reached' : ''}${showLeadingDots ? ' hpl-stage--has-prev' : ''}`}
             >
               <div className="hpl-node" />
               <span className="hpl-stage-label">{milestone.label}</span>
@@ -30,6 +51,9 @@ export default function HabitProgressLine({ habit, streak }) {
           )
         })}
       </div>
+      {allDone && (
+        <div className="hpl-all-done">すべてのマイルストンを達成しました</div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 変更内容

習慣の進捗バーで2週間以降のマイルストンも表示されるよう修正しました。

### 修正前
- `MILESTONES.slice(0, 4)` で1日・4日・1週間・2週間の4件固定

### 修正後
- streak に応じて表示マイルストンを動的に選択
- 達成済みの最後の1件 + 未達成の最大3件を表示
- 先頭が中間マイルストンの場合は「…」で省略を示す
- 全マイルストン達成時は専用メッセージを表示
- 長期継続者でも次の目標が常に見える

## 確認観点
- 2週間を超えた習慣でも次のマイルストンが表示される
- 1年以上継続した場合は「全マイルストン達成」と表示される
- `npm run build` 成功

Closes #292