### PR TITLE
fix: 習慣編集モードの終了・削除ボタンにラベルテキストを追加 (#478)

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,14 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
-      <stop offset="0%" stop-color="#1E1B8B"/>
-      <stop offset="100%" stop-color="#A5B4FC"/>
+    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#818CF8"/>
+    </linearGradient>
+    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#1E1B8B"/>
     </linearGradient>
   </defs>
-  <path d="M 383 383 A 180 180 0 1 1 383 129"
-        fill="none"
-        stroke="url(#g)"
-        stroke-width="36"
-        stroke-linecap="round"/>
-  <circle cx="383" cy="383" r="22" fill="#1E1B8B"/>
+  <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->
+  <path d="M 284 98 A 160 160 0 0 1 395 336"
+        fill="none" stroke="url(#g1)" stroke-width="22" stroke-linecap="round"/>
+  <!-- 弧２: 5時(336,395)[60°] → 12時左(228,98)[260°], 時計回り 200° -->
+  <path d="M 336 395 A 160 160 0 1 1 228 98"
+        fill="none" stroke="url(#g2)" stroke-width="22" stroke-linecap="round"/>
+  <!-- 円: 4時と5時の間 (369,369) -->
+  <circle cx="369" cy="369" r="18" fill="#1E1B8B"/>
 </svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="383" x2="383" y2="129">
+    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
       <stop offset="0%" stop-color="#1E1B8B"/>
       <stop offset="100%" stop-color="#A5B4FC"/>
     </linearGradient>

--- a/src/components/HabitEditItem.css
+++ b/src/components/HabitEditItem.css
@@ -1,7 +1,7 @@
 .habit-edit-item {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   padding: 11px 10px;
   background: #fff;
   border: 1.5px solid var(--color-border);
@@ -58,17 +58,25 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
 }
 
 .habit-edit-action {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
+  gap: 3px;
+  padding: 5px 8px;
   height: 34px;
   border-radius: 8px;
   flex-shrink: 0;
+  font-size: 0.78rem;
+  font-weight: 500;
   transition: background 0.12s, color 0.12s;
+}
+
+.habit-edit-action-label {
+  line-height: 1;
 }
 
 .habit-edit-action.edit {

--- a/src/components/HabitEditItem.jsx
+++ b/src/components/HabitEditItem.jsx
@@ -51,10 +51,11 @@ export default function HabitEditItem({ habit, onEdit, onArchive, onDelete }) {
         onClick={() => onEdit(habit)}
         aria-label={`${habit.name}を編集`}
       >
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
           <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
         </svg>
+        <span className="habit-edit-action-label">編集</span>
       </button>
 
       <button
@@ -62,11 +63,12 @@ export default function HabitEditItem({ habit, onEdit, onArchive, onDelete }) {
         onClick={() => onArchive(habit)}
         aria-label={`${habit.name}を終了`}
       >
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
           <rect x="2" y="3" width="20" height="5" rx="1" />
           <path d="M4 8v11a2 2 0 002 2h12a2 2 0 002-2V8" />
           <path d="M10 12h4" />
         </svg>
+        <span className="habit-edit-action-label">終了</span>
       </button>
 
       <button
@@ -74,12 +76,13 @@ export default function HabitEditItem({ habit, onEdit, onArchive, onDelete }) {
         onClick={() => onDelete(habit)}
         aria-label={`${habit.name}を削除`}
       >
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
           <polyline points="3 6 5 6 21 6" />
           <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
           <path d="M10 11v6M14 11v6" />
           <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
         </svg>
+        <span className="habit-edit-action-label">削除</span>
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary

- 習慣編集モードの各行にある「編集」「終了」「削除」ボタンにラベルテキストを追加
- アイコンのみでは区別しにくく、特に「終了」と「削除」の誤タップリスクが高かった
- 削除ボタンはすでに danger 色（赤）で表示されており、ラベルとの組み合わせで意味が明確になる

## Test plan

- [ ] 習慣を1件以上追加して編集モードに入り、各行に「編集」「終了」「削除」のラベルが表示されることを確認
- [ ] モバイル幅（375px）でボタンが詰まりすぎず読めること
- [ ] 各ボタンが正常に動作すること（編集モーダル開く、終了確認、削除確認）
- [ ] ドラッグによる並び替えが引き続き動作すること
- [ ] `npm run build` が通ること

Closes #478

Generated with [Claude Code](https://claude.com/claude-code)