### PR TITLE
feat: 未達成日の扱いを設定で選べるようにする

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,7 +35,7 @@ import { useModalState } from './hooks/useModalState'
 import { useHabitActions } from './hooks/useHabitActions'
 import { useBackupManager } from './hooks/useBackupManager'
 import { getToday, getYesterday } from './utils/date'
-import { calcCurrentStreak } from './utils/stats'
+import { calcCurrentStreak, calcCurrentStreakWithMode } from './utils/stats'
 import './App.css'
 
 const LAST_BACKUP_KEY = 'habit-tracker-last-backup'
@@ -81,7 +81,7 @@ export default function App() {
     setShowEditHint(false)
   }, [])
 
-  const { habits, records, colorCategories, statsStartDate, setHabits, setRecords, setColorCategories, setStatsStartDate } = useHabitsStorage()
+  const { habits, records, colorCategories, statsStartDate, streakMode, setHabits, setRecords, setColorCategories, setStatsStartDate, setStreakMode } = useHabitsStorage()
   const { themeId, handleThemeSelect } = useTheme()
 
   const [calendarDate, setCalendarDate] = useState(() => new Date())
@@ -553,7 +553,7 @@ export default function App() {
                     key={habit.id}
                     habit={habit}
                     completed={todayRecords.includes(habit.id)}
-                    streak={calcCurrentStreak(habit.id, records)}
+                    streak={calcCurrentStreakWithMode(habit.id, records, streakMode)}
                     onPress={(h) => toggleHabit(h.id, today)}
                     onLongPress={(h) => { dismissEditHint(); setModal({ type: 'longPress', habit: h }) }}
                   />
@@ -573,6 +573,7 @@ export default function App() {
               habits={habits}
               records={records}
               today={today}
+              streakMode={streakMode}
               onDayClick={(dateStr) => setModal({ type: 'day', dateStr })}
               onMonthTitleClick={() => setModal({ type: 'monthPicker' })}
             />
@@ -696,6 +697,8 @@ export default function App() {
           onStatsStartDateChange={setStatsStartDate}
           debugEnabled={viewportDebug}
           onToggleDebug={toggleViewportDebug}
+          streakMode={streakMode}
+          onStreakModeChange={setStreakMode}
         />
       )}
 

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -1,6 +1,6 @@
 import Calendar from './Calendar'
 import HabitProgressLine from './HabitProgressLine'
-import { calcCurrentStreak, MILESTONES, getNextMilestone } from '../utils/stats'
+import { calcCurrentStreakWithMode, MILESTONES, getNextMilestone } from '../utils/stats'
 import './RecordView.css'
 
 function formatMonthKey(date) {
@@ -38,6 +38,7 @@ export default function RecordView({
   habits,
   records,
   today,
+  streakMode = 'decrement',
   onDayClick,
   onMonthTitleClick,
 }) {
@@ -48,7 +49,7 @@ export default function RecordView({
   const activeHabits = habits.filter(h => !h.archivedAt)
 
   const habitStreakList = activeHabits.map(habit => {
-    const streak = calcCurrentStreak(habit.id, records)
+    const streak = calcCurrentStreakWithMode(habit.id, records, streakMode)
     return { habit, streak }
   })
 
@@ -88,7 +89,8 @@ export default function RecordView({
       {/* 積み上がり（#293: 現在日数 + 次のマイルストンで表示） */}
       <section className="section record-summary-section">
         <div className="section-header">
-          <h2 className="section-title">積み上がり</h2>
+          {/* #294: streakModeに応じてセクションタイトルを変更 */}
+          <h2 className="section-title">{streakMode === 'reset' ? '連続日数' : '積み上がり'}</h2>
           <div className="record-mini-stats">
             <span>{monthCount}回 今月</span>
             <span>累計 {totalCount}回</span>

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -163,6 +163,45 @@
   margin: 0;
   line-height: 1.5;
 }
+
+/* #294: さぼったときの扱い設定 */
+.streak-mode-section {
+  margin-bottom: 12px;
+}
+
+.streak-mode-label {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--color-text);
+  margin-bottom: 8px;
+}
+
+.streak-mode-options {
+  display: flex;
+  gap: 6px;
+}
+
+.streak-mode-btn {
+  flex: 1;
+  padding: 8px 4px;
+  border-radius: var(--radius-sm);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+  font-size: 0.78rem;
+  font-weight: 500;
+  text-align: center;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+  cursor: pointer;
+}
+
+.streak-mode-btn.selected {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+  font-weight: 700;
+}
+
 /* #295: 色の名前設定の入口に表示する要約 */
 .color-summary {
   font-size: 0.72rem;

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,4 +1,5 @@
 import Modal from './Modal'
+import { STREAK_MODES } from '../hooks/useHabitsStorage'
 import './SettingsModal.css'
 
 export const THEMES = [

--- a/src/hooks/useHabitsStorage.js
+++ b/src/hooks/useHabitsStorage.js
@@ -3,6 +3,14 @@ import { useState, useEffect } from 'react'
 const STORAGE_KEY = 'habit-tracker-v1'
 const SETTINGS_KEY = 'habit-tracker-settings'
 
+// 未達成日の扱いモード (#294)
+export const STREAK_MODES = [
+  { id: 'reset',       label: 'リセットする',    metricLabel: '連続日数' },
+  { id: 'decrement',   label: '1日分だけ戻す',   metricLabel: '積み上がり' },
+  { id: 'accumulate',  label: '減らさない',       metricLabel: '積み上がり' },
+]
+export const DEFAULT_STREAK_MODE = 'decrement'
+
 export function loadData() {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
@@ -48,6 +56,8 @@ export function useHabitsStorage() {
   const [colorCategories, setColorCategories] = useState(_initial.colorCategories)
   // 集計開始日（YYYY-MM-DD 形式。未設定なら null）
   const [statsStartDate, setStatsStartDate] = useState(_initialSettings.statsStartDate ?? null)
+  // #294: 未達成日の扱いモード
+  const [streakMode, setStreakMode] = useState(_initialSettings.streakMode ?? DEFAULT_STREAK_MODE)
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ habits, records, colorCategories }))
@@ -56,8 +66,9 @@ export function useHabitsStorage() {
   useEffect(() => {
     const settings = {}
     if (statsStartDate) settings.statsStartDate = statsStartDate
+    settings.streakMode = streakMode
     localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings))
-  }, [statsStartDate])
+  }, [statsStartDate, streakMode])
 
-  return { habits, records, colorCategories, statsStartDate, setHabits, setRecords, setColorCategories, setStatsStartDate }
+  return { habits, records, colorCategories, statsStartDate, streakMode, setHabits, setRecords, setColorCategories, setStatsStartDate, setStreakMode }
 }

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -57,6 +57,42 @@ export function calcCurrentStreak(habitId, records) {
   }
   return count
 }
+
+// #294: 未達成日の扱いモードに応じた積み上がりを計算
+// mode: 'reset' (連続), 'decrement' (1日減算), 'accumulate' (減らさない)
+export function calcCurrentStreakWithMode(habitId, records, mode = 'decrement') {
+  if (mode === 'reset') {
+    return calcCurrentStreak(habitId, records)
+  }
+
+  if (mode === 'accumulate') {
+    // 達成した日の総数（全期間）
+    return Object.values(records).filter(ids => (ids || []).includes(habitId)).length
+  }
+
+  // decrement: 達成日は+1、未達成日は-1、ただし0未満にはしない
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  // 最古の記録日から今日まで走査するため、まず記録のある最古日を取得
+  const sortedDates = Object.keys(records).filter(date => (records[date] || []).includes(habitId)).sort()
+  if (sortedDates.length === 0) return 0
+  const earliest = new Date(sortedDates[0])
+  earliest.setHours(0, 0, 0, 0)
+  // earliest から today まで走査
+  const cur = new Date(earliest)
+  let score = 0
+  while (cur <= today) {
+    const dateStr = formatDate(cur)
+    if ((records[dateStr] || []).includes(habitId)) {
+      score++
+    } else if (dateStr < formatDate(today)) {
+      // 今日はまだ達成できるので減算しない
+      score = Math.max(0, score - 1)
+    }
+    cur.setDate(cur.getDate() + 1)
+  }
+  return score
+}
 
 export function calcStats(habitId, records) {
   const completedDates = Object.keys(records)


### PR DESCRIPTION
## 変更内容

設定画面の「習慣」セクションに「さぼったときの扱い」を追加。3択から選択できます。

### 選択肢

| 設定 | 挙動 | 表示ラベル |
|---|---|---|
| リセットする | 1日未達成で0に戻す | 連続日数 |
| 1日分だけ戻す（デフォルト） | 1日未達成で-1 | 積み上がり |
| 減らさない | 達成日を累計する | 積み上がり |

### 設計方針

- デフォルトは「1日分だけ戻す」：「静かに続けられる道具」方針に最も合う中間案
- 「リセットする」のみ「連続日数」と表示し、それ以外は「積み上がり」と表示
- 表示名と数値の意味が設定値に応じて一致するよう実装

### 変更ファイル

- `src/utils/stats.js`: `calcCurrentStreakWithMode` 関数を追加
- `src/hooks/useHabitsStorage.js`: `streakMode` 状態と `STREAK_MODES` 定数を追加
- `src/App.jsx`: `streakMode` を各コンポーネントに伝播
- `src/components/RecordView.jsx`: `streakMode` に応じた表示
- `src/components/SettingsModal.jsx`: `streakMode` 選択UI追加
- `src/components/SettingsModal.css`: 選択ボタンのスタイル追加

## 確認観点
- 設定画面で3択の選択ができる
- 選択に応じて積み上がり数値が変わる
- 「リセットする」のとき「連続日数」と表示される
- 既存ユーザーはデフォルト「1日分だけ戻す」になる
- `npm run build` 成功

Closes #294