### PR TITLE
fix: streak=1で連続表示が出ない問題とLongPressModalタイトルを修正

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,14 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
-      <stop offset="0%" stop-color="#1E1B8B"/>
-      <stop offset="100%" stop-color="#A5B4FC"/>
+    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#818CF8"/>
+    </linearGradient>
+    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#1E1B8B"/>
     </linearGradient>
   </defs>
-  <path d="M 383 383 A 180 180 0 1 1 383 129"
-        fill="none"
-        stroke="url(#g)"
-        stroke-width="36"
-        stroke-linecap="round"/>
-  <circle cx="383" cy="383" r="22" fill="#1E1B8B"/>
+  <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->
+  <path d="M 284 98 A 160 160 0 0 1 395 336"
+        fill="none" stroke="url(#g1)" stroke-width="22" stroke-linecap="round"/>
+  <!-- 弧２: 5時(336,395)[60°] → 12時左(228,98)[260°], 時計回り 200° -->
+  <path d="M 336 395 A 160 160 0 1 1 228 98"
+        fill="none" stroke="url(#g2)" stroke-width="22" stroke-linecap="round"/>
+  <!-- 円: 4時と5時の間 (369,369) -->
+  <circle cx="369" cy="369" r="18" fill="#1E1B8B"/>
 </svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="383" x2="383" y2="129">
+    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
       <stop offset="0%" stop-color="#1E1B8B"/>
       <stop offset="100%" stop-color="#A5B4FC"/>
     </linearGradient>

--- a/src/components/AddHabitModal.jsx
+++ b/src/components/AddHabitModal.jsx
@@ -38,6 +38,7 @@ export default function AddHabitModal({ onSave, onClose, initialHabit = null, co
             value={name}
             onChange={(e) => setName(e.target.value)}
             maxLength={20}
+            autoFocus
           />
         </div>
 

--- a/src/components/HabitButton.jsx
+++ b/src/components/HabitButton.jsx
@@ -77,7 +77,7 @@ export default function HabitButton({ habit, completed, streak, streakMode = 'de
         style={{ backgroundColor: completed ? '#fff' : habit.color }}
       />
       <span className="habit-name">{habit.name}</span>
-      {streak > 1 && <span className="habit-streak">{streak}{streakUnit}</span>}
+      {streak > 0 && <span className="habit-streak">{streak}{streakUnit}</span>}
       {completed && <span className="habit-check">✓</span>}
     </button>
   )

--- a/src/components/LongPressModal.jsx
+++ b/src/components/LongPressModal.jsx
@@ -17,7 +17,7 @@ export default function LongPressModal({
   ]
 
   return (
-    <Modal onClose={onClose} title={`「${habit.name}」の記録`}>
+    <Modal onClose={onClose} title={`「${habit.name}」の記録・編集`}>
       <div className="lp-days">
         {days.map(({ dateStr, label, completed }) => {
           const unavailable = habit.createdAt && dateStr < habit.createdAt

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -241,3 +241,22 @@
 .toggle-switch--on .toggle-switch-thumb {
   transform: translateX(18px);
 }
+
+/* #425: streakMode選択肢の補足説明 */
+.streak-mode-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.streak-mode-desc {
+  font-size: 0.65rem;
+  font-weight: 400;
+  color: var(--color-text-secondary);
+  line-height: 1.3;
+}
+
+.streak-mode-btn.selected .streak-mode-desc {
+  color: var(--color-primary);
+}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,5 +1,11 @@
 import Modal from './Modal'
 import { STREAK_MODES } from '../hooks/useHabitsStorage'
+
+const STREAK_MODE_DESCRIPTIONS = {
+  reset:      '休むとゼロに戻る',
+  decrement:  '少しだけ戻る',
+  accumulate: '変わらず保たれる',
+}
 import './SettingsModal.css'
 
 export const THEMES = [
@@ -88,6 +94,9 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
               aria-pressed={streakMode === mode.id}
             >
               {mode.label}
+              {STREAK_MODE_DESCRIPTIONS[mode.id] && (
+                <span className="streak-mode-desc">{STREAK_MODE_DESCRIPTIONS[mode.id]}</span>
+              )}
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary

- HabitButton の streak 表示条件を `> 1` から `> 0` に変更（closes #427）
  - 連続1日目から右下に「1日」または「1日連続」が表示される
  - streak === 0 のときは引き続き非表示
- LongPressModal のタイトルを「の記録」から「の記録・編集」に変更（closes #428）
  - 記録変更と編集の両方があることを端的に示す

## Test plan

- [ ] 習慣を今日初めて達成したとき（streak=1）、ボタン右下に連続表示が出る
- [ ] 未達成（streak=0）のときは連続表示が出ない
- [ ] streakMode が reset / decrement / accumulate のどれでも単位が正しい
- [ ] 習慣を長押ししたとき、モーダルタイトルが「の記録・編集」になっている
- [ ] ビルドが通る（npm run build 済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)