### PR TITLE
fix: 習慣ボタンの日数表示を累計日数に修正

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,7 +37,7 @@ import { useModalState } from './hooks/useModalState'
 import { useHabitActions } from './hooks/useHabitActions'
 import { useBackupManager } from './hooks/useBackupManager'
 import { getToday, getYesterday } from './utils/date'
-import { calcCurrentStreak } from './utils/stats'
+import { calcStats } from './utils/stats'
 import './App.css'
 
 const LAST_BACKUP_KEY = 'habit-tracker-last-backup'
@@ -557,7 +557,7 @@ export default function App() {
                       key={habit.id}
                       habit={habit}
                       completed={todayRecords.includes(habit.id)}
-                      streak={calcCurrentStreak(habit.id, records)}
+                      days={calcStats(habit.id, records).total}
                       onPress={(h) => toggleHabit(h.id, today)}
                       onLongPress={(h) => { dismissEditHint(); setModal({ type: 'longPress', habit: h }) }}
                     />

--- a/src/components/HabitButton.jsx
+++ b/src/components/HabitButton.jsx
@@ -3,7 +3,7 @@ import './HabitButton.css'
 
 const LONG_PRESS_DELAY = 500
 
-export default function HabitButton({ habit, completed, streak, onPress, onLongPress }) {
+export default function HabitButton({ habit, completed, days, onPress, onLongPress }) {
   const timerRef = useRef(null)
   const isLongPressRef = useRef(false)
   const startPosRef = useRef(null)
@@ -59,7 +59,7 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
     <button
       className={`habit-btn${completed ? ' completed' : ''}${popping ? ' pop' : ''}${unpopping ? ' unpop' : ''}`}
       style={{ '--color': habit.color }}
-      aria-label={`${habit.name}${completed ? '（達成済み）' : ''}${streak > 1 ? `、${streak}日連続` : ''}`}
+      aria-label={`${habit.name}${completed ? '（達成済み）' : ''}${days > 1 ? `、${days}日達成` : ''}`}
       aria-pressed={completed}
       onClick={handleClick}
       onPointerDown={handlePointerDown}
@@ -73,7 +73,7 @@ export default function HabitButton({ habit, completed, streak, onPress, onLongP
         style={{ backgroundColor: completed ? '#fff' : habit.color }}
       />
       <span className="habit-name">{habit.name}</span>
-      {streak > 1 && <span className="habit-streak">{streak}日</span>}
+      {days > 1 && <span className="habit-streak">{days}日</span>}
       {completed && <span className="habit-check">✓</span>}
     </button>
   )


### PR DESCRIPTION
## 概要
習慣ボタンに表示される「X日」が連続日数（streak）になっていたのを累計達成日数（total）に修正。

- `calcCurrentStreak` → `calcStats(...).total` に変更
- aria-label の「X日連続」→「X日達成」に更新

## 確認観点
- [ ] 習慣ボタンの日数バッジが累計達成日数を表示している
- [ ] 連続して達成していない場合でも通算日数が正しく表示される