### PR TITLE
fix: アプリ内文言の文体と正確性を改善

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -549,7 +549,7 @@ export default function App() {
                 {showWelcome ? (
                   <div className="welcome-card">
                     <p className="welcome-title">ようこそ！</p>
-                    <p className="welcome-body">まず最初の習慣を1つ追加してみましょう。記録した日がカレンダーに積み上がっていきます。</p>
+                    <p className="welcome-body">続けたい習慣をひとつ追加してみましょう。</p>
                   </div>
                 ) : (
                   <p className="empty-text">習慣を追加してみよう</p>

--- a/src/components/HelpModal.jsx
+++ b/src/components/HelpModal.jsx
@@ -70,7 +70,7 @@ export default function HelpModal({ onClose }) {
           <h3 className="help-heading">はじめ方</h3>
           <p className="help-intro">
             まずは、続けたい習慣を1つ登録してみましょう。
-            このアプリは、「無理なく続けること」を大切にして作られています。
+            無理なく続けることを意識して作りました。
           </p>
         </section>
 

--- a/src/components/StatsAdviceCard.jsx
+++ b/src/components/StatsAdviceCard.jsx
@@ -3,7 +3,7 @@ function getAdvice(rate7) {
   if (rate7 === null) return null
   if (rate7 >= 80) return 'この7日間、安定したペースです。'
   if (rate7 >= 50) return 'この7日間は半分以上できています。'
-  return 'できた日を積み上げていきましょう。'
+  return '続けやすい日や時間帯を探してみるのもよいかもしれません。'
 }
 
 // statsStartDate がある場合、ラベルを実態に合わせて調整する


### PR DESCRIPTION
close #338
close #340
close #341
close #349
close #350
close #351
close #353

## 変更内容

- habitTips.js: 「記録ミスはあとから直せる」を前日分限定である旨に修正
- StatsAdviceCard.jsx: 達成率が低い時のコメントを観察寄りの表現に変更
- HelpModal.jsx: 設計意図の説明調・説教調の文言を簡潔に短縮
- App.jsx: 初回ウェルカムメッセージを短く自然な表現に変更