### PR TITLE
fix(#313): カレンダーセクションの見出しを「実績」から「カレンダー」に変更

### DIFF
--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -61,7 +61,7 @@ export default function RecordView({
       {/* #278/#280: 実績タイトルをカード内に統一 */}
       <section className="section record-calendar-section">
         <div className="section-header">
-          <h2 className="section-title">実績</h2>
+          <h2 className="section-title">カレンダー</h2>
         </div>
         <Calendar
           date={calendarDate}


### PR DESCRIPTION
close #313

RecordViewでカレンダーを表示するセクションの見出しを「実績」から「カレンダー」に変更しました。#318のヘルプ更新とも整合しています。「習慣の進捗」と「積み上がり」のセクションは役割が明確なため現状維持とします。