### PR TITLE
feat: 集計開始日に「自動に戻す」リセットボタンを追加

### DIFF
--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -153,6 +153,32 @@
   border-color: var(--color-primary);
 }
 
+.stats-start-date-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.stats-start-date-reset {
+  padding: 0 10px;
+  height: 36px;
+  min-height: 44px;
+  border-radius: var(--radius-sm);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+  font-size: 0.82rem;
+  cursor: pointer;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.stats-start-date-reset:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
 .stats-start-date-hint {
   font-size: 0.75rem;
   color: var(--color-text-secondary);

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -82,14 +82,26 @@ export default function SettingsModal({ currentThemeId, onSelectTheme, onExport,
       <p className="section-title">分析</p>
       <div className="stats-start-date-row">
         <label className="stats-start-date-label" htmlFor="stats-start-date">集計開始日</label>
-        <input
-          id="stats-start-date"
-          type="date"
-          className="stats-start-date-input"
-          value={statsStartDate ?? ''}
-          onChange={e => onStatsStartDateChange(e.target.value || null)}
-          aria-describedby="stats-start-date-hint"
-        />
+        <div className="stats-start-date-controls">
+          <input
+            id="stats-start-date"
+            type="date"
+            className="stats-start-date-input"
+            value={statsStartDate ?? ''}
+            onChange={e => onStatsStartDateChange(e.target.value || null)}
+            aria-describedby="stats-start-date-hint"
+          />
+          {statsStartDate && (
+            <button
+              type="button"
+              className="stats-start-date-reset"
+              onClick={() => onStatsStartDateChange(null)}
+              aria-label="集計開始日をリセット"
+            >
+              自動に戻す
+            </button>
+          )}
+        </div>
       </div>
       <p className="stats-start-date-hint" id="stats-start-date-hint">
         {!statsStartDate && autoStatsStartDate


### PR DESCRIPTION
## 背景

iOSのネイティブdateピッカーでは入力値を削除する手段がなく、一度設定した集計開始日をリセットする方法が画面から分からなかった。

## 変更内容

- 集計開始日が設定済みのとき、date input の横に「自動に戻す」ボタンを表示
- ボタンを押すと `statsStartDate` が null にリセットされ、自動計算（最初の記録日）に戻る
- 日付が未設定の状態ではボタンを非表示にする

## 確認観点

- [ ] 集計開始日を設定済みのとき、「自動に戻す」ボタンが表示される
- [ ] ボタンを押すと statsStartDate が null に戻り、ヒント文言が「自動: ○○（最初の記録日）」に変わる
- [ ] 日付が未設定の状態ではボタンが表示されない
- [ ] モバイル幅でボタンと input が横並びで崩れない

Closes #469