### PR TITLE
fix: 実績モーダルからカレンダー削除・ホームカレンダー背景復元・カード間隔調整

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -265,7 +265,7 @@
 .habits-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 10px;
+  gap: 12px;
 }
 
 @media (min-width: 540px) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -632,7 +632,7 @@ export default function App() {
             )}
           </section>
           {/* カレンダー（ホーム主役） */}
-          <div id="section-record" className="section-group">
+          <section id="section-record" className="section">
             <Calendar
               date={calendarDate}
               onDateChange={setCalendarDate}
@@ -642,7 +642,7 @@ export default function App() {
               onDayClick={(dateStr) => setModal({ type: 'day', dateStr })}
               onMonthTitleClick={() => setModal({ type: 'monthPicker' })}
             />
-          </div>
+          </section>
           <HabitTip tip={currentTip} visible={showDeepTip} returning={deepTipReturning} />
         </div>
       </main>

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -1,4 +1,3 @@
-import Calendar from './Calendar'
 import Modal from './Modal'
 import HabitProgressLine from './HabitProgressLine'
 import { calcCurrentStreakWithMode, MILESTONES, getNextMilestone } from '../utils/stats'
@@ -60,22 +59,6 @@ export default function RecordView({
 
   const body = (
     <>
-      {/* #272: カレンダーを今日の習慣の直後（最上部）に配置 */}
-      <section className="section record-calendar-section">
-        <div className="section-header">
-          <h2 className="section-title">カレンダー</h2>
-        </div>
-        <Calendar
-          date={calendarDate}
-          onDateChange={onCalendarDateChange}
-          habits={habits}
-          records={records}
-          today={today}
-          onDayClick={onDayClick}
-          onMonthTitleClick={onMonthTitleClick}
-        />
-      </section>
-
       {/* 習慣の進捗 */}
       {activeHabits.length > 0 && (
         <section className="section record-phase-highlight-section">


### PR DESCRIPTION
## 修正内容

- 実績モーダル（RecordView）からカレンダーセクションを削除（ホームに同じカレンダーがあるため不要）
- ホーム画面のカレンダーを .section でラップして背景・影を復元
- habits-grid の gap を 10px → 12px に調整してカード間隔を改善