### PR TITLE
fix: 日付・曜日・月名の表示定数をdate.jsに集約する (#355)

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,6 +1,6 @@
+import { DOW_LABELS } from '../utils/date'
 import './Calendar.css'
 
-const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
 
 function toDateStr(y, m, d) {
   return `${y}-${String(m + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`

--- a/src/components/MonthPickerModal.jsx
+++ b/src/components/MonthPickerModal.jsx
@@ -1,9 +1,8 @@
 import { useMemo, useState } from 'react'
 import Modal from './Modal'
+import { MONTH_LABELS } from '../utils/date'
 import './MonthPickerModal.css'
-
-const MONTH_LABELS = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月']
-
+
 export default function MonthPickerModal({ currentDate, records, onSelect, onClose }) {
   const [pickerYear, setPickerYear] = useState(currentDate.getFullYear())
   const currentYear = currentDate.getFullYear()

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -29,6 +29,20 @@ export function formatDisplayDate(dateStr) {
   return `${year}年${month}月${day}日（${dow}）`
 }
 
+export const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
+export const MONTH_LABELS = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月']
+
+// 'YYYY-MM-DD' の日付文字列から '2026年5月17日' 形式の文字列を返す
+export function formatYMD(dateStr) {
+  const d = parseLocalDate(dateStr)
+  return d.getFullYear() + '年' + (d.getMonth() + 1) + '月' + d.getDate() + '日'
+}
+
+// Date オブジェクトから '2026年5月' 形式の文字列を返す
+export function formatYearMonth(date) {
+  return date.getFullYear() + '年' + (date.getMonth() + 1) + '月'
+}
+
 export const HABIT_COLORS = [
   '#FF6B6B',
   '#FF9F43',


### PR DESCRIPTION
## 変更内容\n\n- DOW_LABELS・MONTH_LABELS を date.js にまとめて export\n- ormatYMD(dateStr) 関数（2026年5月17日形式）を追加\n- ormatYearMonth(date) 関数（2026年5月形式）を追加\n- Calendar.jsx のローカル DOW_LABELS 定義を削除し、date.js から import に統一\n- MonthPickerModal.jsx のローカル MONTH_LABELS 定義を削除し、date.js から import に統一\n\n## 修正理由\n日付表示がコンポーネントごとにローカル定義されており、将来のロケール対応時に各所を個別修正する必要があった。一箇所に集約することで修正箇所を限定する。\n\nCloses #355