### PR TITLE
fix(#322): 分析画面の傾向コメントを主情報より控えめな表現へ

### DIFF
--- a/src/components/StatsAdviceCard.jsx
+++ b/src/components/StatsAdviceCard.jsx
@@ -1,9 +1,9 @@
 // 達成率に基づく傾向コメント（#195: 評価ではなく支援寄りのトーン）
 function getAdvice(rate7) {
   if (rate7 === null) return null
-  if (rate7 >= 80) return '安定したペースで続けられています。'
-  if (rate7 >= 50) return '半分以上できています。今の調子を大切に。'
-  return '無理のないペースで続けることが、長続きにつながりやすいです。'
+  if (rate7 >= 80) return 'この7日間、安定したペースです。'
+  if (rate7 >= 50) return 'この7日間は半分以上できています。'
+  return 'できた日を積み上げていきましょう。'
 }
 
 // statsStartDate がある場合、ラベルを実態に合わせて調整する

--- a/src/components/StatsView.css
+++ b/src/components/StatsView.css
@@ -54,9 +54,12 @@
 
 .analysis-advice-note {
   margin-top: 10px;
+  padding: 8px 10px;
   color: var(--color-text-secondary);
-  font-size: 0.8rem;
+  font-size: 0.74rem;
   line-height: 1.5;
+  background: var(--color-bg);
+  border-radius: 6px;
 }
 
 .analysis-weekday-list {


### PR DESCRIPTION
close #322

## 変更内容

- advice-noteのフォントサイズを0.8remから0.74remに縮小
- 背景色（color-bg）を追加して数値カードより視覚的に一段下げる
- コメント文言を評価口調から観察的な表現に変更
  - 「安定したペースで続けられています」→「この7日間、安定したペースです。」
  - 「半分以上できています。今の調子を大切に。」→「この7日間は半分以上できています。」
  - 長めの励まし文→「できた日を積み上げていきましょう。」