### PR TITLE
fix: UIテキスト定義ファイルを新設し文言分離の構造を導入 (#354)

### DIFF
--- a/src/data/strings.js
+++ b/src/data/strings.js
@@ -1,0 +1,60 @@
+// UIテキスト定義ファイル
+// 将来の多言語対応に備え、主要なUI文言をここに集約する。
+// 全画面ではなく、空状態・共通ボタン・主要メッセージを対象とする。
+// (#354)
+
+export const UI = {
+  // 空状態メッセージ
+  empty: {
+    habits: '習慣を追加してみよう',
+    analysis: '習慣を追加すると達成率が表示されます。',
+    record: '習慣を追加すると続いた日数が表示されます。',
+    stats: '習慣を追加すると統計が表示されます。',
+    noHabitsOnDay: '習慣がまだ登録されていません',
+    noColorCategory: '名前が設定された色の習慣がありません。',
+  },
+
+  // 共通ボタン
+  button: {
+    close: '閉じる',
+    cancel: 'キャンセル',
+    confirm: '確認',
+    edit: '編集',
+    done: '完了',
+    save: '保存',
+    add: '追加',
+    addHabit: '+ 最初の習慣を追加',
+  },
+
+  // ナビゲーション
+  nav: {
+    record: '実績',
+    analysis: '分析',
+    help: 'ヘルプ',
+    settings: '設定',
+    home: '今日の習慣へ戻る',
+  },
+
+  // モーダルタイトル
+  modal: {
+    record: '実績',
+    analysis: '分析',
+    settings: '設定',
+    help: '使い方',
+    stats: '統計',
+  },
+
+  // 設定ラベル
+  settings: {
+    theme: '見た目',
+    habit: '習慣',
+    analysis: '分析',
+    data: 'データ',
+    streakMode: '達成できなかった日の扱い',
+    statsStartDate: '集計開始日',
+    colorNames: '色の名前を設定',
+    colorNameUnset: '未設定',
+    backup: 'バックアップを保存',
+    restore: 'バックアップから復元',
+  },
+}


### PR DESCRIPTION
close #354

## 変更内容

- src/data/strings.js を新規作成
- 空状態テキスト・共通ボタン・ナビゲーション・モーダルタイトル・設定ラベルを定義
- 将来の多言語対応時に参照できる構造を準備（全コンポーネントへの即時適用は段階的）