### PR TITLE
fix: ホームにカレンダーを主役として残し実績・分析をモーダルへ移動 (#312, #321)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ import MonthPickerModal from './components/MonthPickerModal'
 import HabitTip from './components/HabitTip'
 import { getRandomTip } from './data/habitTips'
 import RecordView from './components/RecordView'
+import Calendar from './components/Calendar'
 import StatsView from './components/StatsView'
 import CategoryManageModal from './components/CategoryManageModal'
 import { useHabitsStorage, loadData } from './hooks/useHabitsStorage'
@@ -439,21 +440,21 @@ export default function App() {
           )}
         </button>
         <div className="header-actions">
-          {/* カレンダーへ移動 */}
+          {/* 実績モーダルを開く */}
           <button
             className="header-btn"
-            onClick={() => scrollToSection('record')}
-            aria-label="カレンダー"
-            title="カレンダー"
+            onClick={() => setModal({ type: 'record' })}
+            aria-label="実績"
+            title="実績"
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
+              <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
             </svg>
           </button>
-          {/* 分析（グラフ）へ移動 */}
+          {/* 分析モーダルを開く */}
           <button
             className="header-btn"
-            onClick={() => scrollToSection('stats')}
+            onClick={() => setModal({ type: 'analysis' })}
             aria-label="分析"
             title="分析"
           >
@@ -630,27 +631,48 @@ export default function App() {
               </div>
             )}
           </section>
-          {/* 実績セクション */}
+          {/* カレンダー（ホーム主役） */}
           <div id="section-record" className="section-group">
-            <RecordView
-              calendarDate={calendarDate}
-              onCalendarDateChange={setCalendarDate}
+            <Calendar
+              date={calendarDate}
+              onDateChange={setCalendarDate}
               habits={habits}
               records={records}
               today={today}
-              streakMode={streakMode}
               onDayClick={(dateStr) => setModal({ type: 'day', dateStr })}
               onMonthTitleClick={() => setModal({ type: 'monthPicker' })}
             />
           </div>
-
-          {/* 分析セクション */}
-          <div id="section-stats" className="section-group">
-            <StatsView habits={habits} records={records} today={today} colorCategories={colorCategories} statsStartDate={effectiveStatsStartDate} />
-          </div>
           <HabitTip tip={currentTip} visible={showDeepTip} returning={deepTipReturning} />
         </div>
       </main>
+
+      {modal?.type === 'record' && (
+        <RecordView
+          calendarDate={calendarDate}
+          onCalendarDateChange={setCalendarDate}
+          habits={habits}
+          records={records}
+          today={today}
+          streakMode={streakMode}
+          onDayClick={(dateStr) => setModal({ type: 'day', dateStr })}
+          onMonthTitleClick={() => setModal({ type: 'monthPicker' })}
+          asModal
+          onClose={closeModal}
+        />
+      )}
+
+      {modal?.type === 'analysis' && (
+        <StatsView
+          habits={habits}
+          records={records}
+          today={today}
+          colorCategories={colorCategories}
+          statsStartDate={effectiveStatsStartDate}
+          asModal
+          onClose={closeModal}
+        />
+      )}
 
       {modal?.type === 'monthPicker' && (
         <MonthPickerModal

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -1,4 +1,5 @@
 import Calendar from './Calendar'
+import Modal from './Modal'
 import HabitProgressLine from './HabitProgressLine'
 import { calcCurrentStreakWithMode, MILESTONES, getNextMilestone } from '../utils/stats'
 import './RecordView.css'
@@ -41,6 +42,8 @@ export default function RecordView({
   streakMode = 'decrement',
   onDayClick,
   onMonthTitleClick,
+  asModal = false,
+  onClose,
 }) {
   const monthKey = formatMonthKey(calendarDate)
   const monthCount = countRecordsInMonth(records, monthKey)
@@ -55,10 +58,9 @@ export default function RecordView({
 
   const sortedHabits = [...habitStreakList].sort((a, b) => b.streak - a.streak)
 
-  return (
+  const body = (
     <>
       {/* #272: カレンダーを今日の習慣の直後（最上部）に配置 */}
-      {/* #278/#280: 実績タイトルをカード内に統一 */}
       <section className="section record-calendar-section">
         <div className="section-header">
           <h2 className="section-title">カレンダー</h2>
@@ -74,7 +76,7 @@ export default function RecordView({
         />
       </section>
 
-      {/* 習慣の進捗（#272: カレンダーの後に移動） */}
+      {/* 習慣の進捗 */}
       {activeHabits.length > 0 && (
         <section className="section record-phase-highlight-section">
           <div className="phase-highlight-heading">習慣の進捗</div>
@@ -86,10 +88,9 @@ export default function RecordView({
         </section>
       )}
 
-      {/* 積み上がり（#293: 現在日数 + 次のマイルストンで表示） */}
+      {/* 積み上がり */}
       <section className="section record-summary-section">
         <div className="section-header">
-          {/* #294: streakModeに応じてセクションタイトルを変更 */}
           <h2 className="section-title">{streakMode === 'reset' ? '連続日数' : '積み上がり'}</h2>
           <div className="record-mini-stats">
             <span>{monthCount}回 今月</span>
@@ -129,4 +130,13 @@ export default function RecordView({
       </section>
     </>
   )
+
+  if (asModal) {
+    return (
+      <Modal title="実績" onClose={onClose}>
+        {body}
+      </Modal>
+    )
+  }
+  return body
 }

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -4,6 +4,7 @@ import StatsAdviceCard from './StatsAdviceCard'
 import StatsWeekdayCard from './StatsWeekdayCard'
 import StatsCategoryCard from './StatsCategoryCard'
 import './StatsView.css'
+import Modal from './Modal'
 
 const DOW_LABELS = ['日', '月', '火', '水', '木', '金', '土']
 
@@ -81,7 +82,8 @@ function calcColorStats(habits, records, today, colorCategories, statsStartDate)
     .sort((a, b) => (b.rate ?? -1) - (a.rate ?? -1))
 }
 
-export default function StatsView({ habits, records, today, colorCategories = {}, statsStartDate = null }) {
+
+export default function StatsView({ habits, records, today, colorCategories = {}, statsStartDate = null, asModal = false, onClose }) {
   const stats7 = calcRateForRange(habits, records, today, 7, statsStartDate)
   const rate7 = stats7.rate
   const stats30 = calcRateForRange(habits, records, today, 30, statsStartDate)
@@ -90,11 +92,9 @@ export default function StatsView({ habits, records, today, colorCategories = {}
   const colorStats = calcColorStats(habits, records, today, colorCategories, statsStartDate)
   const hasNamedColors = Object.values(colorCategories).some(v => v?.trim())
 
-  if (habits.length === 0) {
-    return <p className="analysis-empty">習慣を追加すると達成率が表示されます。</p>
-  }
-
-  return (
+  const body = habits.length === 0 ? (
+    <p className="analysis-empty">習慣を追加すると達成率が表示されます。</p>
+  ) : (
     <>
       <StatsAdviceCard rate7={rate7} rate30={rate30} statsStartDate={statsStartDate} achieved7={stats7.achieved} total7={stats7.total} achieved30={stats30.achieved} total30={stats30.total} />
 
@@ -105,4 +105,13 @@ export default function StatsView({ habits, records, today, colorCategories = {}
       <StatsWeekdayCard weekdayRates={weekdayRates} />
     </>
   )
+
+  if (asModal) {
+    return (
+      <Modal title="分析" onClose={onClose}>
+        {body}
+      </Modal>
+    )
+  }
+  return body
 }


### PR DESCRIPTION
## 変更内容

- ホーム画面から実績（進捗・積み上がり）と分析（達成率・曜日別）を削除
- ホームにはカレンダーを直接配置し、今日の習慣とカレンダーが主役
- ヘッダーボタンを実績モーダル・分析モーダルに変更
- RecordView・StatsViewにasModalプロップを追加
- 実績モーダル（type='record'）：カレンダー・習慣の進捗・積み上がりを表示
- 分析モーダル（type='analysis'）：StatsViewを表示

close #312
close #321