### PR TITLE
fix: 習慣編集後のフィードバックとedit-hintボタンのタップ領域を改善

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,12 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
-      <stop offset="0%" stop-color="#A5B4FC"/>
-      <stop offset="100%" stop-color="#818CF8"/>
-    </linearGradient>
-    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
-      <stop offset="0%" stop-color="#A5B4FC"/>
-      <stop offset="100%" stop-color="#1E1B8B"/>
+    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
+      <stop offset="0%" stop-color="#1E1B8B"/>
+      <stop offset="100%" stop-color="#A5B4FC"/>
     </linearGradient>
   </defs>
   <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,8 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
-      <stop offset="0%" stop-color="#1E1B8B"/>
-      <stop offset="100%" stop-color="#A5B4FC"/>
+    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#818CF8"/>
+    </linearGradient>
+    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#1E1B8B"/>
     </linearGradient>
   </defs>
   <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->

--- a/src/App.css
+++ b/src/App.css
@@ -463,7 +463,9 @@
   color: var(--color-primary);
   font-size: 0.72rem;
   font-weight: 700;
-  padding: 2px 4px;
+  padding: 10px 12px;
+  min-height: 44px;
+  margin: -8px -8px -8px 0;
 }
 
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,6 +63,9 @@ export default function App() {
     dismissWelcome()
     setToast('「' + name + '」を追加しました')
   }, [dismissWelcome])
+  const handleUpdateHabit = useCallback((name) => {
+    setToast('「' + name + '」を更新しました')
+  }, [])
   const dismissEditHint = useCallback(() => {
     try { localStorage.setItem(EDIT_HINT_KEY, '1') } catch {}
     setShowEditHint(false)
@@ -176,6 +179,7 @@ export default function App() {
     setRecords,
     setModal,
     onAddHabit: handleAddHabit,
+    onUpdateHabit: handleUpdateHabit,
   })
 
   const {

--- a/src/hooks/useHabitActions.js
+++ b/src/hooks/useHabitActions.js
@@ -9,7 +9,7 @@ import { arrayMove } from '@dnd-kit/sortable'
  * - 記録の切り替え（toggle）とundo
  * - ドラッグによる並び替え
  */
-export function useHabitActions({ records, today, setHabits, setRecords, setModal, onAddHabit, onUndoComplete }) {
+export function useHabitActions({ records, today, setHabits, setRecords, setModal, onAddHabit, onUpdateHabit }) {
   const [undoAction, setUndoAction] = useState(null)
   const undoTimerRef = useRef(null)
 
@@ -57,8 +57,9 @@ export function useHabitActions({ records, today, setHabits, setRecords, setModa
     setHabits(prev =>
       prev.map(h => h.id === habitId ? { ...h, name, color } : h)
     )
+    onUpdateHabit?.(name)
     setModal(null)
-  }, [setHabits, setModal])
+  }, [setHabits, setModal, onUpdateHabit])
 
   const deleteHabit = useCallback((habitId) => {
     setHabits(prev => prev.filter(h => h.id !== habitId))


### PR DESCRIPTION
## Summary

- 習慣を編集して保存したとき「○○を更新しました」トーストを表示（#445）
- edit-hintバナーの「閉じる」ボタンを min-height: 44px に拡張し、モバイルで押しやすくした（#446）

## Test plan

- [ ] 習慣を編集して「保存する」を押すと「○○を更新しました」トーストが表示される
- [ ] 習慣を追加したときの「○○を追加しました」トーストは引き続き正常に表示される
- [ ] edit-hintバナーの「閉じる」ボタンがモバイルで確実にタップできる（44px以上の領域）
- [ ] バナーを閉じると以後表示されない
- [ ] `npm run build` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)