### PR TITLE
feat: NNookプライバシーポリシーへの導線をフッターに追加する

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -213,6 +213,24 @@
   padding-bottom: calc(env(safe-area-inset-bottom, 16px) + 16px);
 }
 
+/* コンテンツ末尾のNNook導線。他アプリへ横展開しやすいよう最小構成にする */
+.app-footer {
+  display: flex;
+  justify-content: center;
+  padding: 4px 0 0;
+}
+
+.app-footer-link {
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  text-decoration: none;
+}
+
+.app-footer-link:hover,
+.app-footer-link:focus-visible {
+  text-decoration: underline;
+}
+
 .modal-open .app-main {
   overflow: hidden;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -611,6 +611,17 @@ export default function App() {
             />
           </section>
           <HabitTip tip={currentTip} visible={showDeepTip} returning={deepTipReturning} />
+
+          <footer className="app-footer">
+            <a
+              className="app-footer-link"
+              href="https://nonsensicalnook.com/privacy-policy.html"
+              target="_blank"
+              rel="noreferrer"
+            >
+              NNook・プライバシーポリシー
+            </a>
+          </footer>
         </div>
       </main>
 


### PR DESCRIPTION
## 背景
公開アプリ単体からNNookのプライバシーポリシーへ到達できる導線が無かった。

## 変更内容
- コンテンツ末尾（習慣・カレンダーの下）にフッターを新設し、NNookのプライバシーポリシーへのリンクを追加
- クラス名・構造をシンプルにし、他アプリへも横展開しやすい形にした

## 確認内容
- `npm run build` / `npm run preview` でリンク表示・遷移先URLを確認
- `npm run lint` / `npm test` で既存の警告以外の増加がないことを確認