### PR TITLE
fix: COLOR_NAMESをdate.jsに集約し重複定義を解消

### DIFF
--- a/src/components/AddHabitModal.jsx
+++ b/src/components/AddHabitModal.jsx
@@ -1,20 +1,10 @@
 import { useState, useRef, useEffect } from 'react'
 import Modal from './Modal'
-import { HABIT_COLORS } from '../utils/date'
+import { HABIT_COLORS, COLOR_NAMES } from '../utils/date'
 import './AddHabitModal.css'
 
 const MAX_NAME_LENGTH = 20
 
-const COLOR_NAMES = {
-  '#FF6B6B': 'レッド',
-  '#FF9F43': 'オレンジ',
-  '#FECA57': 'イエロー',
-  '#48DBB4': 'グリーン',
-  '#54A0FF': 'ブルー',
-  '#A29BFE': 'ラベンダー',
-  '#FD79A8': 'ピンク',
-  '#6C5CE7': 'パープル',
-}
 
 export default function AddHabitModal({ onSave, onClose, initialHabit = null, colorCategories = {} }) {
   const isEdit = !!initialHabit

--- a/src/components/CategoryManageModal.jsx
+++ b/src/components/CategoryManageModal.jsx
@@ -1,18 +1,8 @@
 import { useState } from 'react'
 import Modal from './Modal'
-import { HABIT_COLORS } from '../utils/date'
+import { HABIT_COLORS, COLOR_NAMES } from '../utils/date'
 import './CategoryManageModal.css'
 
-const COLOR_NAMES = {
-  '#FF6B6B': 'レッド',
-  '#FF9F43': 'オレンジ',
-  '#FECA57': 'イエロー',
-  '#48DBB4': 'グリーン',
-  '#54A0FF': 'ブルー',
-  '#A29BFE': 'ラベンダー',
-  '#FD79A8': 'ピンク',
-  '#6C5CE7': 'パープル',
-}
 
 export default function CategoryManageModal({ colorCategories, onUpdate, onClose }) {
   const [draft, setDraft] = useState({ ...colorCategories })

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -53,3 +53,14 @@ export const HABIT_COLORS = [
   '#FD79A8',
   '#6C5CE7',
 ]
+
+export const COLOR_NAMES = {
+  '#FF6B6B': 'レッド',
+  '#FF9F43': 'オレンジ',
+  '#FECA57': 'イエロー',
+  '#48DBB4': 'グリーン',
+  '#54A0FF': 'ブルー',
+  '#A29BFE': 'ラベンダー',
+  '#FD79A8': 'ピンク',
+  '#6C5CE7': 'パープル',
+}


### PR DESCRIPTION
## 背景
AddHabitModal.jsx と CategoryManageModal.jsx に同一の COLOR_NAMES オブジェクトが重複定義されており、色を追加・変更するときに複数ファイルの同期が必要な状態だった。

## 変更内容
- `src/utils/date.js` に `COLOR_NAMES` を追加してエクスポート
- `AddHabitModal.jsx` / `CategoryManageModal.jsx` のローカル定義を削除し、date.js からのインポートに変更

## 確認観点
- `npm run build` 通過確認済み
- 色名は引き続き各コンポーネントで正常に参照される

Closes #516