### PR TITLE
fix: 習慣の進捗タイトル統一・設定画面見出し余白追加（#297 残件）

### DIFF
--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -13,13 +13,13 @@
   flex-direction: column;
 }
 
-/* section-sub（0.72rem）に合わせて統一 */
 .phase-highlight-heading {
-  font-size: 0.72rem;
-  font-weight: 700;
-  opacity: 0.75;
-  letter-spacing: 0.04em;
-  margin-bottom: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.85;
+  margin-bottom: 10px;
 }
 
 .phase-highlight-next {

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -117,6 +117,11 @@
   font-weight: 400;
 }
 
+/* 設定モーダル内のsection-titleとコンテンツの間の余白 */
+.modal-sheet .section-title {
+  margin-bottom: 12px;
+}
+
 /* 集計開始日設定（#275） */
 .stats-start-date-row {
   display: flex;


### PR DESCRIPTION
## 概要
ISSUE #297 の完了条件として明記されていたが未修正だった2点を対応。

## 変更内容

### RecordView.css — `phase-highlight-heading`
- `font-size: 0.72rem` → `0.9rem`（他のカードタイトルと同じサイズへ）
- `font-weight: 700` → `600`
- `letter-spacing: 0.04em` → `0.06em`
- `text-transform: uppercase` を追加
- `opacity: 0.75` → `0.85`（白背景でない分、少し抑えつつ視認性を確保）
- `margin-bottom: 6px` → `10px`

### SettingsModal.css — 設定モーダルの見出し余白
- `.modal-sheet .section-title { margin-bottom: 12px }` を追加
- 「見た目」「習慣」「分析」「データ」「開発者」各見出しとコンテンツの間の呼吸を確保

## 確認済み
- `習慣の進捗`: 14.4px / weight 600 / letter-spacing 0.864px / uppercase → 他タイトルと一致
- 設定画面: 各見出しに 12px の margin-bottom

closes #297