### PR TITLE
fix: ヒントの背景を削除しバネアニメーションで戻るよう修正 (#286)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,8 +110,18 @@ export default function App() {
 
   // 最下部 overscroll 検知による deep tip 表示
   const [showDeepTip, setShowDeepTip] = useState(false)
+  const [deepTipReturning, setDeepTipReturning] = useState(false)
   const deepTipTimer = useRef(null)
+  const deepTipReturnTimer = useRef(null)
   const overscrollStartY = useRef(null)
+
+  const hideDeepTip = useCallback(() => {
+    setDeepTipReturning(true)
+    deepTipReturnTimer.current = setTimeout(() => {
+      setShowDeepTip(false)
+      setDeepTipReturning(false)
+    }, 700)
+  }, [])
 
   useEffect(() => {
     const el = mainRef.current
@@ -122,16 +132,17 @@ export default function App() {
     }
     const onTouchMove = (e) => {
       if (overscrollStartY.current === null) return
-      // 指を上方向に動かす = コンテンツをさらに引き下げる → dy が正
       const dy = overscrollStartY.current - e.touches[0].clientY
       if (dy > 30) {
         setShowDeepTip(true)
+        setDeepTipReturning(false)
         clearTimeout(deepTipTimer.current)
+        clearTimeout(deepTipReturnTimer.current)
       }
     }
     const onTouchEnd = () => {
       overscrollStartY.current = null
-      deepTipTimer.current = setTimeout(() => setShowDeepTip(false), 2500)
+      deepTipTimer.current = setTimeout(() => hideDeepTip(), 2500)
     }
     el.addEventListener('touchstart', onTouchStart, { passive: true })
     el.addEventListener('touchmove', onTouchMove, { passive: true })
@@ -141,8 +152,9 @@ export default function App() {
       el.removeEventListener('touchmove', onTouchMove)
       el.removeEventListener('touchend', onTouchEnd)
       clearTimeout(deepTipTimer.current)
+      clearTimeout(deepTipReturnTimer.current)
     }
-  }, [mainRef])
+  }, [mainRef, hideDeepTip])
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -618,7 +630,7 @@ export default function App() {
           <div id="section-stats" className="section-group">
             <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} statsStartDate={statsStartDate} />
           </div>
-          <HabitTip today={today} visible={showDeepTip} />
+          <HabitTip today={today} visible={showDeepTip} returning={deepTipReturning} />
         </div>
       </main>
 

--- a/src/components/HabitTip.css
+++ b/src/components/HabitTip.css
@@ -1,16 +1,33 @@
-/* コンテンツ末尾に配置。通常時は画面外へ隠し、最下部 overscroll 時だけ覗く */
+/* コンテンツ末尾に配置。通常時は下に隠れ、最下部 overscroll 時だけ覗く */
 .habit-tip-pull {
   overflow: hidden;
   max-height: 0;
+  transform: translateY(40px);
   opacity: 0;
   pointer-events: none;
-  transition: max-height 0.35s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease;
+  transition:
+    max-height 0.35s cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 0.35s cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 0.25s ease;
 }
 
 .habit-tip-pull.visible {
   max-height: 120px;
+  transform: translateY(0);
   opacity: 1;
   pointer-events: auto;
+}
+
+/* バネで戻るアニメーション */
+.habit-tip-pull.returning {
+  max-height: 0;
+  transform: translateY(40px);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    max-height 0.7s cubic-bezier(0.4, 0, 0.6, 1),
+    transform 0.7s cubic-bezier(0.4, 0, 0.6, 1),
+    opacity 0.5s ease;
 }
 
 .habit-tip-pull-body {
@@ -21,5 +38,4 @@
   line-height: 1.6;
   white-space: pre-line;
   border-left: 3px solid var(--color-primary, #6366f1);
-  background: var(--color-surface, #f5f5f5);
 }

--- a/src/components/HabitTip.jsx
+++ b/src/components/HabitTip.jsx
@@ -1,11 +1,15 @@
 import { getDailyTip } from '../data/habitTips'
 import './HabitTip.css'
 
-// 深いスワイプ時だけ表示するヒント（常設なし）
-export default function HabitTip({ today, visible }) {
+export default function HabitTip({ today, visible, returning }) {
   const tip = getDailyTip(today)
+  const cls = [
+    'habit-tip-pull',
+    visible ? 'visible' : '',
+    returning ? 'returning' : '',
+  ].filter(Boolean).join(' ')
   return (
-    <div className={`habit-tip-pull${visible ? ' visible' : ''}`} aria-live="polite" aria-atomic="true">
+    <div className={cls} aria-live="polite" aria-atomic="true">
       <p className="habit-tip-pull-body">{tip}</p>
     </div>
   )


### PR DESCRIPTION
## 変更内容

- 背景色（`background: var(--color-surface)`）を削除
- 非表示時は `transform: translateY(40px)` + `opacity: 0` で下に隠れた状態
- 表示時は `cubic-bezier(0.2, 0.8, 0.2, 1)` でスムーズに浮き上がる
- 非表示に戻る際は `returning` クラスで `cubic-bezier(0.4, 0, 0.6, 1)` + 0.7s のバネアニメーション（pull-to-refresh と同じ感触）

Closes #286