### PR TITLE
feat: CI/CDにlintとtestステップを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run lint
+      - run: npm run test
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## 背景
deploy.yml のデプロイフローに lint・test の実行ステップがなく、テストや lint が失敗していても main push 時に自動デプロイが走る状態だった。

## 変更内容
- `deploy.yml` に `npm run lint` ステップを build の前に追加
- `deploy.yml` に `npm run test` ステップを build の前に追加
- lint・test 失敗時にデプロイが中断される

## 確認観点
- lint → test → build の順でステップが実行される
- どちらか失敗した場合はデプロイが止まる

Closes #520