### PR TITLE
fix: undo-toastをsafe-area-inset-bottomに対応する

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -389,7 +389,7 @@
 
 .undo-toast {
   position: fixed;
-  bottom: 16px;
+  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
   left: 50%;
   transform: translateX(-50%);
   display: flex;


### PR DESCRIPTION
fixes #414

## 変更内容

- `.undo-toast` の `bottom` を `calc(16px + env(safe-area-inset-bottom, 0px))` に変更
- iPhoneのホームバー領域にトーストが隠れなくなる