### PR TITLE
feat: stats.jsとdate.jsのユニットテストを追加

### DIFF
--- a/tests/date.test.js
+++ b/tests/date.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { formatDate, parseLocalDate, formatDisplayDate } from '../src/utils/date'
+
+describe('formatDate', () => {
+  it('月末の日付を正しくフォーマットする', () => {
+    expect(formatDate(new Date(2026, 11, 31))).toBe('2026-12-31')
+  })
+
+  it('年末を正しくフォーマットする', () => {
+    expect(formatDate(new Date(2026, 11, 31))).toBe('2026-12-31')
+  })
+
+  it('月を2桁でゼロ埋めする', () => {
+    expect(formatDate(new Date(2026, 0, 5))).toBe('2026-01-05')
+  })
+})
+
+describe('parseLocalDate', () => {
+  it('YYYY-MM-DD文字列をローカル日付に変換する', () => {
+    const d = parseLocalDate('2026-06-09')
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(5) // 0-indexed
+    expect(d.getDate()).toBe(9)
+  })
+
+  it('月末日を正しく解析する', () => {
+    const d = parseLocalDate('2026-01-31')
+    expect(d.getDate()).toBe(31)
+  })
+})
+
+describe('formatDisplayDate', () => {
+  it('日本語表示形式に変換する', () => {
+    const result = formatDisplayDate('2026-06-09')
+    expect(result).toContain('2026年')
+    expect(result).toContain('6月')
+    expect(result).toContain('9日')
+  })
+})

--- a/tests/stats.test.js
+++ b/tests/stats.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { calcCurrentStreak, calcStats, getNextMilestone, MILESTONES } from '../src/utils/stats'
+
+// calcCurrentStreak は new Date() に依存するためモックが必要
+const TODAY = '2026-06-09'
+
+function makeRecords(dates, habitId = 'h_1') {
+  return Object.fromEntries(dates.map(d => [d, [habitId]]))
+}
+
+describe('calcCurrentStreak', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-09'))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('今日未達で昨日から連続している場合はストリークを返す', () => {
+    const records = makeRecords(['2026-06-07', '2026-06-08'])
+    expect(calcCurrentStreak('h_1', records)).toBe(2)
+  })
+
+  it('今日達成していてストリークが続く', () => {
+    const records = makeRecords(['2026-06-08', '2026-06-09'])
+    expect(calcCurrentStreak('h_1', records)).toBe(2)
+  })
+
+  it('連続記録なし（昨日も今日も未達）はゼロを返す', () => {
+    const records = makeRecords(['2026-06-05'])
+    expect(calcCurrentStreak('h_1', records)).toBe(0)
+  })
+
+  it('記録が空の場合はゼロを返す', () => {
+    expect(calcCurrentStreak('h_1', {})).toBe(0)
+  })
+})
+
+describe('getNextMilestone', () => {
+  it('streak=0のとき最初のマイルストン(1日目)を返す', () => {
+    expect(getNextMilestone(0)).toEqual(MILESTONES[0])
+  })
+
+  it('streak=7のとき次のマイルストン(21日目)を返す', () => {
+    const next = getNextMilestone(7)
+    expect(next?.days).toBe(21)
+  })
+
+  it('streak=365以上のときnullを返す（全達成）', () => {
+    expect(getNextMilestone(365)).toBeNull()
+  })
+})
+
+describe('calcStats', () => {
+  it('記録なしは全てゼロ', () => {
+    expect(calcStats('h_1', {})).toEqual({ current: 0, longest: 0, total: 0 })
+  })
+
+  it('最長ストリークが正しく計算される', () => {
+    beforeEach(() => vi.useFakeTimers())
+    const records = makeRecords(['2026-06-01', '2026-06-02', '2026-06-03', '2026-06-05', '2026-06-06'])
+    const stats = calcStats('h_1', records)
+    expect(stats.longest).toBe(3)
+    expect(stats.total).toBe(5)
+  })
+})


### PR DESCRIPTION
## 背景
ストリーク計算・カテゴリ集計など主要な計算ロジックに回帰テストがなく、仕様変更時に意図しない結果が検出できない状態だった。

## 変更内容
- `tests/stats.test.js` を追加: `calcCurrentStreak`（今日未達・昨日達成・記録なし）、`getNextMilestone`（境界値）、`calcStats`（最長ストリーク・総数）
- `tests/date.test.js` を追加: `formatDate`（月末・年末・ゼロ埋め）、`parseLocalDate`（月末）、`formatDisplayDate`（日本語形式）

## 確認観点
- `npm run test` で全テストが通ることを CI で確認する
- `npm run build` 通過確認済み

Closes #521