### PR TITLE
fix: 習慣の進捗見出しを白文字に修正

### DIFF
--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -8,6 +8,10 @@
   padding: 16px 20px;
 }
 
+.record-phase-highlight-section .section-title {
+  color: rgba(255, 255, 255, 0.85);
+}
+
 .progress-line-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 原因

.record-phase-highlight-section は ackground: var(--color-primary)（紫）だが、.section-title の color: var(--color-text-secondary)（グレー）が上書きされておらず、紫背景にグレー文字で見えにくかった。

## 修正

.record-phase-highlight-section .section-title { color: rgba(255,255,255,0.85) } を追加。既存の opacity: 0.85 パターンと統一。