### PR TITLE
feat: dependabotを設定しnpm依存の自動更新を有効化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## 背景
.github/dependabot.yml が存在せず、依存パッケージのセキュリティアップデートが自動検知されない状態だった。

## 変更内容
- `.github/dependabot.yml` を作成
- npm エコシステムの週次自動更新を有効化
- ルートディレクトリ `/` を対象に設定

## 確認観点
- GitHub が週次で依存パッケージの更新 PR を自動作成する

Closes #522