### PR TITLE
fix: インポート確認ダイアログに色カテゴリ情報を表示 (#332)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -715,6 +715,8 @@ export default function App() {
 
       {modal?.type === 'importFile' && (() => {
         const recordDates = Object.keys(modal.data.records).sort()
+        const hasColorCategories = modal.data.colorCategories && Object.keys(modal.data.colorCategories).length > 0
+        const colorText = hasColorCategories ? '\n色の名前: あり（復元されます）' : '\n色の名前: なし（現在の設定は変わりません）'
         const skippedText = modal.skippedUnknownRecords > 0
           ? `\n\n※ バックアップ内に存在しない習慣IDの記録 ${modal.skippedUnknownRecords}件は除外して復元します。`
           : ''
@@ -724,7 +726,7 @@ export default function App() {
         return (
           <ConfirmModal
             title="インポートの確認"
-            message={`「${modal.filename}」をインポートします。\n\n習慣: ${modal.data.habits.length}件\n記録日数: ${recordDates.length}日\n期間: ${rangeText}${skippedText}\n\n⚠ 現在のデータはすべて上書きされます。\nこの操作は取り消せません。`}
+            message={`「${modal.filename}」をインポートします。\n\n習慣: ${modal.data.habits.length}件\n記録日数: ${recordDates.length}日\n期間: ${rangeText}${colorText}${skippedText}\n\n⚠ 現在のデータはすべて上書きされます。\nこの操作は取り消せません。`}
             confirmLabel="インポート"
             danger={true}
             onConfirm={handleImportConfirm}


### PR DESCRIPTION
## 変更内容\n\nインポート確認ダイアログのメッセージに「色の名前」データの有無を追加した。\n\n- colorCategories が空でない場合: 色の名前: あり（復元されます）\n- colorCategories が空の場合: 色の名前: なし（現在の設定は変わりません）\n\nこれにより、バックアップファイルに色名データが含まれるかどうかをインポート前にユーザーが確認できる。\n\n## 関連ISSUE\nCloses #332