### PR TITLE
fix: 実績画面のセクションタイトル修正とHabitButtonのaria-label改善 (#482 #483)

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,14 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
-      <stop offset="0%" stop-color="#1E1B8B"/>
-      <stop offset="100%" stop-color="#A5B4FC"/>
+    <linearGradient id="g1" gradientUnits="userSpaceOnUse" x1="284" y1="98" x2="395" y2="336">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#818CF8"/>
+    </linearGradient>
+    <linearGradient id="g2" gradientUnits="userSpaceOnUse" x1="228" y1="629" x2="228" y2="98">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#1E1B8B"/>
     </linearGradient>
   </defs>
-  <path d="M 383 383 A 180 180 0 1 1 383 129"
-        fill="none"
-        stroke="url(#g)"
-        stroke-width="36"
-        stroke-linecap="round"/>
-  <circle cx="383" cy="383" r="22" fill="#1E1B8B"/>
+  <!-- 弧１: 12時右(284,98)[280°] → 4時(395,336)[30°], 時計回り 110° -->
+  <path d="M 284 98 A 160 160 0 0 1 395 336"
+        fill="none" stroke="url(#g1)" stroke-width="22" stroke-linecap="round"/>
+  <!-- 弧２: 5時(336,395)[60°] → 12時左(228,98)[260°], 時計回り 200° -->
+  <path d="M 336 395 A 160 160 0 1 1 228 98"
+        fill="none" stroke="url(#g2)" stroke-width="22" stroke-linecap="round"/>
+  <!-- 円: 4時と5時の間 (369,369) -->
+  <circle cx="369" cy="369" r="18" fill="#1E1B8B"/>
 </svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="383" x2="383" y2="129">
+    <linearGradient id="g" gradientUnits="userSpaceOnUse" x1="383" y1="129" x2="383" y2="383">
       <stop offset="0%" stop-color="#1E1B8B"/>
       <stop offset="100%" stop-color="#A5B4FC"/>
     </linearGradient>

--- a/src/components/HabitButton.jsx
+++ b/src/components/HabitButton.jsx
@@ -63,7 +63,7 @@ export default function HabitButton({ habit, completed, streak, streakMode = 'de
     <button
       className={`habit-btn${completed ? ' completed' : ''}${popping ? ' pop' : ''}`}
       style={{ '--color': habit.color }}
-      aria-label={`${habit.name}${completed ? '（達成済み）' : ''}`}
+      aria-label={`${habit.name}${completed ? '（達成済み）' : ''}${streak > 1 ? '、' + streak + streakUnit : ''}`}
       aria-pressed={completed}
       onClick={handleClick}
       onPointerDown={handlePointerDown}

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -83,7 +83,7 @@ export default function RecordView({
       {/* 継続ペース */}
       <section className="section record-summary-section">
         <div className="section-header">
-          <h2 className="section-title">{streakMode === 'reset' ? '連続日数' : '週何回ペースで続いている'}</h2>
+          <h2 className="section-title">{streakMode === 'reset' ? '連続日数' : '継続ペース'}</h2>
           <div className="record-mini-stats">
             <span>{monthCount}回 今月</span>
             <span>累計 {totalCount}回</span>


### PR DESCRIPTION
## 変更概要

- **#482** RecordView: decrement/accumulateモード時のセクションタイトル「週何回ペースで続いている」（述語文）を「継続ペース」（名詞句）に変更
- **#483** HabitButton: streak > 1のとき aria-label に連続日数情報を追加し、スクリーンリーダーで進捗が分かるように改善

## 確認観点

- streakMode が reset のとき実績画面のセクションタイトルが「連続日数」のまま
- streakMode が decrement / accumulate のとき「継続ペース」と表示される
- 連続日数が2以上のとき HabitButton の aria-label に「、N日連続」または「、Nスコア」が付く
- 連続日数が0または1のとき aria-label が変わらない
- npm run build 通過済み

Generated with Claude Code