### PR TITLE
fix: Service Workerのキャッシュ削除範囲を自アプリに限定する

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -18,7 +18,11 @@ self.addEventListener('install', (e) => {
 self.addEventListener('activate', (e) => {
   e.waitUntil(
     caches.keys().then(keys =>
-      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
+      Promise.all(
+        keys
+          .filter(k => k.startsWith('habit-tracker-') && k !== CACHE)
+          .map(k => caches.delete(k))
+      )
     )
   )
   self.clients.claim()


### PR DESCRIPTION
## 変更内容
同一origin (junkoma2.github.io) 配下で複数アプリのGitHub Pagesを公開しているため、Service Workerのactivateハンドラで「自CACHE名と一致しないキーを全削除」していると他アプリのキャッシュも巻き添えで削除されてしまう。削除対象を `habit-tracker-` プレフィックスのキーに限定した。

## 確認観点
- 他アプリ（task-manager-, word-list-, gather- 等）のキャッシュ名が activate時に削除されないこと
- 自アプリの旧バージョンキャッシュ（habit-tracker-旧version）は引き続き削除されること