### PR TITLE
fix(#327): 長押しヒントの文言を記録変更の役割に合わせて更新

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -535,7 +535,7 @@ export default function App() {
 
             {activeHabits.length > 0 && !editMode && !showWelcome && showEditHint && (
               <div className="edit-hint">
-                <span>習慣は長押しで編集できます。</span>
+                <span>習慣を長押しすると今日・昨日の記録をまとめて変更できます。</span>
                 <button type="button" onClick={dismissEditHint}>閉じる</button>
               </div>
             )}


### PR DESCRIPTION
close #327

長押し操作のヒントテキストを「習慣は長押しで編集できます」から「習慣を長押しすると今日・昨日の記録をまとめて変更できます」に変更しました。編集モード（並び替え・追加・削除）と長押し（記録変更）の役割の違いをより正確に伝えます。