### PR TITLE
fix(#317): streakModeに応じて習慣カードの連続日数ラベルを切り替える

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -614,6 +614,7 @@ export default function App() {
                     habit={habit}
                     completed={todayRecords.includes(habit.id)}
                     streak={calcCurrentStreakWithMode(habit.id, records, streakMode)}
+                    streakMode={streakMode}
                     onPress={(h) => toggleHabit(h.id, today)}
                     onLongPress={(h) => { dismissEditHint(); setModal({ type: 'longPress', habit: h }) }}
                   />

--- a/src/components/HabitButton.jsx
+++ b/src/components/HabitButton.jsx
@@ -3,7 +3,13 @@ import './HabitButton.css'
 
 const LONG_PRESS_DELAY = 500
 
-export default function HabitButton({ habit, completed, streak, onPress, onLongPress }) {
+// streakModeに応じた連続日数の単位ラベル
+function getStreakUnit(streakMode) {
+  if (streakMode === 'reset') return '日連続'
+  return '日'
+}
+
+export default function HabitButton({ habit, completed, streak, streakMode = 'decrement', onPress, onLongPress }) {
   const timerRef = useRef(null)
   const isLongPressRef = useRef(false)
   const startPosRef = useRef(null)
@@ -51,6 +57,8 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
     isLongPressRef.current = false
   }, [habit, onPress, completed])
 
+  const streakUnit = getStreakUnit(streakMode)
+
   return (
     <button
       className={`habit-btn${completed ? ' completed' : ''}${popping ? ' pop' : ''}`}
@@ -69,7 +77,7 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
         style={{ backgroundColor: completed ? '#fff' : habit.color }}
       />
       <span className="habit-name">{habit.name}</span>
-      {streak > 1 && <span className="habit-streak">{streak}日継続</span>}
+      {streak > 1 && <span className="habit-streak">{streak}{streakUnit}</span>}
       {completed && <span className="habit-check">✓</span>}
     </button>
   )


### PR DESCRIPTION
close #317

## 変更内容

- HabitButtonにstreakModeプロップを追加
- reset（リセットする）モードは「N日連続」、それ以外（decrement / accumulate）は「N日」と表示
- App.jsxからstreakModeを渡すように修正

「日継続」という表現は連続日数モード特有のニュアンスがあるため、decrement / accumulateモードではよりシンプルに「N日」としました。