### PR TITLE
fix: カードタイトル配置統一とフォントサイズ揺れを解消

### DIFF
--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -1,12 +1,3 @@
-/* 実績セクション全体のタイトルヘッダー */
-.record-section-header {
-  padding: 4px 0 0;
-}
-
-.record-section-header .section-title {
-  color: var(--color-text-secondary);
-}
-
 /* フェーズハイライト（実績画面最上部） */
 .section.record-phase-highlight-section {
   background: var(--color-primary);
@@ -22,6 +13,7 @@
   flex-direction: column;
 }
 
+/* section-sub（0.72rem）に合わせて統一 */
 .phase-highlight-heading {
   font-size: 0.72rem;
   font-weight: 700;
@@ -31,7 +23,7 @@
 }
 
 .phase-highlight-next {
-  font-size: 0.82rem;
+  font-size: 0.72rem;
   opacity: 0.85;
   margin-top: 4px;
 }
@@ -110,16 +102,6 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-}
-
-.phase-group-title {
-  font-size: 0.72rem;
-  font-weight: 700;
-  color: var(--color-primary);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  padding-bottom: 4px;
-  border-bottom: 1px solid var(--color-border);
 }
 
 .phase-habit-row {

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -57,12 +57,12 @@ export default function RecordView({
 
   return (
     <>
-      {/* #278/#280: 実績画面の役割を明確にするヘッダー */}
-      <div className="record-section-header">
-        <h2 className="section-title">実績</h2>
-      </div>
       {/* #272: カレンダーを今日の習慣の直後（最上部）に配置 */}
+      {/* #278/#280: 実績タイトルをカード内に統一 */}
       <section className="section record-calendar-section">
+        <div className="section-header">
+          <h2 className="section-title">実績</h2>
+        </div>
         <Calendar
           date={calendarDate}
           onDateChange={onCalendarDateChange}


### PR DESCRIPTION
@
## 修正内容

### 1. 実績タイトルをカード内に移動
- `record-section-header` div（カード外ヘッダー）を削除
- カレンダーカード（`section.record-calendar-section`）内に `section-header > section-title` として「実績」タイトルを移動
- Stats系カードと同じ構造に統一

### 2. フォントサイズ統一
- `phase-highlight-next`: 0.82rem → 0.72rem（`section-sub` 基準に合わせる）
- `phase-highlight-heading` は元から 0.72rem のため変更なし

### 3. 未使用クラス削除
- `.phase-group-title`（JSXで使用されていない）を RecordView.css から削除
- `.record-section-header` およびそのスタイルを削除

## 確認
- `npm run build` 成功
- SettingsModal は変更なし
@