### PR TITLE
fix(#336): キーボード操作時のフォーカスリングをグローバルに追加

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -88,6 +88,18 @@ button {
   font-size: inherit;
 }
 
+/* キーボード操作時のフォーカスリング（#336） */
+:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* タッチ操作時はフォーカスリングを非表示 */
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
 input {
   font-family: inherit;
   font-size: inherit;


### PR DESCRIPTION
close #336

:focus-visibleセレクタを使ったフォーカスリングをindex.cssにグローバルで定義しました。キーボードのTab操作時に現在位置が明確になります。:focus:not(:focus-visible)でタッチ操作時はアウトラインを非表示にします。