### PR TITLE
fix(#342): 空状態・補助文の日本語を横断で統一する

### DIFF
--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -98,7 +98,7 @@ export default function RecordView({
         </div>
 
         {activeHabits.length === 0 ? (
-          <p className="record-empty">習慣を追加すると、積み上がりがここに表示されます。</p>
+          <p className="record-empty">習慣を追加すると続いた日数が表示されます。</p>
         ) : (
           <div className="streak-summary-list">
             {sortedHabits.map(({ habit, streak }) => {

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -94,7 +94,7 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
       <p className="stats-start-date-hint" id="stats-start-date-hint">
         {!statsStartDate && autoStatsStartDate
           ? `自動: ${autoStatsStartDate}（最初の記録日）`
-          : 'この日より前を達成率の分母に含めません'}
+          : 'この日より前の記録を達成率の計算から除きます'}
       </p>
 
       <hr className="settings-divider" />

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -91,7 +91,7 @@ export default function StatsView({ habits, records, today, colorCategories = {}
   const hasNamedColors = Object.values(colorCategories).some(v => v?.trim())
 
   if (habits.length === 0) {
-    return <p className="analysis-empty">習慣を追加すると、達成率が表示されます。</p>
+    return <p className="analysis-empty">習慣を追加すると達成率が表示されます。</p>
   }
 
   return (


### PR DESCRIPTION
close #342

## 変更内容

- SettingsModal: 「この日より前を達成率の分母に含めません」→「この日より前の記録を達成率の計算から除きます」
- RecordView: 「積み上がりがここに表示されます。」→「続いた日数が表示されます。」
- StatsView: 「達成率が表示されます。」の読点を除いて統一