### PR TITLE
fix(#316): カレンダーセルの押下中に背景色を表示する

### DIFF
--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -90,7 +90,12 @@
 }
 
 .cal-cell:active {
-  opacity: 0.7;
+  background: var(--color-primary-light);
+}
+
+.cal-cell.today:active {
+  /* today背景に重ねて少し濃く */
+  opacity: 0.75;
 }
 
 .cal-cell.other-month {


### PR DESCRIPTION
close #316

カレンダーの日付セルについて、:activeの表示をopacityのみからprimary-light背景色に変更しました。今日のセルはopacityで一段濃くなります。指を離すと元に戻るため、選択状態とは混同されません。