### PR TITLE
fix(#326): 日別詳細モーダルの編集不可時に閲覧のみバッジを表示

### DIFF
--- a/src/components/DayDetailModal.css
+++ b/src/components/DayDetailModal.css
@@ -23,6 +23,11 @@
   color: #4338CA;
 }
 
+
+.readonly-badge {
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+}
 .day-summary {
   text-align: center;
   margin-bottom: 18px;
@@ -55,6 +60,10 @@
   margin-bottom: 16px;
 }
 
+
+.day-habit-list.is-readonly {
+  opacity: 0.7;
+}
 .day-habit-item {
   width: 100%;
 }

--- a/src/components/DayDetailModal.jsx
+++ b/src/components/DayDetailModal.jsx
@@ -26,13 +26,16 @@ export default function DayDetailModal({
 
   return (
     <Modal onClose={onClose} title={formatDisplayDate(dateStr)}>
-      {dateLabel && (
-        <div className="day-badge">
+      <div className="day-badge-row">
+        {dateLabel && (
           <span className={`badge ${dateLabel === '今日' ? 'today' : 'yesterday'}`}>
             {dateLabel}
           </span>
-        </div>
-      )}
+        )}
+        {!isEditable && (
+          <span className="badge readonly-badge">閲覧のみ</span>
+        )}
+      </div>
 
       <div className="day-summary">
         <span className="summary-count">{completedCount}</span>
@@ -42,7 +45,7 @@ export default function DayDetailModal({
       {activeHabits.length === 0 ? (
         <p className="no-habits">習慣がまだ登録されていません</p>
       ) : (
-        <ul className="day-habit-list">
+        <ul className={`day-habit-list ${!isEditable ? 'is-readonly' : ''}`}>
           {activeHabits.map(habit => {
             const done = completedIds.includes(habit.id)
             return (
@@ -68,10 +71,6 @@ export default function DayDetailModal({
             )
           })}
         </ul>
-      )}
-
-      {!isEditable && (
-        <p className="edit-note">編集できるのは当日・前日のみです</p>
       )}
 
       <button className="day-close-btn" onClick={onClose}>


### PR DESCRIPTION
close #326

## 変更内容

- タイトル下に「閲覧のみ」バッジを表示（今日・昨日バッジと同じ位置）
- 編集不可時はリスト全体のopacityを0.7に下げてインタラクティブ感を弱める
- 「編集できるのは当日・前日のみです」テキストは「閲覧のみ」バッジに統合