### PR TITLE
fix: 設定画面の色名要約表示とデバッグトグルUI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -689,6 +689,7 @@ export default function App() {
           onExport={() => { closeModal(); setTimeout(() => setModal({ type: 'exportConfirm' }), 50) }}
           onImport={() => { closeModal(); setTimeout(() => setModal({ type: 'importConfirm' }), 50) }}
           onManageCategories={() => { closeModal(); setTimeout(() => setModal({ type: 'categoryManage' }), 50) }}
+          colorCategories={colorCategories}
           onClose={closeModal}
           lastBackupDate={lastBackupDate}
           statsStartDate={statsStartDate}

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -163,3 +163,64 @@
   margin: 0;
   line-height: 1.5;
 }
+/* #295: 色の名前設定の入口に表示する要約 */
+.color-summary {
+  font-size: 0.72rem;
+  color: var(--color-text-secondary);
+  font-weight: 400;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+/* #296: デバッグトグル行 */
+.debug-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+}
+
+.debug-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+/* トグルスイッチ */
+.toggle-switch {
+  width: 44px;
+  height: 26px;
+  border-radius: 13px;
+  background: var(--color-border);
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.toggle-switch--on {
+  background: var(--color-primary);
+}
+
+.toggle-switch-thumb {
+  display: block;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  transition: transform 0.2s ease;
+  transform: translateX(0);
+}
+
+.toggle-switch--on .toggle-switch-thumb {
+  transform: translateX(18px);
+}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -19,7 +19,17 @@ export function applyTheme(theme) {
   document.querySelector('meta[name="theme-color"]')?.setAttribute('content', theme.primary)
 }
 
-export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate, debugEnabled, onToggleDebug, statsStartDate, onStatsStartDateChange }) {
+// #295: 設定済みの色名を要約する
+function summarizeColorCategories(colorCategories) {
+  if (!colorCategories) return null
+  const names = Object.values(colorCategories).filter(v => v?.trim())
+  if (names.length === 0) return null
+  return names.slice(0, 3).join(' / ') + (names.length > 3 ? ' …' : '')
+}
+
+export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate, debugEnabled, onToggleDebug, statsStartDate, onStatsStartDateChange, colorCategories }) {
+  const colorSummary = summarizeColorCategories(colorCategories)
+
   return (
     <Modal title="設定" onClose={onClose}>
       <p className="settings-section-title">見た目</p>
@@ -56,7 +66,13 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" /><line x1="7" y1="7" x2="7.01" y2="7" />
           </svg>
-          <span>色の名前を設定</span>
+          {/* #295: 設定済み色名の要約を入口で表示 */}
+          <span className="data-mgmt-btn-text">
+            色の名前を設定
+            <span className="color-summary">
+              {colorSummary ?? '未設定'}
+            </span>
+          </span>
         </button>
       </div>
 
@@ -103,12 +119,22 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
         <>
           <hr className="settings-divider" />
           <p className="settings-section-title">開発者</p>
-          <div className="data-mgmt-list">
-            <button className="data-mgmt-btn" onClick={onToggleDebug}>
+          {/* #296: ON/OFF文言からトグルスイッチUIへ */}
+          <div className="debug-toggle-row">
+            <div className="debug-toggle-label">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="12" cy="12" r="3" /><path d="M19.07 4.93l-1.41 1.41M5.34 5.34l1.41 1.41M21 12h-2M5 12H3M19.07 19.07l-1.41-1.41M5.34 18.66l1.41-1.41M12 21v-2M12 5V3" />
               </svg>
-              <span>viewport デバッグ: {debugEnabled ? 'ON' : 'OFF'}</span>
+              <span>viewport デバッグ</span>
+            </div>
+            <button
+              className={`toggle-switch${debugEnabled ? ' toggle-switch--on' : ''}`}
+              role="switch"
+              aria-checked={debugEnabled}
+              aria-label="viewport デバッグ"
+              onClick={onToggleDebug}
+            >
+              <span className="toggle-switch-thumb" />
             </button>
           </div>
         </>


### PR DESCRIPTION
## 変更内容

### #295 色の名前設定に入る前に現在設定内容を確認できるようにする

- 「色の名前を設定」ボタンに設定済み色名の要約を表示
  - 例: `運動 / 家事 / 勉強`（3件以上は `…` で省略）
  - 未設定の場合は `未設定` を表示
- `App.jsx` から `colorCategories` を `SettingsModal` に渡すよう変更

### #296 デバッグ表示設定をトグルUIにする

- `viewport デバッグ: ON/OFF` 文言表示からトグルスイッチUIに変更
- `role="switch"` + `aria-checked` でアクセシビリティを担保
- ON時はプライマリカラー、OFF時はボーダーカラーで状態を視覚的に表示

## 確認観点
- 設定済みの色名が入口で確認できる
- 未設定の場合は「未設定」と表示される
- デバッグトグルが ON/OFF で見た目が切り替わる
- `npm run build` 成功

Closes #295
Closes #296