### PR TITLE
fix: 達成取り消し時に視覚フィードバックを追加

### DIFF
--- a/src/components/HabitButton.css
+++ b/src/components/HabitButton.css
@@ -84,3 +84,19 @@
   line-height: 1;
   margin-top: -2px;
 }
+
+@keyframes habit-unpop {
+  0%   { opacity: 1; transform: scale(1); }
+  30%  { opacity: 0.7; transform: scale(0.96); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+.habit-btn.unpop {
+  animation: habit-unpop 0.2s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .habit-btn.unpop {
+    animation: none;
+  }
+}

--- a/src/components/HabitButton.jsx
+++ b/src/components/HabitButton.jsx
@@ -8,6 +8,7 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
   const isLongPressRef = useRef(false)
   const startPosRef = useRef(null)
   const [popping, setPopping] = useState(false)
+  const [unpopping, setUnpopping] = useState(false)
 
   const handlePointerDown = useCallback((e) => {
     isLongPressRef.current = false
@@ -45,6 +46,9 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
         setPopping(true)
         if (navigator.vibrate) navigator.vibrate(30)
         setTimeout(() => setPopping(false), 300)
+      } else {
+        setUnpopping(true)
+        setTimeout(() => setUnpopping(false), 250)
       }
       onPress(habit)
     }
@@ -53,7 +57,7 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
 
   return (
     <button
-      className={`habit-btn${completed ? ' completed' : ''}${popping ? ' pop' : ''}`}
+      className={`habit-btn${completed ? ' completed' : ''}${popping ? ' pop' : ''}${unpopping ? ' unpop' : ''}`}
       style={{ '--color': habit.color }}
       aria-label={`${habit.name}${completed ? '（達成済み）' : ''}${streak > 1 ? `、${streak}日` : ''}`}
       aria-pressed={completed}


### PR DESCRIPTION
## 背景

習慣ボタンを「達成済み → 未達成」に切り替えた際、視覚的な変化が色のみだったため操作結果が分かりにくかった。

## 変更内容

- `HabitButton.jsx`: `completed` が true のときのクリックで `unpopping` state を true にし、250ms 後にリセット
- `HabitButton.css`: `habit-unpop` キーフレームを追加（scale 縮小 + 透明度フェードの 0.2s アニメーション）
- `prefers-reduced-motion` が有効な環境では `unpop` アニメーションを無効化

## 確認観点

- 達成済みの習慣をタップしたとき、未達成への変化が視覚的に確認できるか
- 達成操作時の `pop` アニメーションと衝突しないか
- `prefers-reduced-motion` 有効時にアニメーションが省略されるか

Closes #476