### PR TITLE
fix: カレンダーのドット・カウント重複を解消し2行折り返し表示に統一

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -127,11 +127,7 @@ export default function Calendar({ date, onDateChange, habits, records, today, o
                   <span className="cal-dot-more">+{completedHabits.length - 10}</span>
                 )}
               </div>
-              {total > 0 && count > 0 && (
-                <span className={`cal-count ${allDone ? 'all' : ''}`}>
-                  {count}/{total}
-                </span>
-              )}
+
             </div>
           )
         })}


### PR DESCRIPTION
## 背景

カレンダーセルにドット（`cal-dots`）と達成数カウント（`N/M`、`cal-count`）が両方表示されており、情報が重複していた。また習慣数が多い場合に +N で省略されていた。

## 変更内容

- `cal-count`（`N/M` テキスト）の表示を廃止し、ドットのみに統一（#471）
- 既存の `flex-wrap: wrap` により最大10個まで2行に自然に折り返す（#489）
- 11個以上のときは `+N` で省略

## 確認観点

- [ ] カレンダーセルでカウント（N/M）が表示されなくなっている
- [ ] 習慣数が1〜10件のとき、達成したドットが全て（2行折り返しで）表示される
- [ ] 習慣数が11件以上のとき、10個表示＋「+N」で省略される
- [ ] モバイル幅（375px）でセルが崩れない

Closes #471
Closes #489