### PR TITLE
fix: 日付をまたいだまま使用した場合にtoday/yesterdayを再評価する

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -93,8 +93,34 @@ export default function App() {
   const stableViewportRef = useRef({ width: window.innerWidth, height: 0 })
   const stableHandlersRef = useRef(null)
 
-  const today = getToday()
-  const yesterday = getYesterday()
+  const [today, setToday] = useState(() => getToday())
+  const [yesterday, setYesterday] = useState(() => getYesterday())
+
+  // 日付をまたいだまま使い続けた場合に today/yesterday を再評価する
+  useEffect(() => {
+    const checkDateChange = () => {
+      const freshToday = getToday()
+      setToday(prev => (prev === freshToday ? prev : freshToday))
+      setYesterday(prev => {
+        const freshYesterday = getYesterday()
+        return prev === freshYesterday ? prev : freshYesterday
+      })
+    }
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden) checkDateChange()
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('focus', checkDateChange)
+    const intervalId = setInterval(checkDateChange, 60 * 1000)
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('focus', checkDateChange)
+      clearInterval(intervalId)
+    }
+  }, [])
   const onRefresh = useCallback(() => {
     const fresh = loadData()
     setHabits(fresh.habits)


### PR DESCRIPTION
## 概要
深夜0時をまたいでページを開いたまま使い続けると、`today`/`yesterday`が古い日付のまま固定されてしまい、チェックが前日の記録として保存される問題を修正する。

## 変更内容
- `today`/`yesterday`を`useState`化
- `visibilitychange`（タブ復帰時）/ `focus`（フォーカス復帰時）/ 1分間隔の`setInterval`で`getToday()`/`getYesterday()`を再評価し、変化があればstateを更新するuseEffectを追加

## 確認観点
- 通常の起動・操作で日付表示や習慣チェックに影響がないこと
- `npm run build`が通ること
- vitestの既存テスト（31件）がすべてパスすること

Closes #555