### PR TITLE
fix: バックアップ未経験ユーザーに促進文言を表示する (#458)

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,12 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
-      <stop offset="0%" stop-color="#A5B4FC"/>
-      <stop offset="100%" stop-color="#818CF8"/>
-    </linearGradient>
-    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
-      <stop offset="0%" stop-color="#A5B4FC"/>
-      <stop offset="100%" stop-color="#1E1B8B"/>
+    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
+      <stop offset="0%" stop-color="#1E1B8B"/>
+      <stop offset="100%" stop-color="#A5B4FC"/>
     </linearGradient>
   </defs>
   <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,8 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
-      <stop offset="0%" stop-color="#1E1B8B"/>
-      <stop offset="100%" stop-color="#A5B4FC"/>
+    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#818CF8"/>
+    </linearGradient>
+    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#1E1B8B"/>
     </linearGradient>
   </defs>
   <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -242,10 +242,8 @@
   transform: translateX(18px);
 }
 
-/* #442: ストリークモード補足説明 */
-.streak-mode-desc {
-  margin-top: 8px;
-  font-size: 0.75rem;
-  color: var(--color-text-secondary);
-  line-height: 1.5;
+/* #458: バックアップ未経験ユーザーへの促進文言 */
+.no-backup-hint {
+  color: var(--color-primary);
+  font-weight: 500;
 }

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -133,7 +133,10 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
           </svg>
           <span className="data-mgmt-btn-text">
             バックアップを保存
-            {lastBackupDate && <span className="last-backup-date">最終: {lastBackupDate}</span>}
+            {lastBackupDate
+              ? <span className="last-backup-date">最終: {lastBackupDate}</span>
+              : <span className="last-backup-date no-backup-hint">まだバックアップがありません</span>
+            }
           </span>
         </button>
         <button className="data-mgmt-btn" onClick={onImport}>


### PR DESCRIPTION
## Summary

- `lastBackupDate` が未設定（一度もバックアップしていない）のとき、「まだバックアップがありません」を設定画面のバックアップボタン内に表示する
- バックアップ済みの場合は従来の「最終: YYYY-MM-DD」表示のまま変わらない
- 文言は `--color-primary` カラーで表示し、通常のサブテキストと区別する

## Test plan

- [ ] 一度もバックアップしていない状態で設定を開き、「まだバックアップがありません」が表示されることを確認
- [ ] バックアップを実行後、「最終: ...」に切り替わることを確認
- [ ] `npm run build` が通ることを確認済み

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)