### PR TITLE
fix: icon.svgの弧の角度をPNGに合わせて修正する

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,14 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="412" y1="346" x2="412" y2="166">
+    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="383" x2="383" y2="129">
       <stop offset="0%" stop-color="#1E1B8B"/>
       <stop offset="100%" stop-color="#A5B4FC"/>
     </linearGradient>
   </defs>
-  <path d="M 412 346 A 180 180 0 1 1 412 166"
+  <path d="M 383 383 A 180 180 0 1 1 383 129"
         fill="none"
         stroke="url(#g)"
         stroke-width="36"
         stroke-linecap="round"/>
-  <circle cx="412" cy="346" r="22" fill="#1E1B8B"/>
+  <circle cx="383" cy="383" r="22" fill="#1E1B8B"/>
 </svg>


### PR DESCRIPTION
## 背景
PR #410でiconのSVGを更新したが、弧の角度がPNG（icon-192.png / icon-512.png）と一致しない状態になっていた。

## 問題
- SVGの実装: ドットが4時の位置(412,346)、弧の端が2時の位置(412,166)、60°のギャップ
- PNGの正解: ドットが4:30の位置(383,383)、弧の端が1:30の位置(383,129)、90°のギャップ

## 確認観点
- app-hubで表示されるiconがPNGアイコンと同じ見た目になっているか
- SVGのドットが右下（4:30）、弧の開口部が右（3時方向）になっているか