### PR TITLE
fix: undoトースト実行後のフィードバックと編集モーダルの対象習慣名表示を追加 (#466 #467)

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,14 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
-      <stop offset="0%" stop-color="#1E1B8B"/>
-      <stop offset="100%" stop-color="#A5B4FC"/>
+    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#818CF8"/>
+    </linearGradient>
+    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#1E1B8B"/>
     </linearGradient>
   </defs>
-  <path d="M 383 383 A 180 180 0 1 1 383 129"
-        fill="none"
-        stroke="url(#g)"
-        stroke-width="36"
-        stroke-linecap="round"/>
-  <circle cx="383" cy="383" r="22" fill="#1E1B8B"/>
+  <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->
+  <path d="M 284 98 A 160 160 0 0 1 395 336"
+        fill="none" stroke="url(#g1)" stroke-width="22" stroke-linecap="round"/>
+  <!-- 弧２: 5時(336,395)[60°] → 12時左(228,98)[260°], 時計回り 200° -->
+  <path d="M 336 395 A 160 160 0 1 1 228 98"
+        fill="none" stroke="url(#g2)" stroke-width="22" stroke-linecap="round"/>
+  <!-- 円: 4時と5時の間 (369,369) -->
+  <circle cx="369" cy="369" r="18" fill="#1E1B8B"/>
 </svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="383" x2="383" y2="129">
+    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
       <stop offset="0%" stop-color="#1E1B8B"/>
       <stop offset="100%" stop-color="#A5B4FC"/>
     </linearGradient>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -172,6 +172,7 @@ export default function App() {
     setRecords,
     setModal,
     onAddHabit: dismissWelcome,
+    onUndoComplete: () => setToast('元に戻しました'),
   })
 
   const {

--- a/src/components/AddHabitModal.jsx
+++ b/src/components/AddHabitModal.jsx
@@ -27,7 +27,7 @@ export default function AddHabitModal({ onSave, onClose, initialHabit = null, co
   }
 
   return (
-    <Modal onClose={onClose} title={isEdit ? '習慣を編集' : '習慣を追加'}>
+    <Modal onClose={onClose} title={isEdit ? `「${initialHabit.name}」を編集` : "習慣を追加"}>
       <form onSubmit={handleSubmit} className="add-form">
         <div className="form-group">
           <label className="form-label">名前</label>

--- a/src/hooks/useHabitActions.js
+++ b/src/hooks/useHabitActions.js
@@ -9,7 +9,7 @@ import { arrayMove } from '@dnd-kit/sortable'
  * - 記録の切り替え（toggle）とundo
  * - ドラッグによる並び替え
  */
-export function useHabitActions({ records, today, setHabits, setRecords, setModal, onAddHabit }) {
+export function useHabitActions({ records, today, setHabits, setRecords, setModal, onAddHabit, onUndoComplete }) {
   const [undoAction, setUndoAction] = useState(null)
   const undoTimerRef = useRef(null)
 
@@ -42,7 +42,8 @@ export function useHabitActions({ records, today, setHabits, setRecords, setModa
       return { ...prev, [dateStr]: [...dr, habitId] }
     })
     setUndoAction(null)
-  }, [undoAction, setRecords])
+    onUndoComplete?.()
+  }, [undoAction, setRecords, onUndoComplete])
 
   const addHabit = useCallback(({ name, color }) => {
     const id = `h_${Date.now()}`


### PR DESCRIPTION
## 概要

UIレビューで発見した2件の問題を修正します。

- #466 undoトーストで「元に戻す」実行後に「元に戻しました」Toastを表示
- #467 習慣編集モーダルのタイトルを「「習慣名」を編集」に変更し、何を編集中か一目で分かるように

## 変更内容

- `useHabitActions.js`: `handleUndo` 実行後に `onUndoComplete` コールバックを呼ぶ
- `App.jsx`: `onUndoComplete` で `setToast('元に戻しました')` を渡す
- `AddHabitModal.jsx`: 編集時のタイトルを `「${initialHabit.name}」を編集` に変更

## 確認観点

- [ ] 習慣達成後に「元に戻す」を押すと「元に戻しました」Toastが表示される
- [ ] 習慣を編集すると「「習慣名」を編集」がタイトルに表示される
- [ ] 習慣追加モーダル（isEdit=false）のタイトルは「習慣を追加」のまま
- [ ] `npm run build` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)
