### PR TITLE
fix: showNameErrorをJSXで参照しエラーメッセージを表示

### DIFF
--- a/src/components/AddHabitModal.css
+++ b/src/components/AddHabitModal.css
@@ -175,3 +175,9 @@
   color: var(--color-text-secondary);
   margin-top: -2px;
 }
+
+.field-error {
+  font-size: 0.78rem;
+  color: #e53e3e;
+  margin-top: -2px;
+}

--- a/src/components/AddHabitModal.jsx
+++ b/src/components/AddHabitModal.jsx
@@ -66,9 +66,10 @@ export default function AddHabitModal({ onSave, onClose, initialHabit = null, co
             value={name}
             onChange={(e) => setName(e.target.value)}
             maxLength={MAX_NAME_LENGTH}
+            aria-invalid={showNameError}
           />
-          {!name.trim() && name.length === 0 && (
-            <p className="field-hint">名前を入力してから追加できます</p>
+          {showNameError && (
+            <p className="field-error" role="alert" aria-live="assertive">名前を入力してください</p>
           )}
         </div>
 


### PR DESCRIPTION
## 背景
AddHabitModal.jsx の `showNameError` state は submit 時に空名前なら true にセットされるが、JSX で参照している箇所がなかった。空のまま「追加する」を押しても何も起こらないように見え、操作失敗の理由がわからない状態だった。

## 変更内容
- `<input>` に `aria-invalid={showNameError}` を追加
- `showNameError === true` のときエラーメッセージ（「名前を入力してください」）を `role="alert"` / `aria-live="assertive"` で表示
- `.field-error` スタイルを AddHabitModal.css に追加

## 確認観点
- 空のまま送信するとエラーメッセージが表示される
- 入力後は aria-invalid が false になる
- スクリーンリーダーに `role="alert"` で通知される
- `npm run build` 通過確認済み

Closes #517