### PR TITLE
fix: 非連続モードで適切な継続スコア表示に変更

### DIFF
--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -103,12 +103,22 @@ export default function RecordView({
                   <div className="streak-summary-right">
                     {streak > 0 ? (
                       <>
-                        <span className="streak-summary-days">{streak}日継続中</span>
-                        {next ? (
-                          <span className="streak-summary-next">次は{next.label}</span>
-                        ) : currentLabel ? (
-                          <span className="streak-summary-next streak-summary-next--done">{currentLabel} 達成</span>
-                        ) : null}
+                        {streakMode === 'reset' && (
+                          <>
+                            <span className="streak-summary-days">{streak}日継続中</span>
+                            {next ? (
+                              <span className="streak-summary-next">次は{next.label}</span>
+                            ) : currentLabel ? (
+                              <span className="streak-summary-next streak-summary-next--done">{currentLabel} 達成</span>
+                            ) : null}
+                          </>
+                        )}
+                        {streakMode === 'decrement' && (
+                          <span className="streak-summary-days">スコア {streak}</span>
+                        )}
+                        {streakMode === 'accumulate' && (
+                          <span className="streak-summary-days">累計 {streak}日</span>
+                        )}
                       </>
                     ) : (
                       <span className="streak-summary-days">まだ記録なし</span>


### PR DESCRIPTION
## 背景

`streak-summary-row` の「N日継続中」表示が `streakMode` に関わらず固定されており、`decrement`/`accumulate` モードでは継続日数と混同しやすい問題があった。

## 変更内容

`RecordView.jsx` の streak ラベルを `streakMode` に応じて切り替えるよう修正。

- reset: 「N日継続中」（変更なし）
- decrement: 「スコア N」
- accumulate: 「累計 N日」

## 確認内容

- reset モードでは「N日継続中」のまま表示される
- decrement モードでは「スコア N」と表示される
- accumulate モードでは「累計 N日」と表示される
- npm run build が通ることを確認済み

Closes #412