### PR TITLE
fix: undo-toastをToastコンポーネントに統合しアクセシビリティを統一

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -399,40 +399,6 @@
 
 
 
-.undo-toast {
-  position: fixed;
-  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  background: #1e293b;
-  color: #fff;
-  padding: 10px 16px;
-  border-radius: 8px;
-  font-size: 0.875rem;
-  white-space: nowrap;
-  z-index: 30;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-  animation: toast-in 0.2s ease;
-}
-
-@keyframes toast-in {
-  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
-
-.undo-btn {
-  background: none;
-  border: none;
-  color: var(--color-today);
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  padding: 0;
-}
-
 .edit-mode-hint {
   font-size: 0.75rem;
   color: var(--color-text-sub);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -771,10 +771,12 @@ export default function App() {
       )}
 
       {undoAction && (
-        <div className="undo-toast">
-          <span className="undo-message">達成を取り消しました</span>
-          <button className="undo-btn" onClick={handleUndo}>元に戻す</button>
-        </div>
+        <Toast
+          message="達成を取り消しました"
+          action="元に戻す"
+          onAction={handleUndo}
+          onDismiss={() => {}}
+        />
       )}
       {toast && <Toast message={toast} onDismiss={() => setToast(null)} />}
 

--- a/src/components/Toast.css
+++ b/src/components/Toast.css
@@ -24,3 +24,24 @@
     animation: none;
   }
 }
+
+/* アクション付きトースト（undo等） */
+.toast--action {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-radius: 8px;
+  white-space: nowrap;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 80px);
+}
+
+.toast-action-btn {
+  background: none;
+  border: none;
+  color: var(--color-today, #38bdf8);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -1,15 +1,20 @@
 import { useEffect } from 'react'
 import './Toast.css'
 
-export default function Toast({ message, onDismiss }) {
+export default function Toast({ message, action, onAction, onDismiss }) {
   useEffect(() => {
-    const timer = setTimeout(onDismiss, 3000)
+    const timer = setTimeout(onDismiss, action ? 4000 : 3000)
     return () => clearTimeout(timer)
-  }, [message, onDismiss])
+  }, [message, action, onDismiss])
 
   return (
-    <div className="toast" role="status" aria-live="polite">
-      {message}
+    <div className={`toast${action ? ' toast--action' : ''}`} role="status" aria-live="polite">
+      <span>{message}</span>
+      {action && (
+        <button className="toast-action-btn" onClick={() => { onAction?.(); onDismiss(); }}>
+          {action}
+        </button>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 背景

`undo-toast` はプレーンな `div` で実装されており、`Toast` コンポーネントが持つ `role="status"` / `aria-live` 属性がなかった。スタイルも `App.css` と `Toast.css` で二重管理になっていた。

## 変更内容

- `Toast` コンポーネントに `action` / `onAction` プロパティを追加し、アクション付きトーストをサポート
- `App.jsx` の `undo-toast` 実装を `<Toast action="元に戻す" onAction={handleUndo} />` に置き換え
- `App.css` から `undo-toast` / `@keyframes toast-in` / `undo-btn` スタイルを削除
- `Toast.css` に `toast--action` / `toast-action-btn` スタイルを追加

## 確認観点

- [ ] 達成取り消しトーストが既存と同様に表示される
- [ ] 「元に戻す」ボタンが機能する
- [ ] `undo-toast` 専用のスタイル定義が App.css から削除されている
- [ ] Toast.css に集約されている

Closes #475