### PR TITLE
fix: マイルストン説明のinfoボタンを追加（#192）

### DIFF
--- a/src/components/RecordView.css
+++ b/src/components/RecordView.css
@@ -229,3 +229,61 @@
   color: var(--color-primary);
   font-weight: 600;
 }
+
+/* マイルストンinfoボタン */
+.record-info-btn {
+  background: none;
+  border: none;
+  padding: 0 0 0 4px;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  line-height: 1;
+  flex-shrink: 0;
+  -webkit-tap-highlight-color: transparent;
+}
+.record-info-btn:active {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+/* マイルストン説明モーダルコンテンツ */
+.milestone-info-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+.milestone-info-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+}
+
+.milestone-info-list li {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 0.82rem;
+  color: var(--color-text-secondary);
+}
+
+.milestone-info-days {
+  font-weight: 700;
+  color: var(--color-primary);
+  min-width: 36px;
+  flex-shrink: 0;
+}
+
+.milestone-info-note {
+  font-size: 0.78rem;
+  color: var(--color-text-secondary);
+}

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import Modal from './Modal'
 import HabitProgressLine from './HabitProgressLine'
 import { calcCurrentStreakWithMode, MILESTONES, getNextMilestone } from '../utils/stats'
@@ -44,6 +45,7 @@ export default function RecordView({
   asModal = false,
   onClose,
 }) {
+  const [showMilestoneInfo, setShowMilestoneInfo] = useState(false)
   const monthKey = formatMonthKey(calendarDate)
   const monthCount = countRecordsInMonth(records, monthKey)
   const totalCount = countTotalRecords(records)
@@ -64,6 +66,11 @@ export default function RecordView({
         <section className="section record-phase-highlight-section">
           <div className="section-header">
             <h2 className="section-title">習慣の進捗</h2>
+            <button
+              className="record-info-btn"
+              onClick={() => setShowMilestoneInfo(true)}
+              aria-label="マイルストンについて"
+            >ⓘ</button>
           </div>
           <div className="progress-line-list">
             {sortedHabits.map(({ habit, streak }) => (
@@ -71,6 +78,22 @@ export default function RecordView({
             ))}
           </div>
         </section>
+      )}
+
+      {showMilestoneInfo && (
+        <Modal title="マイルストンとは" onClose={() => setShowMilestoneInfo(false)}>
+          <div className="milestone-info-content">
+            <p>習慣は繰り返しによって少しずつ自然化すると言われています。</p>
+            <p>研究では平均66日前後で「自動化」が進んだという報告もありますが、個人差があります。</p>
+            <p>このアプリでは、小さな継続を段階的に感じられるよう、1日・1週間・1か月などの目安を設定しています。</p>
+            <ul className="milestone-info-list">
+              {MILESTONES.map(m => (
+                <li key={m.days}><span className="milestone-info-days">{m.days}日</span>{m.label}</li>
+              ))}
+            </ul>
+            <p className="milestone-info-note">続けるペースは人それぞれ。数字はあくまで目安です。</p>
+          </div>
+        </Modal>
       )}
 
       {/* 積み上がり */}


### PR DESCRIPTION
ISSUE #192対応。習慣の進捗カード見出し横にⓘボタンを追加し、マイルストン日数根拠（66日理論・個人差）をモーダルで説明する。