### PR TITLE
fix: 実績画面の累計達成数を正しく表示する

### DIFF
--- a/src/components/RecordView.jsx
+++ b/src/components/RecordView.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import Modal from './Modal'
 import HabitProgressLine from './HabitProgressLine'
-import { calcCurrentStreak, MILESTONES, getNextMilestone } from '../utils/stats'
+import { MILESTONES, getNextMilestone } from '../utils/stats'
+import { buildHabitRecordSummaries } from '../utils/recordSummary'
 import './RecordView.css'
 
 function formatMonthKey(date) {
@@ -35,12 +36,8 @@ function getStreakDisplay(streak) {
 
 export default function RecordView({
   calendarDate,
-  onCalendarDateChange,
   habits,
   records,
-  today,
-  onDayClick,
-  onMonthTitleClick,
   asModal = false,
   onClose,
 }) {
@@ -49,19 +46,12 @@ export default function RecordView({
   const monthCount = countRecordsInMonth(records, monthKey)
   const totalCount = countTotalRecords(records)
 
-  const activeHabits = habits.filter(h => !h.archivedAt)
-
-  const habitStreakList = activeHabits.map(habit => {
-    const streak = calcCurrentStreak(habit.id, records)
-    return { habit, streak }
-  })
-
-  const sortedHabits = [...habitStreakList].sort((a, b) => b.streak - a.streak)
+  const sortedHabits = buildHabitRecordSummaries(habits, records)
 
   const body = (
     <>
       {/* 習慣の進捗 */}
-      {activeHabits.length > 0 && (
+      {sortedHabits.length > 0 && (
         <section className="section record-phase-highlight-section">
           <div className="section-header">
             <h2 className="section-title">習慣の進捗</h2>
@@ -89,21 +79,21 @@ export default function RecordView({
           </div>
         </div>
 
-        {activeHabits.length === 0 ? (
+        {sortedHabits.length === 0 ? (
           <p className="record-empty">習慣を追加すると続いた日数が表示されます。</p>
         ) : (
           <div className="streak-summary-list">
-            {sortedHabits.map(({ habit, streak }) => {
-              const { currentLabel, next } = getStreakDisplay(streak)
+            {sortedHabits.map(({ habit, streak, total }) => {
+              const { next } = getStreakDisplay(streak)
               return (
                 <div key={habit.id} className="streak-summary-row">
                   <span className="streak-summary-dot" style={{ backgroundColor: habit.color }} />
                   <span className="streak-summary-name">{habit.name}</span>
                   <div className="streak-summary-right">
-                    {streak > 0 ? (
+                    {total > 0 ? (
                       <>
-                        <span className="streak-summary-days">累計 {streak}日</span>
-                        {next && (
+                        <span className="streak-summary-days">累計 {total}日</span>
+                        {streak > 0 && next && (
                           <span className="streak-summary-next">次は{next.label}</span>
                         )}
                       </>

--- a/src/utils/recordSummary.js
+++ b/src/utils/recordSummary.js
@@ -1,0 +1,12 @@
+import { calcCurrentStreak, calcStats } from './stats'
+
+export function buildHabitRecordSummaries(habits, records) {
+  return habits
+    .filter(habit => !habit.archivedAt)
+    .map(habit => ({
+      habit,
+      streak: calcCurrentStreak(habit.id, records),
+      total: calcStats(habit.id, records).total,
+    }))
+    .sort((a, b) => b.streak - a.streak)
+}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '20260607-01'
+export const APP_VERSION = '20260616-01'

--- a/tests/recordSummary.test.js
+++ b/tests/recordSummary.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { buildHabitRecordSummaries } from '../src/utils/recordSummary'
+
+describe('buildHabitRecordSummaries', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-09'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('累計達成数と現在の連続日数を別々に返す', () => {
+    const habits = [{ id: 'h_1', name: 'Water', color: '#38bdf8' }]
+    const records = {
+      '2026-06-01': ['h_1'],
+      '2026-06-02': ['h_1'],
+      '2026-06-03': ['h_1'],
+      '2026-06-08': ['h_1'],
+    }
+
+    const [summary] = buildHabitRecordSummaries(habits, records)
+
+    expect(summary.streak).toBe(1)
+    expect(summary.total).toBe(4)
+  })
+})


### PR DESCRIPTION
## 背景
実績画面の「継続の記録」で `累計 n日` と表示している箇所が、累計達成数ではなく現在の連続日数を使っていました。そのため、過去に積み重ねた達成数があるのに、連続が途切れると数値が小さく見える状態でした。

## 変更内容
- 実績画面用の集計を `buildHabitRecordSummaries()` に切り出し
- 表示上の「累計」は `calcStats().total` を使うよう修正
- 現在の連続日数は進捗表示と並び順に維持
- 累計4日・現在連続1日の回帰テストを追加
- バージョンを `20260616-01` に更新

## 確認内容
- `npm.cmd test`（70件成功）
- `npm.cmd run build`
- 変更ファイル対象の `npx.cmd eslint src/components/RecordView.jsx src/utils/recordSummary.js tests/recordSummary.test.js src/version.js`
- ローカルブラウザでアプリ起動、コンソールエラーなしを確認

補足: repo全体の `npm.cmd run lint` は `.claude/worktrees` 配下と既存React Compiler指摘まで拾うため失敗します。今回変更ファイルに限定したlintはエラーなしです。

Closes #582