### PR TITLE
fix(#337): モーダルのドラッグハンドルを視認しやすくする

### DIFF
--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -52,11 +52,12 @@
 }
 
 .modal-handle {
-  width: 36px;
-  height: 4px;
-  border-radius: 2px;
+  width: 44px;
+  height: 5px;
+  border-radius: 3px;
   background: var(--color-border);
-  margin: 0 auto 16px;
+  margin: 4px auto 18px;
+  opacity: 0.7;
 }
 
 .modal-title {


### PR DESCRIPTION
close #337

モーダル上部のドラッグハンドル（つまみ）のサイズを36x4pxから44x5pxに拡大し、マージンを追加しました。下スワイプで閉じられることが初見でも分かりやすくなります。backdrop tapでも閉じられる動作は従来通りです。