### PR TITLE
fix: streakMode dead codeを削除

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,7 +37,7 @@ import { useModalState } from './hooks/useModalState'
 import { useHabitActions } from './hooks/useHabitActions'
 import { useBackupManager } from './hooks/useBackupManager'
 import { getToday, getYesterday } from './utils/date'
-import { calcCurrentStreak, calcCurrentStreakWithMode } from './utils/stats'
+import { calcCurrentStreak } from './utils/stats'
 import './App.css'
 
 const LAST_BACKUP_KEY = 'habit-tracker-last-backup'
@@ -73,7 +73,7 @@ export default function App() {
 
   const [toast, setToast] = useState(null)
   const onSaveError = useCallback((msg) => setToast(msg), [])
-  const { habits, records, colorCategories, statsStartDate, streakMode, setHabits, setRecords, setColorCategories, setStatsStartDate, setStreakMode } = useHabitsStorage({ onSaveError })
+  const { habits, records, colorCategories, statsStartDate, setHabits, setRecords, setColorCategories, setStatsStartDate } = useHabitsStorage({ onSaveError })
   const { themeId, handleThemeSelect } = useTheme({ onSaveError })
 
   // 記録の中で最も古い日付（未設定時の集計開始日フォールバック）
@@ -201,8 +201,6 @@ export default function App() {
     setColorCategories,
     statsStartDate,
     setStatsStartDate,
-    streakMode,
-    setStreakMode,
     setModal,
     setToast,
     modal,
@@ -559,7 +557,7 @@ export default function App() {
                       key={habit.id}
                       habit={habit}
                       completed={todayRecords.includes(habit.id)}
-                      streak={calcCurrentStreakWithMode(habit.id, records, 'accumulate')}
+                      streak={calcCurrentStreak(habit.id, records)}
                       onPress={(h) => toggleHabit(h.id, today)}
                       onLongPress={(h) => { dismissEditHint(); setModal({ type: 'longPress', habit: h }) }}
                     />

--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import Modal from './Modal'
 import HabitProgressLine from './HabitProgressLine'
-import { calcCurrentStreakWithMode, MILESTONES, getNextMilestone } from '../utils/stats'
+import { calcCurrentStreak, MILESTONES, getNextMilestone } from '../utils/stats'
 import './RecordView.css'
 
 function formatMonthKey(date) {
@@ -52,7 +52,7 @@ export default function RecordView({
   const activeHabits = habits.filter(h => !h.archivedAt)
 
   const habitStreakList = activeHabits.map(habit => {
-    const streak = calcCurrentStreakWithMode(habit.id, records, 'accumulate')
+    const streak = calcCurrentStreak(habit.id, records)
     return { habit, streak }
   })
 

--- a/src/data/strings.js
+++ b/src/data/strings.js
@@ -50,7 +50,6 @@ export const UI = {
     habit: '習慣',
     analysis: '分析',
     data: 'データ',
-    streakMode: '達成できなかった日の扱い',
     statsStartDate: '集計開始日',
     colorNames: '色の名前を設定',
     colorNameUnset: '未設定',

--- a/src/hooks/useBackupManager.js
+++ b/src/hooks/useBackupManager.js
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef } from 'react'
 import { sanitizeImportData, validateImportData } from '../utils/validation'
 
 const LAST_BACKUP_KEY = 'habit-tracker-last-backup'
-const BACKUP_DIR_NAME = 'habit-tracker-backups'
+const BACKUP_DIR_NAME = 'habit-tracker-backups'
 export const BACKUP_VERSION = 1
 
 /**
@@ -25,9 +25,7 @@ export function useBackupManager({
   setModal,
   setToast,
   statsStartDate,
-  streakMode,
   setStatsStartDate,
-  setStreakMode,
   modal,
 }) {
   const [lastBackupDate, setLastBackupDate] = useState(() => {
@@ -42,7 +40,6 @@ export function useBackupManager({
       ...sanitized.data,
       colorCategories,
       ...(statsStartDate ? { statsStartDate } : {}),
-      streakMode,
     }
     const json = JSON.stringify(backupData, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
@@ -84,7 +81,7 @@ export function useBackupManager({
     URL.revokeObjectURL(url)
     markSaved()
     setToast(`バックアップを保存しました${skippedText}`)
-  }, [habits, records, today, colorCategories, statsStartDate, streakMode, setToast])
+  }, [habits, records, today, colorCategories, statsStartDate, setToast])
 
   const handleImportClick = useCallback(() => {
     fileInputRef.current?.click()
@@ -131,10 +128,9 @@ export function useBackupManager({
     setRecords(modal.data.records)
     if (modal.data.colorCategories) setColorCategories(modal.data.colorCategories)
     if (modal.data.statsStartDate) setStatsStartDate(modal.data.statsStartDate)
-    if (modal.data.streakMode) setStreakMode(modal.data.streakMode)
     setModal(null)
     setToast(`復元しました（${habitCount}件・${dayCount}日分）`)
-  }, [modal, setHabits, setRecords, setColorCategories, setStatsStartDate, setStreakMode, setModal, setToast])
+  }, [modal, setHabits, setRecords, setColorCategories, setStatsStartDate, setModal, setToast])
 
   return {
     lastBackupDate,

--- a/src/hooks/useHabitsStorage.js
+++ b/src/hooks/useHabitsStorage.js
@@ -3,14 +3,6 @@ import { useState, useEffect } from 'react'
 const STORAGE_KEY = 'habit-tracker-v1'
 const SETTINGS_KEY = 'habit-tracker-settings'
 
-// 未達成日の扱いモード (#294)
-export const STREAK_MODES = [
-  { id: 'reset',       label: 'リセットする',    metricLabel: '連続日数',                desc: '未達成の翌日から連続日数が0に戻ります' },
-  { id: 'decrement',   label: '1日分だけ戻す',   metricLabel: '週何回ペースで続いている', desc: '未達成の日は連続日数が1減ります' },
-  { id: 'accumulate',  label: '減らさない',       metricLabel: '週何回ペースで続いている', desc: '未達成の日があっても連続日数は変わりません' },
-]
-export const DEFAULT_STREAK_MODE = 'decrement'
-
 export function loadData() {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
@@ -56,8 +48,6 @@ export function useHabitsStorage({ onSaveError } = {}) {
   const [colorCategories, setColorCategories] = useState(_initial.colorCategories)
   // 集計開始日（YYYY-MM-DD 形式。未設定なら null）
   const [statsStartDate, setStatsStartDate] = useState(_initialSettings.statsStartDate ?? null)
-  // #294: 未達成日の扱いモード
-  const [streakMode, setStreakMode] = useState(_initialSettings.streakMode ?? DEFAULT_STREAK_MODE)
 
   useEffect(() => {
     try {
@@ -71,12 +61,11 @@ export function useHabitsStorage({ onSaveError } = {}) {
     try {
       const settings = {}
       if (statsStartDate) settings.statsStartDate = statsStartDate
-      settings.streakMode = streakMode
       localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings))
     } catch {
       onSaveError?.('設定の保存に失敗しました。ストレージの空き容量が不足しています。')
     }
-  }, [statsStartDate, streakMode, onSaveError])
+  }, [statsStartDate, onSaveError])
 
-  return { habits, records, colorCategories, statsStartDate, streakMode, setHabits, setRecords, setColorCategories, setStatsStartDate, setStreakMode }
+  return { habits, records, colorCategories, statsStartDate, setHabits, setRecords, setColorCategories, setStatsStartDate }
 }

--- a/src/utils/stats.js
+++ b/src/utils/stats.js
@@ -42,42 +42,6 @@ export function calcCurrentStreak(habitId, records) {
   return count
 }
 
-// #294: 未達成日の扱いモードに応じた積み上がりを計算
-// mode: 'reset' (連続), 'decrement' (1日減算), 'accumulate' (減らさない)
-export function calcCurrentStreakWithMode(habitId, records, mode = 'decrement') {
-  if (mode === 'reset') {
-    return calcCurrentStreak(habitId, records)
-  }
-
-  if (mode === 'accumulate') {
-    // 達成した日の総数（全期間）
-    return Object.values(records).filter(ids => (ids || []).includes(habitId)).length
-  }
-
-  // decrement: 達成日は+1、未達成日は-1、ただし0未満にはしない
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  // 最古の記録日から今日まで走査するため、まず記録のある最古日を取得
-  const sortedDates = Object.keys(records).filter(date => (records[date] || []).includes(habitId)).sort()
-  if (sortedDates.length === 0) return 0
-  const earliest = new Date(sortedDates[0])
-  earliest.setHours(0, 0, 0, 0)
-  // earliest から today まで走査
-  const cur = new Date(earliest)
-  let score = 0
-  while (cur <= today) {
-    const dateStr = formatDate(cur)
-    if ((records[dateStr] || []).includes(habitId)) {
-      score++
-    } else if (dateStr < formatDate(today)) {
-      // 今日はまだ達成できるので減算しない
-      score = Math.max(0, score - 1)
-    }
-    cur.setDate(cur.getDate() + 1)
-  }
-  return score
-}
-
 export function calcStats(habitId, records) {
   const completedDates = Object.keys(records)
     .filter(date => (records[date] || []).includes(habitId))

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -65,7 +65,6 @@ export function sanitizeImportData(data) {
         ? { colorCategories: data.colorCategories }
         : {}),
       ...(data.statsStartDate && typeof data.statsStartDate === 'string' ? { statsStartDate: data.statsStartDate } : {}),
-      ...(data.streakMode && typeof data.streakMode === 'string' ? { streakMode: data.streakMode } : {}),
     },
     skippedUnknownRecords,
   }


### PR DESCRIPTION
## Summary
- useHabitsStorage / useBackupManager / validation / strings / stats から streakMode 関連コードをすべて削除
- calcCurrentStreakWithMode を削除し calcCurrentStreak に一本化

## 確認観点
- [ ] ビルドが通る
- [ ] 今日の習慣画面のストリーク表示が正常