### PR TITLE
fix: 縦線マーカーまでの線グラデーションをCSS詳細度修正で有効化

### DIFF
--- a/src/components/HabitProgressLine.css
+++ b/src/components/HabitProgressLine.css
@@ -95,7 +95,7 @@
 }
 
 /* 今ここ縦線マーカーがある線：縦線位置までを白、以降をグレーにする */
-.hpl-stage--has-marker::before {
+.hpl-stage.hpl-stage--has-marker::before {
   background: linear-gradient(
     to right,
     #fff calc(var(--marker-pos) * 100%),


### PR DESCRIPTION
セレクタを .hpl-stage.hpl-stage--has-marker::before に変更して詳細度を上げ、グラデーションが正しく適用されるようにした。