### PR TITLE
fix: 曜日別達成率のバー幅をカテゴリ別と揃える

### DIFF
--- a/src/components/StatsView.css
+++ b/src/components/StatsView.css
@@ -70,7 +70,7 @@
 
 .analysis-weekday-row {
   display: grid;
-  grid-template-columns: 24px minmax(0, 7rem) 1fr 40px;
+  grid-template-columns: minmax(0, 3rem) 1fr 40px;
   align-items: center;
   gap: 8px;
 }
@@ -83,11 +83,11 @@
 }
 
 .analysis-weekday-bar {
-  grid-column: 3;
+  grid-column: 2;
 }
 
 .analysis-weekday-rate {
-  grid-column: 4;
+  grid-column: 3;
   text-align: right;
   color: var(--color-text-secondary);
   font-size: 0.76rem;


### PR DESCRIPTION
## 背景

StatsView の曜日別達成率のバーが、カテゴリ別達成率のバーより大きく長く見えていた。`.analysis-weekday-row` のグリッドに使われていない2カラム目（空の 7rem）があり、バー開始位置がずれていた。

## 変更内容

- `.analysis-weekday-row` のグリッドを `24px minmax(0, 7rem) 1fr 40px` から `minmax(0, 3rem) 1fr 40px` に変更（空の2カラム目を削除）
- `grid-column` 指定を合わせて調整（bar: 3→2、rate: 4→3）

## 確認観点

- StatsView 上で曜日別達成率とカテゴリ別達成率のバー長さが揃って見えるか
- モバイル幅（375px）でレイアウトが崩れないか
- 曜日名と達成率の数値が適切に表示されているか

Closes #491