### PR TITLE
fix: eslintのlint対象をローカル補助ディレクトリ除外まで広げる

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,10 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 
 export default [
   {
-    ignores: ['dist/**', 'node_modules/**'],
+    // .gitignore の運用ファイル・ツール設定ディレクトリと揃える。
+    // ローカルにのみ存在する補助ディレクトリ（一時的な作業用チェックアウト等）が
+    // 増えても本体コードのlint結果に影響しないようにする。
+    ignores: ['dist/**', 'node_modules/**', '.claude/**', '.codex/**', '.cursor/**', '.windsurf/**'],
   },
   js.configs.recommended,
   {


### PR DESCRIPTION
## 背景

`eslint.config.js` の `ignores` は `dist/**` と `node_modules/**` のみで、`.gitignore` に既にある `.claude/` `.codex/` `.cursor/` `.windsurf/` などのローカル専用ディレクトリは対象外だった。

ローカル環境でこれらのディレクトリ配下に一時的な作業用チェックアウトができると、`npm run lint` が本体コードとは無関係な大量の警告・エラーを出力し、レビュー時に本体コード由来の結果が埋もれてしまう問題があった（直近の確認では該当ディレクトリ由来のnoiseが3000件以上）。

## 変更内容

- `eslint.config.js` の `ignores` に `.claude/**` `.codex/**` `.cursor/**` `.windsurf/**` を追加し、`.gitignore` の対象と揃えた
- `src` / `tests` / `public/sw.js` / `vite.config.js` / `scripts` など実際に守りたい対象のlintルールは変更していない

## 確認内容

- `npm run lint`: 変更前後とも 0 errors / 23 warnings（本体コードの既存warningのみ、差分なし）
- ローカルに上記補助ディレクトリと壊れたコードを一時的に置いて `npm run lint` を実行し、対象から除外されることを確認（PRには含めない検証用ファイル）
- `npm test`: 13 files / 70 tests passed
- `npm run build`: 成功
