### PR TITLE
fix: 分析の色別達成率で終了済み習慣も活動期間内の実績を含める (#344, #345)

### DIFF
--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -65,15 +65,19 @@ function calcWeekdayRates(habits, records, today, days = 30, statsStartDate) {
 }
 
 function calcColorStats(habits, records, today, colorCategories, statsStartDate) {
-  const activeHabits = habits.filter(h => !h.archivedAt)
+  // #344: 分析では終了済み習慣も活動期間内の実績を含める
+  // activeHabitのみではなく全habitを対象にし、isHabitActiveOnで期間フィルタ
   return HABIT_COLORS
     .filter(color => colorCategories[color]?.trim())
     .map(color => {
-      const colorHabits = activeHabits.filter(h => h.color === color)
+      const colorHabits = habits.filter(h => h.color === color)
+      // カウントはアクティブなもののみ（終了済みは数の表示に含めない）
+      const activeCount = colorHabits.filter(h => !h.archivedAt).length
+      // 達成率は終了済みも含めた全体（活動期間内で計算）
       return {
         color,
         name: colorCategories[color],
-        count: colorHabits.length,
+        count: activeCount,
         rate: calcRateForRange(colorHabits, records, today, 30, statsStartDate).rate,
       }
     })


### PR DESCRIPTION
close #344
close #345

## 変更内容

- calcColorStatsで終了済み習慣（archivedAt設定済み）も達成率の計算対象に含める
- 全体達成率・曜日別達成率はisHabitActiveOnで既に活動期間を考慮済みのため一貫
- 表示件数はアクティブ習慣のみ（終了済みは件数に表示しない）