### PR TITLE
fix(#343): 習慣化のヒント見出しを「ひとこと」に変更

### DIFF
--- a/src/components/HabitTip.jsx
+++ b/src/components/HabitTip.jsx
@@ -8,7 +8,7 @@ export default function HabitTip({ tip, visible, returning }) {
   ].filter(Boolean).join(' ')
   return (
     <div className={cls} aria-live="polite" aria-atomic="true">
-      <p className="habit-tip-pull-heading">習慣化のヒント</p>
+      <p className="habit-tip-pull-heading">ひとこと</p>
       <p className="habit-tip-pull-body">{tip}</p>
     </div>
   )


### PR DESCRIPTION
close #343

隠れ要素の見出し「習慣化のヒント」を「ひとこと」に変更しました。実際のコンテンツはアプリの設計思想を静かに語る内容であり、「ヒント」という語より自然な見出しです。