### PR TITLE
fix(#323): ヘッダーのカレンダーボタンのaria-labelを更新

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -435,12 +435,12 @@ export default function App() {
           )}
         </button>
         <div className="header-actions">
-          {/* 実績（カレンダー）へ移動 */}
+          {/* カレンダーへ移動 */}
           <button
             className="header-btn"
             onClick={() => scrollToSection('record')}
-            aria-label="実績"
-            title="実績"
+            aria-label="カレンダー"
+            title="カレンダー"
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
               <rect x="3" y="4" width="18" height="18" rx="2" ry="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />


### PR DESCRIPTION
close #323

ヘッダー左側のカレンダーアイコンのaria-label / title を「実績」から「カレンダー」に変更しました。カレンダーセクションへスクロールする導線であることに合わせた修正です。