### PR TITLE
fix: 2タブ同時操作でlocalStorageが後書き側に上書きされる問題を修正

### DIFF
--- a/src/hooks/useHabitsStorage.js
+++ b/src/hooks/useHabitsStorage.js
@@ -67,5 +67,22 @@ export function useHabitsStorage({ onSaveError } = {}) {
     }
   }, [statsStartDate, onSaveError])
 
+  // 他タブの書き込みを検知して最新データを読み直す（後書きタブによる上書き消失を防ぐ）
+  useEffect(() => {
+    const handleStorage = (e) => {
+      if (e.key === STORAGE_KEY || e.key === null) {
+        const data = loadData()
+        setHabits(data.habits)
+        setRecords(data.records)
+        setColorCategories(data.colorCategories)
+      }
+      if (e.key === SETTINGS_KEY || e.key === null) {
+        setStatsStartDate(loadSettings().statsStartDate ?? null)
+      }
+    }
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [])
+
   return { habits, records, colorCategories, statsStartDate, setHabits, setRecords, setColorCategories, setStatsStartDate }
 }


### PR DESCRIPTION
## 概要

複数タブで同時操作した場合、後から書き込んだタブが古いstateでlocalStorageを上書きし、先に保存した変更（習慣チェック等）が消える問題を修正。

Fixes #538

## 対応内容

`useHabitsStorage` に `window.addEventListener('storage', ...)` を追加し、他タブの書き込みを検知したら localStorage から最新データを読み直して React state に反映する。複雑なマージロジックは導入せず、最新データの再読込のみのシンプルな方式。

- `habit-tracker-v1`（habits / records / colorCategories）と `habit-tracker-settings`（statsStartDate）の両キーを対象
- `e.key === null`（storage.clear）の場合も再読込
- 再読込後の保存effectは同一内容を書き戻すだけで、同値書き込みではstorageイベントが発火しないためタブ間ループは起きない

## 確認観点

- [ ] `npm run build` が通る（確認済み）
- [ ] タブAで習慣チェック → タブBで習慣追加 → タブAのチェックが消えない
- [ ] タブBでの追加・変更がタブAに即時反映される