### PR TITLE
feat: add date-based app version

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,1 @@
+export const APP_VERSION = '20260607-01'

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,16 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { execSync } from 'child_process'
 import { readFileSync, writeFileSync } from 'fs'
 import { resolve } from 'path'
-
-function getVersion() {
-  try {
-    return execSync('git describe --tags --always').toString().trim()
-  } catch {
-    return 'unknown'
-  }
-}
+import { APP_VERSION } from './src/version.js'
 
 function injectSwVersion(version) {
   return {
@@ -23,13 +15,11 @@ function injectSwVersion(version) {
   }
 }
 
-const version = getVersion()
-
 export default defineConfig({
   base: '/habit-tracker/',
-  plugins: [react(), injectSwVersion(version)],
+  plugins: [react(), injectSwVersion(APP_VERSION)],
   define: {
-    __APP_VERSION__: JSON.stringify(version),
+    __APP_VERSION__: JSON.stringify(APP_VERSION),
   },
   server: {
     port: process.env.PORT ? parseInt(process.env.PORT) : 5173,


### PR DESCRIPTION
## 背景
アプリのバージョン表記を、更新日と同日内の連番が分かる形式に統一します。

## 変更内容
- バージョンを `20260607-01` として定義
- ビルド時とヘルプ画面の表示に共通バージョンを使用
- Service Workerのキャッシュ名にも同じバージョンを反映

## 確認内容
- `npm run build`
- PC幅・スマートフォン幅でヘルプ画面の表示を確認