### PR TITLE
fix: 積み上がりの表示改善とカードタイトルの統一

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -244,6 +244,13 @@
   font-size: 0.95rem;
 }
 
+/* カード見出しの補足テキスト（期間ラベル等）#297 */
+.section-sub {
+  font-size: 0.72rem;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
 .edit-toggle-btn {
   font-size: 0.82rem;
   font-weight: 600;

--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -230,3 +230,16 @@
   font-weight: 600;
   white-space: nowrap;
 }
+
+/* #293: 次のマイルストン表示 */
+.streak-summary-next {
+  font-size: 0.68rem;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.streak-summary-next--done {
+  color: var(--color-primary);
+  font-weight: 600;
+}

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -1,6 +1,6 @@
 import Calendar from './Calendar'
 import HabitProgressLine from './HabitProgressLine'
-import { calcCurrentStreak, MILESTONES } from '../utils/stats'
+import { calcCurrentStreak, MILESTONES, getNextMilestone } from '../utils/stats'
 import './RecordView.css'
 
 function formatMonthKey(date) {
@@ -20,11 +20,16 @@ function countTotalRecords(records) {
   return Object.values(records).reduce((total, ids) => total + new Set(ids).size, 0)
 }
 
-// 達成したマイルストン数をラベル付きで返す
-function getMilestoneLabel(streak) {
-  const reached = MILESTONES.filter(m => streak >= m.days)
-  if (reached.length === 0) return null
-  return reached[reached.length - 1].label
+// 現在地（継続日数）と次のマイルストンを返す
+// #293: フェーズ名ではなく「現在日数 + 次の目標」を表示する
+function getStreakDisplay(streak) {
+  if (streak === 0) return { current: null, next: null }
+  const next = getNextMilestone(streak)
+  const reachedMilestones = MILESTONES.filter(m => streak >= m.days)
+  const currentLabel = reachedMilestones.length > 0
+    ? reachedMilestones[reachedMilestones.length - 1].label
+    : null
+  return { currentLabel, next }
 }
 
 export default function RecordView({
@@ -42,13 +47,12 @@ export default function RecordView({
 
   const activeHabits = habits.filter(h => !h.archivedAt)
 
-  const habitPhaseList = activeHabits.map(habit => {
+  const habitStreakList = activeHabits.map(habit => {
     const streak = calcCurrentStreak(habit.id, records)
-    const milestoneLabel = getMilestoneLabel(streak)
-    return { habit, streak, milestoneLabel }
+    return { habit, streak }
   })
 
-  const sortedHabits = [...habitPhaseList].sort((a, b) => b.streak - a.streak)
+  const sortedHabits = [...habitStreakList].sort((a, b) => b.streak - a.streak)
 
   return (
     <>
@@ -81,7 +85,7 @@ export default function RecordView({
         </section>
       )}
 
-      {/* 積み上がり（#273: マイルストン到達ラベルで表示） */}
+      {/* 積み上がり（#293: 現在日数 + 次のマイルストンで表示） */}
       <section className="section record-summary-section">
         <div className="section-header">
           <h2 className="section-title">積み上がり</h2>
@@ -95,21 +99,29 @@ export default function RecordView({
           <p className="record-empty">習慣を追加すると、積み上がりがここに表示されます。</p>
         ) : (
           <div className="streak-summary-list">
-            {sortedHabits.map(({ habit, streak, milestoneLabel }) => (
-              <div key={habit.id} className="streak-summary-row">
-                <span className="streak-summary-dot" style={{ backgroundColor: habit.color }} />
-                <span className="streak-summary-name">{habit.name}</span>
-                <div className="streak-summary-right">
-                  {milestoneLabel && (
-                    <span className="streak-summary-milestone">{milestoneLabel}</span>
-                  )}
-                  {/* #274: streak 0 のとき「未開始」ではなく空欄にしてやわらかく */}
-                  <span className="streak-summary-days">
-                    {streak > 0 ? `${streak}日継続中` : 'まだ記録なし'}
-                  </span>
+            {sortedHabits.map(({ habit, streak }) => {
+              const { currentLabel, next } = getStreakDisplay(streak)
+              return (
+                <div key={habit.id} className="streak-summary-row">
+                  <span className="streak-summary-dot" style={{ backgroundColor: habit.color }} />
+                  <span className="streak-summary-name">{habit.name}</span>
+                  <div className="streak-summary-right">
+                    {streak > 0 ? (
+                      <>
+                        <span className="streak-summary-days">{streak}日継続中</span>
+                        {next ? (
+                          <span className="streak-summary-next">次は{next.label}</span>
+                        ) : currentLabel ? (
+                          <span className="streak-summary-next streak-summary-next--done">{currentLabel} 達成</span>
+                        ) : null}
+                      </>
+                    ) : (
+                      <span className="streak-summary-days">まだ記録なし</span>
+                    )}
+                  </div>
                 </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         )}
       </section>

--- a/src/components/StatsCategoryCard.jsx
+++ b/src/components/StatsCategoryCard.jsx
@@ -1,9 +1,9 @@
 export default function StatsCategoryCard({ colorStats }) {
   return (
     <section className="section">
-      <div className="analysis-subhead">
-        <span>色別達成率</span>
-        <small>直近30日</small>
+      <div className="section-header">
+        <h2 className="section-title">色別達成率</h2>
+        <small className="section-sub">直近30日</small>
       </div>
       {colorStats.length === 0 ? (
         <p className="analysis-note">カテゴリが設定された色の習慣がありません。</p>

--- a/src/components/StatsWeekdayCard.jsx
+++ b/src/components/StatsWeekdayCard.jsx
@@ -1,11 +1,9 @@
-const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
-
 export default function StatsWeekdayCard({ weekdayRates }) {
   return (
     <section className="section">
-      <div className="analysis-subhead">
-        <span>曜日別達成率</span>
-        <small>直近30日</small>
+      <div className="section-header">
+        <h2 className="section-title">曜日別達成率</h2>
+        <small className="section-sub">直近30日</small>
       </div>
       <div className="analysis-weekday-list">
         {weekdayRates.map(item => (


### PR DESCRIPTION
## 変更内容

### #293 積み上がりのフェーズ名を現在日数が分かる表現へ見直す

**修正前**
- 達成済みマイルストンラベル（例:「1週間」）だけを表示
- 2日目でも「1日目」と表示され現在地が分かりにくい

**修正後**
- 「X日継続中」で現在地を明示
- 「次はY」で次の目標を表示（例:「次は1か月」）
- 全マイルストン達成時は「1年 達成」と表示

### #297 カードタイトルの位置・サイズ・スタイルを整理

**修正前**
- 曜日別・色別達成率の見出しに `analysis-subhead` クラスを使用（独自スタイル）
- section-title と見た目が異なる

**修正後**
- `section-header` + `h2.section-title` + `small.section-sub` パターンに統一
- 期間ラベル（「直近30日」）を `section-sub` クラスで統一表示
- `App.css` に `section-sub` クラスを追加

## 確認観点
- 積み上がりで現在日数と次の目標が一目で分かる
- 全カード見出しのスタイルが揃う
- `npm run build` 成功

Closes #293
Closes #297