### PR TITLE
fix(#314): 色別達成率のラベル列を固定幅グリッドにしてバー開始位置を揃える

### DIFF
--- a/src/components/StatsCategoryCard.jsx
+++ b/src/components/StatsCategoryCard.jsx
@@ -12,8 +12,10 @@ export default function StatsCategoryCard({ colorStats }) {
           {colorStats.map(({ color, name, count, rate }) => (
             <div className="analysis-color-row" key={color}>
               <span className="analysis-color-dot" style={{ backgroundColor: color }} />
-              <span className="analysis-color-name">{name}</span>
-              <span className="analysis-color-count">{count}件</span>
+              <span className="analysis-color-label">
+                <span className="analysis-color-name">{name}</span>
+                <span className="analysis-color-count">{count}件</span>
+              </span>
               <div className="analysis-weekday-bar">
                 <span style={{ width: `${rate ?? 0}%` }} />
               </div>

--- a/src/components/StatsView.css
+++ b/src/components/StatsView.css
@@ -105,7 +105,7 @@
 
 .analysis-color-row {
   display: grid;
-  grid-template-columns: 12px auto auto 1fr 40px;
+  grid-template-columns: 12px minmax(0, 7rem) 1fr 36px;
   align-items: center;
   gap: 8px;
 }
@@ -117,10 +117,20 @@
   flex-shrink: 0;
 }
 
+.analysis-color-label {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  overflow: hidden;
+}
+
 .analysis-color-name {
   color: var(--color-text);
   font-size: 0.78rem;
   font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
close #314

色別達成率の各行を4列グリッド（ドット | ラベル固定幅 | バー | 数値）に変更し、バーの開始位置を全行で揃えました。長い色名はellipsisで省略します。