### PR TITLE
fix(#324/#325): 設定画面に未達成日の扱い設定UIを追加

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -28,7 +28,7 @@ function summarizeColorCategories(colorCategories) {
   return names.slice(0, 3).join(' / ') + (names.length > 3 ? ' …' : '')
 }
 
-export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate, debugEnabled, onToggleDebug, statsStartDate, autoStatsStartDate, onStatsStartDateChange, colorCategories }) {
+export default function SettingsModal({ currentThemeId, onSelectTheme, onExport, onImport, onManageCategories, onClose, lastBackupDate, debugEnabled, onToggleDebug, statsStartDate, autoStatsStartDate, onStatsStartDateChange, colorCategories, streakMode, onStreakModeChange }) {
   const colorSummary = summarizeColorCategories(colorCategories)
 
   return (
@@ -75,6 +75,22 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
             </span>
           </span>
         </button>
+      </div>
+
+      <div className="streak-mode-section">
+        <p className="streak-mode-label">達成できなかった日の扱い</p>
+        <div className="streak-mode-options" role="group" aria-label="達成できなかった日の扱い">
+          {STREAK_MODES.map(mode => (
+            <button
+              key={mode.id}
+              className={`streak-mode-btn${streakMode === mode.id ? ' selected' : ''}`}
+              onClick={() => onStreakModeChange && onStreakModeChange(mode.id)}
+              aria-pressed={streakMode === mode.id}
+            >
+              {mode.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       <hr className="settings-divider" />


### PR DESCRIPTION
close #324
close #325

## 変更内容

- 設定画面の「習慣」セクションに「達成できなかった日の扱い」選択肢（3択ボタン）を追加
- STREAK_MODESを使い、現在の選択が選択済みとして見えるよう実装
- streakMode / onStreakModeChangeをpropsとして受け取るよう変更（既存のApp.jsxの渡し方と互換）
- 設定項目のグルーピングを「見た目 → 習慣（色名・未達成日扱い）→ 分析 → データ」の順に整理（#325対応）