### PR TITLE
fix: カテゴリ管理ボタンの文言を効用ベースに変更

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -68,9 +68,9 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
           </svg>
           {/* #295: 設定済み色名の要約を入口で表示 */}
           <span className="data-mgmt-btn-text">
-            色の名前を設定
+            習慣を色でグループ分けする
             <span className="color-summary">
-              {colorSummary ?? '未設定'}
+              {colorSummary ?? '色ごとに名前をつけてグループ化できます'}
             </span>
           </span>
         </button>


### PR DESCRIPTION
## 背景

設定モーダルの「色の名前を設定」ボタンは操作名になっており、機能の効用が伝わりにくかった。また未設定時の補助文言「未設定」では何もできることが分からなかった。

## 変更内容

- ボタンラベルを「色の名前を設定」→「習慣を色でグループ分けする」に変更
- 未設定時の補助文言を「未設定」→「色ごとに名前をつけてグループ化できます」に変更

## 確認観点

- 設定モーダルを開いたときにボタンの目的が伝わるか
- 未設定時の補助文言が「こういうことができる」に変わっているか
- 設定済みの場合は引き続き `colorSummary` が正しく表示されるか

Closes #485