### PR TITLE
fix(#319): 色の名前設定の用語を「カテゴリ」から「色の名前」に統一

### DIFF
--- a/src/components/CategoryManageModal.jsx
+++ b/src/components/CategoryManageModal.jsx
@@ -42,7 +42,7 @@ export default function CategoryManageModal({ colorCategories, onUpdate, onClose
               type="text"
               value={draft[color] ?? ''}
               onChange={e => handleChange(color, e.target.value)}
-              placeholder="カテゴリ名（任意）"
+              placeholder="色の名前（任意）"
               maxLength={20}
             />
           </div>

--- a/src/components/StatsCategoryCard.jsx
+++ b/src/components/StatsCategoryCard.jsx
@@ -6,7 +6,7 @@ export default function StatsCategoryCard({ colorStats }) {
         <small className="section-sub">直近30日</small>
       </div>
       {colorStats.length === 0 ? (
-        <p className="analysis-note">カテゴリが設定された色の習慣がありません。</p>
+        <p className="analysis-note">名前が設定された色の習慣がありません。</p>
       ) : (
         <div className="analysis-color-list">
           {colorStats.map(({ color, name, count, rate }) => (


### PR DESCRIPTION
close #319

「カテゴリ名」と「色の名前」が混在していた表現を「色の名前」に統一しました。

- CategoryManageModal: placeholder「カテゴリ名（任意）」→「色の名前（任意）」
- StatsCategoryCard: 「カテゴリが設定された色の習慣がありません」→「名前が設定された色の習慣がありません」