### PR TITLE
fix(#329): 習慣追加モーダルで選択中の色名を表示する

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -657,7 +657,7 @@ export default function App() {
       )}
 
       {modal?.type === 'add' && (
-        <AddHabitModal onSave={addHabit} onClose={closeModal} />
+        <AddHabitModal onSave={addHabit} onClose={closeModal} colorCategories={colorCategories} />
       )}
 
       {modal?.type === 'edit' && (
@@ -665,6 +665,7 @@ export default function App() {
           initialHabit={modal.habit}
           onSave={({ name, color }) => updateHabit({ name, color, habitId: modal.habit.id })}
           onClose={closeModal}
+          colorCategories={colorCategories}
         />
       )}
 

--- a/src/components/AddHabitModal.css
+++ b/src/components/AddHabitModal.css
@@ -18,6 +18,15 @@
   text-transform: uppercase;
 }
 
+.color-name-hint {
+  margin-left: 8px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
 .form-input {
   border: 2px solid var(--color-border);
   border-radius: var(--radius-sm);

--- a/src/components/AddHabitModal.jsx
+++ b/src/components/AddHabitModal.jsx
@@ -14,7 +14,7 @@ const COLOR_NAMES = {
   '#6C5CE7': 'パープル',
 }
 
-export default function AddHabitModal({ onSave, onClose, initialHabit = null }) {
+export default function AddHabitModal({ onSave, onClose, initialHabit = null, colorCategories = {} }) {
   const isEdit = !!initialHabit
   const [name, setName] = useState(initialHabit?.name ?? '')
   const [color, setColor] = useState(initialHabit?.color ?? HABIT_COLORS[0])
@@ -42,7 +42,12 @@ export default function AddHabitModal({ onSave, onClose, initialHabit = null }) 
         </div>
 
         <div className="form-group">
-          <label className="form-label">カラー</label>
+          <label className="form-label">
+            カラー
+            {colorCategories[color] && (
+              <span className="color-name-hint">{colorCategories[color]}</span>
+            )}
+          </label>
           <div className="color-grid">
             {HABIT_COLORS.map((c) => (
               <button
@@ -51,7 +56,7 @@ export default function AddHabitModal({ onSave, onClose, initialHabit = null }) 
                 className={`color-swatch ${color === c ? 'selected' : ''}`}
                 style={{ backgroundColor: c }}
                 onClick={() => setColor(c)}
-                aria-label={`${COLOR_NAMES[c] || c}${color === c ? '（選択中）' : ''}`}
+                aria-label={`${colorCategories[c] || COLOR_NAMES[c] || c}${color === c ? '（選択中）' : ''}`}
                 aria-pressed={color === c}
               />
             ))}


### PR DESCRIPTION
close #329

## 変更内容

- AddHabitModalにcolorCategoriesプロップを追加
- 選択中の色に色名が設定されている場合、「カラー」ラベルの横にその名前を表示
- aria-labelにも色名を優先的に使用（未設定時は従来の内部名）
- 色名未設定ユーザーには追加表示なし（シンプルさを保つ）
- App.jsxで追加・編集モーダル両方にcolorCategoriesを渡すよう修正