### PR TITLE
fix: HabitButton の aria-label に連続日数を自然な日本語で追加

### DIFF
--- a/src/components/HabitButton.jsx
+++ b/src/components/HabitButton.jsx
@@ -55,7 +55,7 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
     <button
       className={`habit-btn${completed ? ' completed' : ''}${popping ? ' pop' : ''}`}
       style={{ '--color': habit.color }}
-      aria-label={`${habit.name}${completed ? '（達成済み）' : ''}${streak > 1 ? `、${streak}日` : ''}`}
+      aria-label={`${habit.name}${completed ? '（達成済み）' : ''}${streak > 1 ? `、${streak}日連続` : ''}`}
       aria-pressed={completed}
       onClick={handleClick}
       onPointerDown={handlePointerDown}


### PR DESCRIPTION
## 背景

HabitButton の aria-label に連続日数情報は含まれていたが「X日」という形式だった。スクリーンリーダーで読み上げたとき何の日数か分かりにくかった。

## 変更内容

- `aria-label` の streak 部分を `${streak}日` → `${streak}日連続` に変更
- `streak > 1` のときのみ追加される挙動は変わらず

## 確認観点

- `streak > 1` のとき aria-label に「X日連続」が含まれているか
- `streak === 0` または `streak === 1` のとき aria-label が冗長にならないか
- スクリーンリーダーでボタンフォーカス時に連続情報が自然に読み上げられるか

Closes #483