### PR TITLE
fix: 曜日別達成率で今日の曜日を強調して現在地を分かりやすくする

### DIFF
--- a/src/components/StatsView.css
+++ b/src/components/StatsView.css
@@ -86,6 +86,16 @@
   text-align: right;
 }
 
+.analysis-weekday-row--today .analysis-weekday-label,
+.analysis-weekday-row--today .analysis-weekday-rate {
+  color: var(--color-primary);
+}
+
+.analysis-weekday-row--today .analysis-weekday-bar span {
+  background: var(--color-primary);
+  opacity: 1;
+}
+
 .analysis-weekday-bar {
   overflow: hidden;
   height: 8px;

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -43,6 +43,7 @@ function calcRateForRange(habits, records, today, days, statsStartDate) {
 
 function calcWeekdayRates(habits, records, today, days = 30, statsStartDate) {
   const end = parseLocalDate(today)
+  const todayDow = end.getDay()
   const startBound = statsStartDate ? parseLocalDate(statsStartDate) : null
   const buckets = DOW_LABELS.map(label => ({ label, achieved: 0, total: 0 }))
 
@@ -59,9 +60,10 @@ function calcWeekdayRates(habits, records, today, days = 30, statsStartDate) {
     bucket.achieved += activeHabits.filter(habit => dayRecords.includes(habit.id)).length
   }
 
-  return buckets.map(bucket => ({
+  return buckets.map((bucket, i) => ({
     label: bucket.label,
     rate: bucket.total > 0 ? Math.round((bucket.achieved / bucket.total) * 100) : null,
+    isToday: i === todayDow,
   }))
 }
 

--- a/src/components/StatsWeekdayCard.jsx
+++ b/src/components/StatsWeekdayCard.jsx
@@ -7,7 +7,7 @@ export default function StatsWeekdayCard({ weekdayRates }) {
       </div>
       <div className="analysis-weekday-list">
         {weekdayRates.map(item => (
-          <div className="analysis-weekday-row" key={item.label}>
+          <div className={`analysis-weekday-row${item.isToday ? ' analysis-weekday-row--today' : ''}`} key={item.label}>
             <span className="analysis-weekday-label">{item.label}</span>
             <div className="analysis-weekday-bar">
               <span style={{ width: `${item.rate ?? 0}%` }} />


### PR DESCRIPTION
## 問題

曜日別達成率（直近30日）で今日がどの曜日かが分からず、週のどこにいるか把握しにくかった。

## 修正

- calcWeekdayRates に isToday フラグを追加（今日の曜日に 	rue）
- StatsWeekdayCard で今日の行に .analysis-weekday-row--today クラスを付与
- 今日の曜日ラベル・達成率・バーをプライマリカラーで強調表示