### PR TITLE
feat: meta description・OGPタグを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="description" content="毎日の習慣にチェックを入れて継続を記録するアプリ。ストリークや達成率を確認しながら、静かに習慣を続けられます。" />
+    <meta property="og:title" content="習慣トラッカー" />
+    <meta property="og:description" content="毎日の習慣にチェックを入れて継続を記録するアプリ。ストリークや達成率を確認しながら、静かに習慣を続けられます。" />
+    <meta property="og:url" content="https://junkoma2.github.io/habit-tracker/" />
+    <meta property="og:type" content="website" />
     <meta name="theme-color" content="#6366F1" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />


### PR DESCRIPTION
## 背景
index.html に meta description および OGP タグが未設定で、検索エンジンやSNSシェア時に意図しない表示になっていた。

## 変更内容
- `meta name="description"` を追加
- `og:title` / `og:description` / `og:url` / `og:type` を追加

## 確認観点
- ビルド後の dist/index.html に反映されることを確認済み（`npm run build` 通過）

Closes #515