### PR TITLE
fix(#334): ホーム画面追加案内をAndroid/PCのbeforeinstallpromptにも対応

### DIFF
--- a/src/components/AddToHomePrompt.css
+++ b/src/components/AddToHomePrompt.css
@@ -37,3 +37,19 @@
 .add-to-home-dismiss:active {
   opacity: 1;
 }
+
+.add-to-home-install-btn {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  background: none;
+  border: 1.5px solid var(--color-primary);
+  border-radius: 6px;
+  padding: 3px 10px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.add-to-home-install-btn:active {
+  opacity: 0.7;
+}

--- a/src/components/AddToHomePrompt.jsx
+++ b/src/components/AddToHomePrompt.jsx
@@ -1,18 +1,46 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import './AddToHomePrompt.css'
 
 const DISMISSED_KEY = 'add-to-home-dismissed'
 
-function shouldShow() {
-  // navigator.standalone は iOS Safari のみ存在する
-  if (!('standalone' in window.navigator)) return false
-  if (window.navigator.standalone) return false
-  if (window.matchMedia('(display-mode: standalone)').matches) return false
-  try { return !localStorage.getItem(DISMISSED_KEY) } catch { return false }
+function isIos() {
+  // iOS Safari のみ navigator.standalone が存在する
+  return 'standalone' in window.navigator
+}
+
+function isStandalone() {
+  if (window.navigator.standalone) return true
+  if (window.matchMedia('(display-mode: standalone)').matches) return true
+  return false
+}
+
+function isDismissed() {
+  try { return !!localStorage.getItem(DISMISSED_KEY) } catch { return false }
 }
 
 export default function AddToHomePrompt() {
-  const [visible, setVisible] = useState(shouldShow)
+  const [visible, setVisible] = useState(false)
+  const [deferredPrompt, setDeferredPrompt] = useState(null)
+  const isIosDevice = isIos()
+
+  useEffect(() => {
+    if (isStandalone() || isDismissed()) return
+
+    if (isIosDevice) {
+      // iOS: 常にバナーを表示（beforeinstallpromptは使えない）
+      setVisible(true)
+      return
+    }
+
+    // Android/PC: beforeinstallpromptイベントを待つ
+    const handler = (e) => {
+      e.preventDefault()
+      setDeferredPrompt(e)
+      setVisible(true)
+    }
+    window.addEventListener('beforeinstallprompt', handler)
+    return () => window.removeEventListener('beforeinstallprompt', handler)
+  }, [isIosDevice])
 
   if (!visible) return null
 
@@ -21,12 +49,27 @@ export default function AddToHomePrompt() {
     setVisible(false)
   }
 
+  const handleInstall = async () => {
+    if (deferredPrompt) {
+      deferredPrompt.prompt()
+      await deferredPrompt.userChoice
+      setDeferredPrompt(null)
+    }
+    setVisible(false)
+  }
+
   return (
     <div className="add-to-home-prompt" role="banner">
       <span className="add-to-home-text">
-        ホーム画面に追加するとアプリとして快適に使えます
+        ホーム画面に追加するとアプリとして使えます
       </span>
-      <span className="add-to-home-hint">「共有」→「ホーム画面に追加」</span>
+      {isIosDevice ? (
+        <span className="add-to-home-hint">「共有」→「ホーム画面に追加」</span>
+      ) : deferredPrompt ? (
+        <button className="add-to-home-install-btn" onClick={handleInstall}>
+          追加する
+        </button>
+      ) : null}
       <button className="add-to-home-dismiss" onClick={handleDismiss} aria-label="閉じる">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
           <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />


### PR DESCRIPTION
close #334

## 変更内容

- iOS: 従来通りバナーを常時表示（「共有」→「ホーム画面に追加」の案内）
- Android/PC: beforeinstallpromptイベントを受け取ったときのみバナーを表示し「追加する」ボタンで直接インストール可能にする
- スタンドアロン起動時・非表示にした場合は表示しない（従来通り）
- Android用の「追加する」ボタンスタイルをCSSに追加