### PR TITLE
fix: 非連続時の表示文言を分かりやすくする

### DIFF
--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -80,10 +80,10 @@ export default function RecordView({
         </section>
       )}
 
-      {/* 積み上がり */}
+      {/* 継続ペース */}
       <section className="section record-summary-section">
         <div className="section-header">
-          <h2 className="section-title">{streakMode === 'reset' ? '連続日数' : '積み上がり'}</h2>
+          <h2 className="section-title">{streakMode === 'reset' ? '連続日数' : '週何回ペースで続いている'}</h2>
           <div className="record-mini-stats">
             <span>{monthCount}回 今月</span>
             <span>累計 {totalCount}回</span>

--- a/src/hooks/useHabitsStorage.js
+++ b/src/hooks/useHabitsStorage.js
@@ -6,8 +6,8 @@ const SETTINGS_KEY = 'habit-tracker-settings'
 // 未達成日の扱いモード (#294)
 export const STREAK_MODES = [
   { id: 'reset',       label: 'リセットする',    metricLabel: '連続日数' },
-  { id: 'decrement',   label: '1日分だけ戻す',   metricLabel: '積み上がり' },
-  { id: 'accumulate',  label: '減らさない',       metricLabel: '積み上がり' },
+  { id: 'decrement',   label: '1日分だけ戻す',   metricLabel: '週何回ペースで続いている' },
+  { id: 'accumulate',  label: '減らさない',       metricLabel: '週何回ペースで続いている' },
 ]
 export const DEFAULT_STREAK_MODE = 'decrement'
 


### PR DESCRIPTION
## 概要

Issue #408 対応です。
非連続モード時の指標名を、意味が伝わりにくい `積み上がり` から `週何回ペースで続いている` に変更しました。

## 修正内容

- 実績画面の非連続モード時見出しを変更
- `STREAK_MODES` の `metricLabel` も同じ文言へ統一

## 修正理由

連続日数ではない設定では、ユーザーが見ているのは「連続」よりも習慣の継続ペースです。
その意図が表示から伝わるよう、ラベルを具体的な表現に置き換えました。

## 確認

- `npm.cmd run build` 成功

Closes #408