### PR TITLE
fix: 深スワイプヒントをposition:fixed廃止・通常フロー配置に修正 (#286)

### DIFF
--- a/src/components/HabitTip.css
+++ b/src/components/HabitTip.css
@@ -1,30 +1,27 @@
-/* 深いスワイプ時だけ表示されるアプリ設計思想の一言 */
+/* pull-to-refresh 深スワイプ時にのみ表示される一言 */
+/* pull-indicator 直後、通常フロー内に max-height で展開する */
 .habit-tip-pull {
-  position: fixed;
-  top: 80px;
-  left: 50%;
-  transform: translateX(-50%) translateY(-8px);
-  max-width: calc(min(640px, 100vw) - 32px);
-  width: calc(100% - 32px);
-  padding: 12px 16px;
-  border-radius: var(--radius-sm, 8px);
-  background: var(--color-surface, #f5f5f5);
-  border-left: 3px solid var(--color-primary, #6366f1);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  flex: 0 0 auto;
+  overflow: hidden;
+  max-height: 0;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.3s ease, transform 0.3s ease;
-  z-index: 25;
+  transition: max-height 0.35s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease;
 }
 
 .habit-tip-pull.visible {
+  max-height: 120px;
   opacity: 1;
-  transform: translateX(-50%) translateY(0);
+  pointer-events: auto;
 }
 
 .habit-tip-pull-body {
+  margin: 0;
+  padding: 10px 16px 12px;
   color: var(--color-text-muted, #888);
   font-size: 0.82rem;
   line-height: 1.6;
   white-space: pre-line;
+  border-left: 3px solid var(--color-primary, #6366f1);
+  background: var(--color-surface, #f5f5f5);
 }


### PR DESCRIPTION
## 問題

PR #287 で実装した深スワイプヒント（HabitTip）が  で配置されていたため、pull-to-refresh インジケーターと重なりヘッダー直下（画面上部）に表示されていた。

## 修正内容

 の  から  を廃止し、 アニメーションによる通常フロー展開に変更。

**変更前:**
-  — 画面に固定、ヘッダー直下に重なって表示
-  でスライドイン

**変更後:**
-  — 通常フロー、高さ0で非表示
-  時に  へアニメーション展開
- 配置は App.jsx の  直後そのまま（変更なし）

## 動作

- 通常時:  で非表示（レイアウトスペースなし）
- 深スワイプ（150px超）:  直下にフェードイン展開
- 指を離して2.5秒後: 自動的にフェードアウト
- pull-to-refresh 既存動作: 変更なし

Closes #286