### PR TITLE
習慣追加後のToastフィードバックとストリークモード補足説明を追加 (#443 #442)

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,12 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
-      <stop offset="0%" stop-color="#A5B4FC"/>
-      <stop offset="100%" stop-color="#818CF8"/>
-    </linearGradient>
-    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
-      <stop offset="0%" stop-color="#A5B4FC"/>
-      <stop offset="100%" stop-color="#1E1B8B"/>
+    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
+      <stop offset="0%" stop-color="#1E1B8B"/>
+      <stop offset="100%" stop-color="#A5B4FC"/>
     </linearGradient>
   </defs>
   <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,8 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
-      <stop offset="0%" stop-color="#1E1B8B"/>
-      <stop offset="100%" stop-color="#A5B4FC"/>
+    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#818CF8"/>
+    </linearGradient>
+    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#1E1B8B"/>
     </linearGradient>
   </defs>
   <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->

--- a/src/App.css
+++ b/src/App.css
@@ -440,7 +440,7 @@
 
 .edit-hint {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 10px;
   margin: -2px 0 12px;
@@ -455,8 +455,7 @@
 .edit-hint span {
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  line-height: 1.45;
 }
 
 .edit-hint button {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,10 @@ export default function App() {
     try { localStorage.setItem(ONBOARDING_KEY, '1') } catch {}
     setShowWelcome(false)
   }, [])
+  const handleAddHabit = useCallback((name) => {
+    dismissWelcome()
+    setToast('「' + name + '」を追加しました')
+  }, [dismissWelcome])
   const dismissEditHint = useCallback(() => {
     try { localStorage.setItem(EDIT_HINT_KEY, '1') } catch {}
     setShowEditHint(false)
@@ -171,8 +175,7 @@ export default function App() {
     setHabits,
     setRecords,
     setModal,
-    onAddHabit: dismissWelcome,
-    onUndoComplete: () => setToast('元に戻しました'),
+    onAddHabit: handleAddHabit,
   })
 
   const {

--- a/src/components/HabitButton.css
+++ b/src/components/HabitButton.css
@@ -76,13 +76,11 @@
   opacity: 0.9;
 }
 
-/* 連続日数: ✓ マーク（右上）と干渉しないよう左下に配置 */
+/* 連続日数: 習慣名の下にフローで配置し、達成チェック（右上絶対）と干渉しない */
 .habit-streak {
-  position: absolute;
-  bottom: 5px;
-  left: 7px;
-  font-size: 0.7rem;
+  font-size: 0.72rem;
   font-weight: 700;
   opacity: 0.85;
   line-height: 1;
+  margin-top: -2px;
 }

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -242,21 +242,10 @@
   transform: translateX(18px);
 }
 
-/* #425: streakMode選択肢の補足説明 */
-.streak-mode-btn {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-}
-
+/* #442: ストリークモード補足説明 */
 .streak-mode-desc {
-  font-size: 0.65rem;
-  font-weight: 400;
+  margin-top: 8px;
+  font-size: 0.75rem;
   color: var(--color-text-secondary);
-  line-height: 1.3;
-}
-
-.streak-mode-btn.selected .streak-mode-desc {
-  color: var(--color-primary);
+  line-height: 1.5;
 }

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -100,6 +100,7 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
             </button>
           ))}
         </div>
+        {(() => { const m = STREAK_MODES.find(m => m.id === streakMode); return m ? <p className="streak-mode-desc">{m.desc}</p> : null })()}
       </div>
 
       <hr className="settings-divider" />

--- a/src/hooks/useHabitActions.js
+++ b/src/hooks/useHabitActions.js
@@ -49,7 +49,7 @@ export function useHabitActions({ records, today, setHabits, setRecords, setModa
     const id = `h_${Date.now()}`
     setHabits(prev => [...prev, { id, name, color, createdAt: today }])
     setModal(null)
-    onAddHabit?.()
+    onAddHabit?.(name)
   }, [today, setHabits, setModal, onAddHabit])
 
   // updateHabit は modal.habit.id が必要なため、habitId を明示的に引数として受け取る

--- a/src/hooks/useHabitsStorage.js
+++ b/src/hooks/useHabitsStorage.js
@@ -5,9 +5,9 @@ const SETTINGS_KEY = 'habit-tracker-settings'
 
 // 未達成日の扱いモード (#294)
 export const STREAK_MODES = [
-  { id: 'reset',       label: 'リセットする',    metricLabel: '連続日数' },
-  { id: 'decrement',   label: '1日分だけ戻す',   metricLabel: '週何回ペースで続いている' },
-  { id: 'accumulate',  label: '減らさない',       metricLabel: '週何回ペースで続いている' },
+  { id: 'reset',       label: 'リセットする',    metricLabel: '連続日数',                desc: '未達成の翌日から連続日数が0に戻ります' },
+  { id: 'decrement',   label: '1日分だけ戻す',   metricLabel: '週何回ペースで続いている', desc: '未達成の日は連続日数が1減ります' },
+  { id: 'accumulate',  label: '減らさない',       metricLabel: '週何回ペースで続いている', desc: '未達成の日があっても連続日数は変わりません' },
 ]
 export const DEFAULT_STREAK_MODE = 'decrement'
 


### PR DESCRIPTION
## 概要

- #443 習慣追加後のToastフィードバック追加
- #442 設定モーダルのストリークモード選択肢に補足説明追加

## 変更内容

### #443 習慣追加後のToastフィードバック
- `useHabitActions.js`: `onAddHabit`コールバックに習慣名を引数として渡すよう変更
- `App.jsx`: `handleAddHabit`コールバックを追加し、追加成功後に「〇〇 を追加しました」Toastを表示

### #442 ストリークモード補足説明
- `useHabitsStorage.js`: `STREAK_MODES`の各モードに`desc`フィールドを追加
- `SettingsModal.jsx`: 選択中モードの補足説明を選択肢グループの下に表示
- `SettingsModal.css`: `.streak-mode-desc`スタイルを追加

## 確認観点

- 習慣を追加するとモーダルが閉じた後にToastが表示されること
- Toastに追加した習慣名が含まれること
- 設定モーダルのストリークモード選択時に補足説明が表示されること
- `npm run build` 通過済み
