### PR TITLE
fix: 実績・分析モーダルのカード間に gap を付与

### DIFF
--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -119,9 +119,9 @@ export default function RecordView({
   if (asModal) {
     return (
       <Modal title="実績" onClose={onClose}>
-        {body}
+        <div className="section-group">{body}</div>
       </Modal>
     )
   }
-  return body
+  return <div className="section-group">{body}</div>
 }

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -113,9 +113,9 @@ export default function StatsView({ habits, records, today, colorCategories = {}
   if (asModal) {
     return (
       <Modal title="分析" onClose={onClose}>
-        {body}
+        <div className="section-group">{body}</div>
       </Modal>
     )
   }
-  return body
+  return <div className="section-group">{body}</div>
 }


### PR DESCRIPTION
## 修正内容

RecordView・StatsView のモーダル描画で、cards（.section）が直接 Fragment で並んでいて gap なし。

section-group（display:flex; flex-direction:column; gap:16px）でラップして呼吸を追加。

## 原因
モーダル内コンテンツに gap コンテナがなく、カード間に間隔が出なかった。
ビルド成功だけ確認してプレビュー目視を省いていたことで見落とした。