### PR TITLE
feat: 全習慣達成日のカレンダーセルを軽く着色して強調する

### DIFF
--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -115,6 +115,15 @@
   font-weight: 700;
 }
 
+/* #464: 全習慣達成日の軽い視覚強調 */
+.cal-cell.all-done:not(.today) {
+  background: var(--color-primary-light);
+}
+
+.cal-cell.all-done.other-month {
+  background: none;
+}
+
 .cal-cell.sun .cal-day-num { color: #EF4444; }
 .cal-cell.sat .cal-day-num { color: #3B82F6; }
 

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -105,6 +105,7 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
                 'cal-cell',
                 other ? 'other-month' : '',
                 isToday ? 'today' : '',
+                allDone ? 'all-done' : '',
                 dow === 0 ? 'sun' : '',
                 dow === 6 ? 'sat' : '',
               ].filter(Boolean).join(' ')}


### PR DESCRIPTION
## 背景

全習慣達成日（allDone）は `cal-count` のテキスト色のみ変化していたが、セル自体に変化がなく一目で分からなかった。

## 変更内容

- `allDone` のとき `cal-cell` に `all-done` クラスを付与
- `.cal-cell.all-done:not(.today)` に `--color-primary-light` で背景を薄く着色
- 今日セル（`.today`）は既存スタイルを優先し背景変更なし
- 他月セル（`.other-month`）は背景変更なし（opacity で薄く見えるため）

## 確認観点

- [ ] 全習慣を達成した日のセルが、一部達成の日と視覚的に区別できる
- [ ] 今日のセルとの見た目の衝突がない
- [ ] 他月セルでの表示が崩れない
- [ ] モバイル幅でセルが小さくなっても崩れない

Closes #464