### PR TITLE
fix: 集計開始日未設定時に最古記録日をフォールバックとして使う

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo } from 'react'
 import {
   DndContext,
   closestCenter,
@@ -84,6 +84,13 @@ export default function App() {
 
   const { habits, records, colorCategories, statsStartDate, streakMode, setHabits, setRecords, setColorCategories, setStatsStartDate, setStreakMode } = useHabitsStorage()
   const { themeId, handleThemeSelect } = useTheme()
+
+  // 記録の中で最も古い日付（未設定時の集計開始日フォールバック）
+  const oldestRecordDate = useMemo(() => {
+    const dates = Object.keys(records).filter(d => (records[d] || []).length > 0).sort()
+    return dates.length > 0 ? dates[0] : null
+  }, [records])
+  const effectiveStatsStartDate = statsStartDate ?? oldestRecordDate
 
   const [calendarDate, setCalendarDate] = useState(() => new Date())
   const [editMode, setEditMode] = useState(false)
@@ -634,7 +641,7 @@ export default function App() {
 
           {/* 分析セクション */}
           <div id="section-stats" className="section-group">
-            <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} statsStartDate={statsStartDate} />
+            <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} statsStartDate={effectiveStatsStartDate} />
           </div>
           <HabitTip tip={currentTip} visible={showDeepTip} returning={deepTipReturning} />
         </div>
@@ -748,6 +755,7 @@ export default function App() {
           onClose={closeModal}
           lastBackupDate={lastBackupDate}
           statsStartDate={statsStartDate}
+          autoStatsStartDate={oldestRecordDate}
           onStatsStartDateChange={setStatsStartDate}
           debugEnabled={viewportDebug}
           onToggleDebug={toggleViewportDebug}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -28,7 +28,7 @@ function summarizeColorCategories(colorCategories) {
   return names.slice(0, 3).join(' / ') + (names.length > 3 ? ' …' : '')
 }
 
-export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate, debugEnabled, onToggleDebug, statsStartDate, onStatsStartDateChange, colorCategories }) {
+export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate, debugEnabled, onToggleDebug, statsStartDate, autoStatsStartDate, onStatsStartDateChange, colorCategories }) {
   const colorSummary = summarizeColorCategories(colorCategories)
 
   return (
@@ -92,7 +92,9 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
         />
       </div>
       <p className="stats-start-date-hint" id="stats-start-date-hint">
-        この日より前を達成率の分母に含めません
+        {!statsStartDate && autoStatsStartDate
+          ? `自動: ${autoStatsStartDate}（最初の記録日）`
+          : 'この日より前を達成率の分母に含めません'}
       </p>
 
       <hr className="settings-divider" />


### PR DESCRIPTION
## 概要
集計開始日が未設定のとき、記録の中で最も古い日付を自動的に開始日として使うようにしました。

## 変更内容

### App.jsx
- `useMemo` で `records` から最古記録日（`oldestRecordDate`）を計算
- `effectiveStatsStartDate = statsStartDate ?? oldestRecordDate` で実効開始日を導出
- `StatsView` には `effectiveStatsStartDate` を渡す（手動設定優先、未設定なら最古記録日）
- `SettingsModal` に `autoStatsStartDate` プロパティを追加

### SettingsModal.jsx
- 集計開始日が未設定のとき、ヒント欄に「自動: YYYY-MM-DD（最初の記録日）」を表示
- 手動設定済みのときは従来のヒント文言を表示

## 期待する挙動
- 設定値あり: その日を優先
- 設定値なし: 最古記録日を自動採用（達成率の分母に開始前の日付が入らない）
- 記録なし: これまで通り（開始日フィルタなし）
- 設定画面で実際に使われている開始日を確認できる

closes #275