### PR TITLE
fix: カードタイトルスタイルを section-header + section-title に統一

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -587,7 +587,7 @@ export default function App() {
                 </button>
                 {archivedHabits.length > 0 && (
                   <div className="archived-section">
-                    <p className="archived-section-title">終了した習慣</p>
+                    <p className="section-title">終了した習慣</p>
                     {archivedHabits.map(habit => (
                       <ArchivedHabitItem
                         key={habit.id}

--- a/src/components/ArchivedHabitItem.css
+++ b/src/components/ArchivedHabitItem.css
@@ -2,16 +2,6 @@
   margin-top: 20px;
 }
 
-.archived-section-title {
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: var(--color-text-secondary);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  margin-bottom: 8px;
-  padding: 0 2px;
-}
-
 .archived-habit-item {
   display: flex;
   align-items: center;

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -1,12 +1,3 @@
-.settings-section-title {
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: var(--color-text-secondary);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  margin: 0 0 10px;
-}
-
 .settings-divider {
   border: none;
   border-top: 1px solid var(--color-border);

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -33,7 +33,7 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
 
   return (
     <Modal title="設定" onClose={onClose}>
-      <p className="settings-section-title">見た目</p>
+      <p className="section-title">見た目</p>
       <div className="theme-grid">
         {THEMES.map(theme => (
           <button
@@ -61,7 +61,7 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
 
       <hr className="settings-divider" />
 
-      <p className="settings-section-title">習慣</p>
+      <p className="section-title">習慣</p>
       <div className="data-mgmt-list">
         <button className="data-mgmt-btn" onClick={onManageCategories}>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
@@ -79,7 +79,7 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
 
       <hr className="settings-divider" />
 
-      <p className="settings-section-title">分析</p>
+      <p className="section-title">分析</p>
       <div className="stats-start-date-row">
         <label className="stats-start-date-label" htmlFor="stats-start-date">集計開始日</label>
         <input
@@ -97,7 +97,7 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
 
       <hr className="settings-divider" />
 
-      <p className="settings-section-title">データ</p>
+      <p className="section-title">データ</p>
       <div className="data-mgmt-list">
         <button className="data-mgmt-btn" onClick={onExport}>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
@@ -119,7 +119,7 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
       {onToggleDebug && (
         <>
           <hr className="settings-divider" />
-          <p className="settings-section-title">開発者</p>
+          <p className="section-title">開発者</p>
           {/* #296: ON/OFF文言からトグルスイッチUIへ */}
           <div className="debug-toggle-row">
             <div className="debug-toggle-label">

--- a/src/components/StatsPhaseCard.jsx
+++ b/src/components/StatsPhaseCard.jsx
@@ -42,8 +42,8 @@ export default function StatsPhaseCard({ habitPhases }) {
 
   return (
     <section className="section">
-      <div className="analysis-subhead">
-        <span>習慣化フェーズ</span>
+      <div className="section-header">
+        <span className="section-title">習慣化フェーズ</span>
         <button
           className="phase-info-btn"
           onClick={() => setShowInfo(v => !v)}

--- a/src/components/StatsView.css
+++ b/src/components/StatsView.css
@@ -59,17 +59,6 @@
   line-height: 1.5;
 }
 
-.analysis-subhead {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 10px;
-  margin-bottom: 12px;
-  color: var(--color-text);
-  font-size: 0.86rem;
-  font-weight: 800;
-}
-
 .analysis-weekday-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 概要

カードタイトルのスタイルが3箇所でばらばらに定義されていたため、App.css の共通クラスに統一しました。

## 変更内容

| ファイル | 変更前 | 変更後 |
|---|---|---|
| StatsPhaseCard.jsx | `analysis-subhead` | `section-header` + `section-title` |
| App.jsx | `archived-section-title` | `section-title` |
| SettingsModal.jsx (5箇所) | `settings-section-title` | `section-title` |

削除したCSS定義:
- `StatsView.css` の `.analysis-subhead`
- `ArchivedHabitItem.css` の `.archived-section-title`
- `SettingsModal.css` の `.settings-section-title`

## 見た目への影響

- **SettingsModal**: font-size が 0.75rem → 0.9rem、font-weight が 700 → 600、letter-spacing が 0.08em → 0.06em に変わります（統一後のほうが他セクションと揃う）
- **ArchivedHabitItem**: font-size が 0.75rem → 0.9rem に変わります
- **StatsPhaseCard**: フォントスタイルが analysis-subhead（0.86rem, 800）から section-title（0.9rem, 600）に変わります

いずれも微差で、section-title の定義に揃えることが目的です。

## 確認

- `npm run build` 成功