### PR TITLE
fix: ヒントをコンテンツ末尾の overscroll 検知に変更（ISSUE #286 再修正）

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,9 +104,45 @@ export default function App() {
   }, [setHabits, setRecords])
 
   const {
-    pullY, pullReturning, refreshing, refreshComplete, scrolled, showDeepTip,
+    pullY, pullReturning, refreshing, refreshComplete, scrolled,
     handleTouchStart, handleTouchMove, handleTouchEnd,
   } = usePullToRefresh({ mainRef, onRefresh })
+
+  // 最下部 overscroll 検知による deep tip 表示
+  const [showDeepTip, setShowDeepTip] = useState(false)
+  const deepTipTimer = useRef(null)
+  const overscrollStartY = useRef(null)
+
+  useEffect(() => {
+    const el = mainRef.current
+    if (!el) return
+    const onTouchStart = (e) => {
+      const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 2
+      overscrollStartY.current = atBottom ? e.touches[0].clientY : null
+    }
+    const onTouchMove = (e) => {
+      if (overscrollStartY.current === null) return
+      // 指を上方向に動かす = コンテンツをさらに引き下げる → dy が正
+      const dy = overscrollStartY.current - e.touches[0].clientY
+      if (dy > 30) {
+        setShowDeepTip(true)
+        clearTimeout(deepTipTimer.current)
+      }
+    }
+    const onTouchEnd = () => {
+      overscrollStartY.current = null
+      deepTipTimer.current = setTimeout(() => setShowDeepTip(false), 2500)
+    }
+    el.addEventListener('touchstart', onTouchStart, { passive: true })
+    el.addEventListener('touchmove', onTouchMove, { passive: true })
+    el.addEventListener('touchend', onTouchEnd, { passive: true })
+    return () => {
+      el.removeEventListener('touchstart', onTouchStart)
+      el.removeEventListener('touchmove', onTouchMove)
+      el.removeEventListener('touchend', onTouchEnd)
+      clearTimeout(deepTipTimer.current)
+    }
+  }, [mainRef])
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -456,7 +492,6 @@ export default function App() {
         )}
       </div>
 
-      <HabitTip today={today} visible={showDeepTip} />
       <main ref={mainRef} className="app-main">
         {/* 習慣セクション（トップ） */}
         <div className="main-content">
@@ -583,6 +618,7 @@ export default function App() {
           <div id="section-stats" className="section-group">
             <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} statsStartDate={statsStartDate} />
           </div>
+          <HabitTip today={today} visible={showDeepTip} />
         </div>
       </main>
 

--- a/src/components/HabitTip.css
+++ b/src/components/HabitTip.css
@@ -1,7 +1,5 @@
-/* pull-to-refresh 深スワイプ時にのみ表示される一言 */
-/* pull-indicator 直後、通常フロー内に max-height で展開する */
+/* コンテンツ末尾に配置。通常時は画面外へ隠し、最下部 overscroll 時だけ覗く */
 .habit-tip-pull {
-  flex: 0 0 auto;
   overflow: hidden;
   max-height: 0;
   opacity: 0;

--- a/src/hooks/usePullToRefresh.js
+++ b/src/hooks/usePullToRefresh.js
@@ -1,8 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 
 export const PULL_THRESHOLD = 80
-// 通常のpull-to-refreshよりさらに深く引いたときのしきい値
-export const DEEP_PULL_THRESHOLD = 150
 
 export function usePullToRefresh({ mainRef, scrollKey, onRefresh }) {
   const [pullY, setPullY] = useState(0)
@@ -10,12 +8,10 @@ export function usePullToRefresh({ mainRef, scrollKey, onRefresh }) {
   const [refreshing, setRefreshing] = useState(false)
   const [refreshComplete, setRefreshComplete] = useState(false)
   const [scrolled, setScrolled] = useState(false)
-  const [showDeepTip, setShowDeepTip] = useState(false)
 
   const pullStartY = useRef(null)
   const justScrolledToTop = useRef(false)
   const scrollStopTimer = useRef(null)
-  const deepPullTriggered = useRef(false)
 
   useEffect(() => {
     const scrollEl = mainRef.current
@@ -45,7 +41,6 @@ export function usePullToRefresh({ mainRef, scrollKey, onRefresh }) {
     // スクロール戻り直後はpull-to-refreshを許可しない
     if ((mainRef.current?.scrollTop ?? 0) === 0 && !justScrolledToTop.current) {
       pullStartY.current = e.touches[0].clientY
-      deepPullTriggered.current = false
     }
   }, [mainRef])
 
@@ -59,13 +54,6 @@ export function usePullToRefresh({ mainRef, scrollKey, onRefresh }) {
         ? visual
         : Math.min(PULL_THRESHOLD + (visual - PULL_THRESHOLD) * 0.3, PULL_THRESHOLD + 50)
       setPullY(clamped)
-
-      // 深いスワイプ検知: 元の指の移動量がDEEP_PULL_THRESHOLD/0.4を超えたとき
-      const rawDy = dy
-      if (rawDy >= DEEP_PULL_THRESHOLD && !deepPullTriggered.current) {
-        deepPullTriggered.current = true
-        setShowDeepTip(true)
-      }
     } else {
       pullStartY.current = null
       setPullY(0)
@@ -73,7 +61,6 @@ export function usePullToRefresh({ mainRef, scrollKey, onRefresh }) {
   }, [])
 
   const handleTouchEnd = useCallback(async () => {
-    deepPullTriggered.current = false
     if (pullY >= PULL_THRESHOLD) {
       setRefreshing(true)
       setPullY(0)
@@ -143,14 +130,10 @@ export function usePullToRefresh({ mainRef, scrollKey, onRefresh }) {
       })
     }
     pullStartY.current = null
-    // deep tipは2秒後に自動的に消す
-    if (showDeepTip) {
-      setTimeout(() => setShowDeepTip(false), 2500)
-    }
-  }, [pullY, onRefresh, showDeepTip])
+  }, [pullY, onRefresh])
 
   return {
-    pullY, pullReturning, refreshing, refreshComplete, scrolled, showDeepTip,
+    pullY, pullReturning, refreshing, refreshComplete, scrolled,
     handleTouchStart, handleTouchMove, handleTouchEnd,
   }
 }


### PR DESCRIPTION
## 修正内容

PR #302 で対応したが、HabitTip がヘッダー下（pull-indicator 直後）に配置されたままだったため再修正。

### 変更点

- `HabitTip` をヘッダー下から `.main-content` の**末尾**に移動
- `showDeepTip` を `usePullToRefresh` の上スワイプ連動から完全に切り離し
- `.app-main` の最下部で `touchmove` による overscroll を検知して表示
  - `scrollTop + clientHeight >= scrollHeight - 2` で最下部を判定
  - そこから指を上方向（コンテンツをさらに下へ引く）に 30px 以上動かしたら表示
  - `touchend` から 2.5 秒後に自動非表示
- `usePullToRefresh.js` から `showDeepTip` / `deepPullTriggered` / `DEEP_PULL_THRESHOLD` を削除
- pull-to-refresh（上からの引き下げ）の既存動作は影響なし

## 動作

- 通常スクロール: ヒントは見えない（`max-height: 0`）
- コンテンツ最下部でさらに下へ引く: ヒントが展開表示される
- 指を離す: 2.5 秒後に非表示に戻る

Closes #286