### PR TITLE
feat: 依存関係の脆弱性を定期検知するnpm auditワークフローを追加

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,0 +1,18 @@
+name: Dependency Audit
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm audit --audit-level=high


### PR DESCRIPTION
## 背景

開発ダッシュボードのセキュリティレビューで「依存関係の脆弱性スキャン結果を取得していない」と継続指摘されていた。package.json / package-lock.json があり npm audit が実行可能なため、これを定期的に確認する仕組みを追加する。

## 変更内容

- `.github/workflows/npm-audit.yml` を新規追加
  - トリガー: 週次cron（毎週月曜 03:00 UTC）+ `workflow_dispatch`（手動実行）
  - `actions/checkout` → `actions/setup-node@v4`（node 20, npm cache） → `npm ci` → `npm audit --audit-level=high`
  - `npm audit fix` などの自動修正は行わない。検知のみが目的
  - high/critical脆弱性があれば `npm audit` が非ゼロ終了し、ワークフローが失敗する（Actionsのrun履歴・失敗通知で気づける）
- 既存の `deploy.yml` / `auto-tag.yml` は変更なし。独立した新規ワークフローとして追加

## 確認内容

- ローカルで `npm audit --audit-level=high` を実行し、現状の脆弱性は0件であることを確認済み

```
found 0 vulnerabilities
```
