### PR TITLE
fix: 習慣の進捗見出しをsection-titleに統一し残りの揺れを解消 (#297)

### DIFF
--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -77,7 +77,9 @@ export default function RecordView({
       {/* 習慣の進捗（#272: カレンダーの後に移動） */}
       {activeHabits.length > 0 && (
         <section className="section record-phase-highlight-section">
-          <div className="phase-highlight-heading">習慣の進捗</div>
+          <div className="section-header">
+            <h2 className="section-title">習慣の進捗</h2>
+          </div>
           <div className="progress-line-list">
             {sortedHabits.map(({ habit, streak }) => (
               <HabitProgressLine key={habit.id} habit={habit} streak={streak} />


### PR DESCRIPTION
close #297

## 変更内容

- RecordView.jsxの習慣の進捗セクション見出しをphase-highlight-headingから
  section-header + section-titleに変更
- カード・セクション全体で見出しスタイルが統一された