### PR TITLE
fix: infoモーダルのModal入れ子を解消してスクロール崩れを修正

### DIFF
--- a/src/components/HabitProgressLine.css
+++ b/src/components/HabitProgressLine.css
@@ -95,7 +95,7 @@
 }
 
 /* 今ここ縦線マーカーがある線：縦線位置までを白、以降をグレーにする */
-.hpl-stage--has-marker::before {
+.hpl-stage.hpl-stage--has-marker::before {
   background: linear-gradient(
     to right,
     #fff calc(var(--marker-pos) * 100%),

--- a/src/components/HabitProgressLine.css
+++ b/src/components/HabitProgressLine.css
@@ -49,7 +49,7 @@
   /* grid-template-columns はインラインで動的に設定 */
 }
 
-/* 左端より前に続く線（達成済み） */
+/* 左端より前に続く線（達成済み・端に向かってフェード） */
 .hpl-track--has-left-tail::before {
   content: '';
   position: absolute;
@@ -57,10 +57,10 @@
   left: 0;
   width: calc(50% / var(--col-count) - 6px);
   height: 2px;
-  background: #fff;
+  background: linear-gradient(to right, transparent, #fff);
 }
 
-/* 右端より先に続く線（未達成） */
+/* 右端より先に続く線（未達成・端に向かってフェード） */
 .hpl-track--has-right-tail::after {
   content: '';
   position: absolute;
@@ -68,7 +68,7 @@
   right: 0;
   width: calc(50% / var(--col-count) - 6px);
   height: 2px;
-  background: rgba(255, 255, 255, 0.3);
+  background: linear-gradient(to right, rgba(255, 255, 255, 0.3), transparent);
 }
 
 .hpl-stage {

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -80,22 +80,6 @@ export default function RecordView({
         </section>
       )}
 
-      {showMilestoneInfo && (
-        <Modal title="継続の目安について" onClose={() => setShowMilestoneInfo(false)}>
-          <div className="milestone-info-content">
-            <p>習慣は繰り返しによって少しずつ自然化すると言われています。</p>
-            <p>研究では平均66日前後で「自動化」が進んだという報告もありますが、個人差があります。</p>
-            <p>このアプリでは、小さな継続を段階的に感じられるよう、1日・1週間・1か月などの目安を設定しています。</p>
-            <ul className="milestone-info-list">
-              {MILESTONES.map(m => (
-                <li key={m.days}><span className="milestone-info-days">{m.days}日</span>{m.label}</li>
-              ))}
-            </ul>
-            <p className="milestone-info-note">続けるペースは人それぞれ。数字はあくまで目安です。</p>
-          </div>
-        </Modal>
-      )}
-
       {/* 積み上がり */}
       <section className="section record-summary-section">
         <div className="section-header">
@@ -139,12 +123,36 @@ export default function RecordView({
     </>
   )
 
+  const milestoneInfoModal = showMilestoneInfo && (
+    <Modal title="継続の目安について" onClose={() => setShowMilestoneInfo(false)}>
+      <div className="milestone-info-content">
+        <p>習慣は繰り返しによって少しずつ自然化すると言われています。</p>
+        <p>研究では平均66日前後で「自動化」が進んだという報告もありますが、個人差があります。</p>
+        <p>このアプリでは、小さな継続を段階的に感じられるよう、1日・1週間・1か月などの目安を設定しています。</p>
+        <ul className="milestone-info-list">
+          {MILESTONES.map(m => (
+            <li key={m.days}><span className="milestone-info-days">{m.days}日</span>{m.label}</li>
+          ))}
+        </ul>
+        <p className="milestone-info-note">続けるペースは人それぞれ。数字はあくまで目安です。</p>
+      </div>
+    </Modal>
+  )
+
   if (asModal) {
     return (
-      <Modal title="実績" onClose={onClose}>
-        <div className="section-group">{body}</div>
-      </Modal>
+      <>
+        <Modal title="実績" onClose={onClose}>
+          <div className="section-group">{body}</div>
+        </Modal>
+        {milestoneInfoModal}
+      </>
     )
   }
-  return <div className="section-group">{body}</div>
+  return (
+    <>
+      <div className="section-group">{body}</div>
+      {milestoneInfoModal}
+    </>
+  )
 }


### PR DESCRIPTION
showMilestoneInfoのModalをbody変数内から取り出し、return文のトップレベルに並列配置。Modal内Modalによるスクロール・backdrop干渉を解消。