### PR TITLE
fix: カードタイトルスタイル統一（section-title--primary 削除）

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -238,11 +238,6 @@
   text-transform: uppercase;
 }
 
-/* 今日の習慣セクション: 他より少しだけ主役として目立たせる */
-.section-title--primary {
-  color: var(--color-primary);
-  font-size: 0.95rem;
-}
 
 /* カード見出しの補足テキスト（期間ラベル等）#297 */
 .section-sub {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -515,7 +515,7 @@ export default function App() {
         <div className="main-content">
           <section className="section">
             <div className="section-header">
-              <h2 className="section-title section-title--primary">今日の習慣</h2>
+              <h2 className="section-title">今日の習慣</h2>
               {habits.length > 0 && (
                 <button
                   className={`edit-toggle-btn ${editMode ? 'active' : ''}`}


### PR DESCRIPTION
## 概要
- `今日の習慣` のカードタイトルに付いていた `.section-title--primary` 修飾子を削除
- 他カードとフォントサイズ・色を統一（全カードタイトルが `.section-title` に）
- 使われなくなった CSS ルール `.section-title--primary` も削除

## 変更ファイル
- `src/App.jsx`: `section-title--primary` クラスを除去
- `src/App.css`: `.section-title--primary` ルールを削除

closes #297