### PR TITLE
fix: 習慣ボタンの連続日数をフロー配置に変更して視認性を改善

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,12 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
-      <stop offset="0%" stop-color="#A5B4FC"/>
-      <stop offset="100%" stop-color="#818CF8"/>
-    </linearGradient>
-    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
-      <stop offset="0%" stop-color="#A5B4FC"/>
-      <stop offset="100%" stop-color="#1E1B8B"/>
+    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
+      <stop offset="0%" stop-color="#1E1B8B"/>
+      <stop offset="100%" stop-color="#A5B4FC"/>
     </linearGradient>
   </defs>
   <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,8 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
-      <stop offset="0%" stop-color="#1E1B8B"/>
-      <stop offset="100%" stop-color="#A5B4FC"/>
+    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#818CF8"/>
+    </linearGradient>
+    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#1E1B8B"/>
     </linearGradient>
   </defs>
   <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->

--- a/src/components/HabitButton.css
+++ b/src/components/HabitButton.css
@@ -76,13 +76,11 @@
   opacity: 0.9;
 }
 
-/* 連続日数: ✓ マーク（右上）と干渉しないよう左下に配置 */
+/* 連続日数: 習慣名の下にフローで配置し、達成チェック（右上絶対）と干渉しない */
 .habit-streak {
-  position: absolute;
-  bottom: 5px;
-  left: 7px;
-  font-size: 0.7rem;
+  font-size: 0.72rem;
   font-weight: 700;
   opacity: 0.85;
   line-height: 1;
+  margin-top: -2px;
 }


### PR DESCRIPTION
## Summary

- 習慣ボタンの連続日数を  から通常フローに変更し、習慣名の直下に配置
-  -> 、 ->  に引き上げて視認性を改善
- 達成チェック（右上の絶対配置 ✓）との干渉を解消

## Test plan

- [ ] 連続日数が習慣名の下に読みやすく表示される
- [ ] 達成済み状態（✓）と連続日数が干渉しない
- [ ] ボタン高さ 80px 内に収まる
- [ ]  通過済み

Closes #436

Generated with [Claude Code](https://claude.com/claude-code)